### PR TITLE
feat(dotfiles): encrypt shared files and machine backups

### DIFF
--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -162,7 +162,7 @@ jobs:
       - run: mise run test:e2e e2e/cli/test_dotfiles_watch_pending
       - run: mise run test:e2e e2e/cli/test_dotfiles_watch_throttle
       - run: mise run test:e2e e2e/cli/test_dotfiles_sync
-      - run: mise run test:e2e e2e/cli/test_dotfiles_sync_encrypted
+      - run: mise run test:e2e e2e/cli/test_dotfiles_sync_encrypted e2e/cli/test_dotfiles_sync_files_encrypted
 
   lint:
     runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-large;overrides.cache-tag=cache' }}

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -162,6 +162,7 @@ jobs:
       - run: mise run test:e2e e2e/cli/test_dotfiles_watch_pending
       - run: mise run test:e2e e2e/cli/test_dotfiles_watch_throttle
       - run: mise run test:e2e e2e/cli/test_dotfiles_sync
+      - run: mise run test:e2e e2e/cli/test_dotfiles_sync_encrypted
 
   lint:
     runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-large;overrides.cache-tag=cache' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,8 @@ dependencies = [
  "sha2 0.10.9",
  "sha3",
  "subtle",
+ "which",
+ "wsl",
  "x25519-dalek",
  "zeroize",
 ]
@@ -183,6 +185,7 @@ dependencies = [
  "rand 0.8.8",
  "secrecy",
  "sha2 0.10.9",
+ "tempfile",
 ]
 
 [[package]]
@@ -12150,6 +12153,12 @@ name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "wsl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ panic = "abort"
 opt-level = 3
 
 [dependencies]
-age = { version = "0.12", features = ["ssh"] }
+age = { version = "0.12", features = ["ssh", "plugin"] }
 aho-corasick = "1"
 aube-registry = { version = "2", default-features = false, features = [
   "rustls",

--- a/docs/bootstrap/setup.md
+++ b/docs/bootstrap/setup.md
@@ -117,6 +117,11 @@ shared files and machine backups are stored in plaintext. A file excluded from s
 may still be included in machine backups; do not assume it stays on this machine.
 Existing checkpoints are not uploaded unless you select `--include-existing`.
 
+For encrypted machine backups, add `--encrypt-backups` when connecting.
+Keep the decryption identity somewhere safe outside this machine; it is needed
+to restore the backups. See [encrypted backups](/history.html#sharing-across-machines)
+for recipients and recovery. Encrypting backups does not encrypt shared files.
+
 Choose the mode that fits your workflow:
 
 | Mode         | Watcher behavior                                                |

--- a/docs/cli/bootstrap/dotfiles/machines.md
+++ b/docs/cli/bootstrap/dotfiles/machines.md
@@ -13,6 +13,8 @@ This machine first, then every machine whose refs the last
 `mise bootstrap dotfiles sync` fetched. Their checkpoints are addressed as
 `<machine>/<ref>`: `mise bootstrap dotfiles rollback --to laptop/latest --all`
 recovers a machine's backed-up files; their journals are data only.
+Encrypted backups are listed without a key; restoring one needs an
+identity among its recipients.
 
 ## Flags
 - **`-J --json`** — Output in JSON format

--- a/docs/cli/bootstrap/dotfiles/origin.md
+++ b/docs/cli/bootstrap/dotfiles/origin.md
@@ -12,11 +12,11 @@ Experimental: enable with `mise settings experimental=true`.
 `set <url>` connects one repository that holds the shared setup branch
 and this machine's recovery refs. Before anything leaves the machine it
 prints exactly what will happen: the sync mode, what is shared per
-stream, what is not and why, what is backed up (in plain form), names
-that look like secrets, private content already committed upstream,
-and how an existing repository would be adopted. The declaration goes
-to `[history.origin]` in the global config; the mode to
-`settings.history.sync`.
+stream, what is not and why, what is backed up (in plain form, or
+encrypted with `--encrypt-backups`), names that look like secrets,
+private content already committed upstream, and how an existing
+repository would be adopted. The declaration goes to `[history.origin]`
+in the global config; the mode to `settings.history.sync`.
 
 ## Flags
 - **`--remove`** — Disconnect: remove `[history.origin]` (local checkpoints and fetched refs stay)
@@ -37,6 +37,8 @@ Examples:
 ```
 mise bootstrap dotfiles origin set https://github.com/you/setup.git
 mise bootstrap dotfiles origin set git@github.com:you/setup.git --name laptop --sync manual
+mise bootstrap dotfiles origin set git@github.com:you/setup.git --encrypt-backups
+mise bootstrap dotfiles origin set git@github.com:you/setup.git --encrypt-backups --recipient age1… --recipient ~/.ssh/id_ed25519.pub
 mise bootstrap dotfiles origin              # what is connected
 mise bootstrap dotfiles origin --remove
 ```

--- a/docs/cli/bootstrap/dotfiles/origin/set.md
+++ b/docs/cli/bootstrap/dotfiles/origin/set.md
@@ -20,7 +20,12 @@ Connect a setup repository
   **Default:** `sync`
 - **`--include-existing`** — Upload the checkpoints recorded before now too
 - **`--allow-committed-private`** — Continue although the repository's history holds private content
-- **`--encrypt-backups`** — Encrypt machine recovery refs (not supported yet)
+- **`--encrypt-backups`** — Encrypt this machine's recovery refs with age for its recipients (see --recipient)
+
+  Every backed-up checkpoint becomes one age payload: file names, descriptions, and content are readable only with a recipient's identity. The setup branch itself is always plaintext.
+- **`--recipient <RECIPIENT>`** — A backup recipient (repeatable): an age public key (`age1…`), an SSH public key (`ssh-ed25519 …`), or a path to a `.pub` file or an age identity file
+
+  Default: this machine's own age key (`~/.config/mise/age.txt` or `settings.age.key_file`) and `~/.ssh/id_ed25519.pub` / `id_rsa.pub`. When none exists, an age identity is generated at the key file path.
 - **`-y --yes`** — Skip the confirmation prompt
 - **`-h --help`** — Print help
 

--- a/docs/cli/bootstrap/dotfiles/origin/set.md
+++ b/docs/cli/bootstrap/dotfiles/origin/set.md
@@ -22,7 +22,7 @@ Connect a setup repository
 - **`--allow-committed-private`** — Continue although the repository's history holds private content
 - **`--encrypt-backups`** — Encrypt this machine's recovery refs with age for its recipients (see --recipient)
 
-  Every backed-up checkpoint becomes one age payload: file names, descriptions, and content are readable only with a recipient's identity. The setup branch itself is always plaintext.
+  Every backed-up checkpoint becomes one age payload: file names, descriptions, and content are readable only with a recipient's identity. Setup configuration stays plaintext; dotfiles can use `encrypt = true`.
 - **`--recipient <RECIPIENT>`** — A backup recipient (repeatable): an age public key (`age1…`), an SSH public key (`ssh-ed25519 …`), or a path to a `.pub` file or an age identity file
 
   Default: this machine's own age key (`~/.config/mise/age.txt` or `settings.age.key_file`) and `~/.ssh/id_ed25519.pub` / `id_rsa.pub`. When none exists, an age identity is generated at the key file path.

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -73,8 +73,9 @@ wrote is not active.
 | Field      | Default | Meaning                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `autosave` | `true`  | Save edits automatically. `false` makes a manual-save file: `mise bootstrap dotfiles save <path>`, or an operation that names it, promotes what is on disk. |
-| `share`    | `true`  | Publish the saved version to the shared setup branch of the connected repository.                                                                            |
-| `backup`   | `true`  | Include the file in this machine's remote backups (plaintext, or encrypted when the connection was made with `--encrypt-backups`).                            |
+| `share`    | `true`  | Publish the saved version to the shared setup branch of the connected repository.                                                                           |
+| `encrypt`  | `false` | Encrypt shared contents for `[history.encryption].recipients`; local files remain plaintext.                                                                |
+| `backup`   | `true`  | Include the file in this machine's remote backups (plaintext, or encrypted when the connection was made with `--encrypt-backups`).                          |
 
 `mise bootstrap dotfiles track --no-autosave|--no-share|--no-backup` sets them;
 `--local` writes the entry to `config.local.toml` (this machine only). A local

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -73,8 +73,8 @@ wrote is not active.
 | Field      | Default | Meaning                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `autosave` | `true`  | Save edits automatically. `false` makes a manual-save file: `mise bootstrap dotfiles save <path>`, or an operation that names it, promotes what is on disk. |
-| `share`    | `true`  | Publish the saved version to the shared setup (a later release).                                                                                            |
-| `backup`   | `true`  | Include the file in remote backups (a later release).                                                                                                       |
+| `share`    | `true`  | Publish the saved version to the shared setup branch of the connected repository.                                                                            |
+| `backup`   | `true`  | Include the file in this machine's remote backups (plaintext, or encrypted when the connection was made with `--encrypt-backups`).                            |
 
 `mise bootstrap dotfiles track --no-autosave|--no-share|--no-backup` sets them;
 `--local` writes the entry to `config.local.toml` (this machine only). A local

--- a/docs/history.md
+++ b/docs/history.md
@@ -292,34 +292,61 @@ through the setup repository.
 `origin set` prints exactly what will happen before anything leaves the
 machine and asks for confirmation (`--yes` skips it): the sync mode, what is
 published per stream, what is not shared and why, what is backed up (in
-plain form: anyone who can read the repository can read every file in
-those snapshots; the setup branch is always plaintext, so use a private
-repository), whether existing checkpoints are included (only new ones by
-default; `--include-existing`), names that look like secrets with the
+plain form, or encrypted for which recipients with `--encrypt-backups`; the
+setup branch is always plaintext, so use a private repository), whether
+existing checkpoints are included (only new ones by default;
+`--include-existing`), names that look like secrets with the
 `track … --no-share --no-backup` line for each, and private content already
 committed in the repository's history, which stops the connection unless
 `--allow-committed-private` is passed (rewriting history is your decision).
 
-**What leaves the machine, in plain text.** Two things, both readable by
-anyone who can read the repository: the setup branch (the shared
+**What leaves the machine.** Two things. The setup branch (the shared
 configuration, the sources it references, and the shared version of every
-tracked entry, per its policies) and this machine's recovery refs
-(`refs/mise-history/<machine>/…`: a snapshot of every tracked file with
-`backup = true`, with private paths and paths with `backup = false` removed
-from the snapshot, the metadata, and the descriptions). `share = false`
-keeps a file out of the setup branch and out of other machines;
-`backup = false` keeps it out of the recovery refs; `*.local.toml` and
-credential stores default to both `share = false` and `backup = false`
-unless a per-file declaration says otherwise.
-Everything else stays on this machine. Encrypted recovery refs are not
-implemented yet: `--encrypt-backups` and `encrypt_backups = true` are refused
-rather than silently uploading in plain text, so a file you would only back
-up encrypted is a file to track with `--no-backup` for now.
+tracked entry, per its policies) is always plain text: it is merged and read
+as configuration by every machine, so anyone who can read the repository
+can read it. This machine's recovery refs (`refs/mise-history/<machine>/…`:
+a snapshot of every tracked file with `backup = true`, with private paths
+and paths with `backup = false` removed from the snapshot, the metadata, and
+the descriptions) are plain text by default, or encrypted with
+`--encrypt-backups` (below). `share = false` keeps a file out of the setup
+branch and out of other machines; `backup = false` keeps it out of the
+recovery refs; `*.local.toml` and credential stores default to both `share = false` and `backup = false` unless a
+per-file declaration says otherwise. Everything else stays on this machine.
 The declaration goes to `[history.origin]` in `config.local.toml` next to the
 global config (machine-local, never published: each machine names the
 repository the way it reaches it, and a fresh machine's own declaration
 never conflicts with the configuration it pulls), the mode
 to `settings.history.sync`.
+
+**Encrypted backups.** `mise bootstrap dotfiles origin set <url> --encrypt-backups`
+encrypts every recovery ref this machine uploads with
+[age](https://age-encryption.org): one payload per checkpoint holding the
+record and every backed-up file, so file names, descriptions, and content
+are readable only with a recipient's identity; the machine name, checkpoint
+id and time, and the number of checkpoints stay visible (`machines` lists
+them without a key). Recipients default to this machine's own identities:
+the age key at `settings.age.key_file` (default `~/.config/mise/age.txt`)
+and the public keys of `~/.ssh/id_ed25519` and `~/.ssh/id_rsa`. When none
+exists, mise generates an age identity at the key file path (mode 0600)
+and prints its public key. `--recipient <age1…|ssh-…|path>` (repeatable)
+names others: an age public key, an SSH public key, or a `.pub` or age
+identity file. The choice is recorded machine-locally as
+`encrypt_backups = true` and `recipients = […]` in `[history.origin]`. To
+restore another machine's encrypted backup here, its identity must be
+among the recipients and present here (`MISE_AGE_KEY`,
+`settings.age.identity_files`, `settings.age.key_file`, or the default
+`age.txt` and SSH keys); the identity file itself is a credential store,
+never captured or shared, so copy it between machines yourself.
+Connecting again with a different choice (plaintext to encrypted, other
+recipients, or back) deletes this machine's refs on the repository and
+uploads the eligible checkpoints again under the new one, so a repository
+never holds a mix by accident. Encryption on without any usable recipient
+uploads nothing and says so in `status` and `mise doctor`; plain text is
+never a fallback. A mise older than this feature skips encrypted refs
+rather than misreading them. Encrypted backups protect recovery copies;
+they are not a way to distribute secrets, and the setup branch stays
+plaintext. Encrypted backups work without `settings.experimental`; the
+`[env]` age directives remain experimental.
 
 **What is synchronized.** The setup branch mirrors the global configuration
 directory at its root (`config.toml`, `conf.d/`, `tasks/`, templates),
@@ -418,13 +445,21 @@ all-or-nothing application with recovery, not atomic filesystem writes.
 `backup = true` entry) are pushed as parentless commits to
 `refs/mise-history/<machine-id>/<uuid>`, rebuilt without every
 `backup = false` and private path and with the record masked; journal blobs
-never travel. Retention removes only this machine's remote refs for
-checkpoints it pruned. `mise bootstrap dotfiles rollback --to <machine>/<ref> --all`
-recovers another machine's backed-up files here; their journals are data
-only, never replayed. `mise bootstrap dotfiles origin --purge` deletes this machine's
-refs from the origin (objects may persist until the host runs gc; setup
-commits are never deleted; forks and host backups may keep content: not
-erasure) and disconnects; `--remove` only disconnects.
+never travel. A plaintext backup commit holds `meta.json` and `snapshot/`;
+an encrypted one holds `backup.toml` (format, machine, checkpoint id and
+time, recipient count) and `payload.age`. Retention removes only this
+machine's remote refs for checkpoints it pruned.
+`mise bootstrap dotfiles rollback --to <machine>/<ref> --all` recovers
+another machine's backed-up files here; an encrypted checkpoint is
+decrypted once with this machine's identities (the plaintext copy stays
+local, under `refs/machines-plain/`) and refused with the reason when none
+of them can read it; their journals are data only, never replayed.
+`mise bootstrap dotfiles machines` shows which machines encrypt.
+`mise bootstrap dotfiles origin --purge` deletes this machine's refs from
+the origin (objects may persist until the host runs gc; setup commits are
+never deleted; forks and host backups may keep content: not erasure) and
+disconnects; `--remove` only disconnects. Every pushed commit carries your
+git author identity, as any commit does.
 
 **Private repositories.** Network commands run with your normal git
 configuration (credential helpers, ssh, URL rewrites). For a private GitHub

--- a/docs/history.md
+++ b/docs/history.md
@@ -584,7 +584,7 @@ instructions: [Secure Enclave on macOS](https://github.com/remko/age-plugin-se) 
 recipient** in the shared list or backup `--recipient` options, and configure the
 local identity file with `settings.age.identity_files`. Native `age1tag` public
 recipients from newer TPM plugins are also supported. Plugin binaries must be
-available on PATH. Mise does not provision hardware keys or install plugins.
+available on PATH. mise does not provision hardware keys or install plugins.
 
 Multiple recipients can decrypt independently: for example, a Mac's Secure
 Enclave, a Linux TPM, and an offline software recovery identity. Keep an independent
@@ -592,7 +592,9 @@ recovery recipient: losing hardware can make hardware-only data unrecoverable.
 Explicit `--recipient` arguments replace backup defaults rather than adding to them.
 
 Interactive restoration may request Touch ID or a PIN. Background work never
-starts hardware identity plugins; status and doctor report them as configured but
+starts identity or recipient plugins. A recipient that requires a plugin must
+be used interactively; native age, SSH, and native tagged recipients can be used
+in the background. Status and doctor report hardware identities as configured but
 unverified. Once decrypted, the local cache may be reused without hardware access.
 
 ### Encryption limits and backup replacement

--- a/docs/history.md
+++ b/docs/history.md
@@ -302,16 +302,18 @@ committed in the repository's history, which stops the connection unless
 
 **What leaves the machine.** Two things. The setup branch (the shared
 configuration, the sources it references, and the shared version of every
-tracked entry, per its policies) keeps configuration readable; selected file
-contents can use `encrypt = true` by every machine, so anyone who can read the repository
-can read it. This machine's recovery refs (`refs/mise-history/<machine>/…`:
+tracked entry, per its policies) keeps setup configuration in plaintext;
+selected file contents can use `encrypt = true`. Anyone with repository
+access can read the configuration and unencrypted files. This machine's
+recovery refs (`refs/mise-history/<machine>/…`:
 a snapshot of every tracked file with `backup = true`, with private paths
 and paths with `backup = false` removed from the snapshot, the metadata, and
 the descriptions) are plain text by default, or encrypted with
 `--encrypt-backups` (below). `share = false` keeps a file out of the setup
 branch and out of other machines; `backup = false` keeps it out of the
-recovery refs; `*.local.toml` and credential stores default to both `share = false` and `backup = false` unless a
-per-file declaration says otherwise. Everything else stays on this machine.
+recovery refs; `*.local.toml` and credential stores default to both
+`share = false` and `backup = false` unless a per-file declaration says
+otherwise. Everything else stays on this machine.
 The declaration goes to `[history.origin]` in `config.local.toml` next to the
 global config (machine-local, never published: each machine names the
 repository the way it reaches it, and a fresh machine's own declaration

--- a/docs/history.md
+++ b/docs/history.md
@@ -293,7 +293,7 @@ through the setup repository.
 machine and asks for confirmation (`--yes` skips it): the sync mode, what is
 published per stream, what is not shared and why, what is backed up (in
 plain form, or encrypted for which recipients with `--encrypt-backups`; the
-setup branch is always plaintext, so use a private repository), whether
+setup configuration is plaintext, so use a private repository), whether
 existing checkpoints are included (only new ones by default;
 `--include-existing`), names that look like secrets with the
 `track … --no-share --no-backup` line for each, and private content already
@@ -302,8 +302,8 @@ committed in the repository's history, which stops the connection unless
 
 **What leaves the machine.** Two things. The setup branch (the shared
 configuration, the sources it references, and the shared version of every
-tracked entry, per its policies) is always plain text: it is merged and read
-as configuration by every machine, so anyone who can read the repository
+tracked entry, per its policies) keeps configuration readable; selected file
+contents can use `encrypt = true` by every machine, so anyone who can read the repository
 can read it. This machine's recovery refs (`refs/mise-history/<machine>/…`:
 a snapshot of every tracked file with `backup = true`, with private paths
 and paths with `backup = false` removed from the snapshot, the metadata, and
@@ -338,15 +338,14 @@ among the recipients and present here (`MISE_AGE_KEY`,
 `age.txt` and SSH keys); the identity file itself is a credential store,
 never captured or shared, so copy it between machines yourself.
 Connecting again with a different choice (plaintext to encrypted, other
-recipients, or back) deletes this machine's refs on the repository and
-uploads the eligible checkpoints again under the new one, so a repository
+recipients, or back) atomically replaces this machine's refs on the repository
+with eligible checkpoints under the new scheme, so a repository
 never holds a mix by accident. Encryption on without any usable recipient
 uploads nothing and says so in `status` and `mise doctor`; plain text is
 never a fallback. A mise older than this feature skips encrypted refs
 rather than misreading them. Encrypted backups protect recovery copies;
-they are not a way to distribute secrets, and the setup branch stays
-plaintext. Encrypted backups work without `settings.experimental`; the
-`[env]` age directives remain experimental.
+encrypted shared files are configured separately with `encrypt = true`
+and `[history.encryption].recipients`. The `[env]` age directives remain experimental.
 
 **What is synchronized.** The setup branch mirrors the global configuration
 directory at its root (`config.toml`, `conf.d/`, `tasks/`, templates),
@@ -497,7 +496,7 @@ symlink targets, private files, and any declaration history could not honour.
 
 ### Policies
 
-Each entry carries three policies, set on the `[dotfiles]` entry or with
+Each entry carries policies, set on the `[dotfiles]` entry or with
 `mise bootstrap dotfiles track --no-autosave|--no-share|--no-backup`:
 
 | Policy     | Meaning                                                               |
@@ -507,6 +506,9 @@ Each entry carries three policies, set on the `[dotfiles]` entry or with
 | `backup`   | Include the file in remote backups (default `true` for tracked files) |
 
 Sharing and recovery backups follow these policies when you connect an origin.
+
+Use `encrypt = true` to protect shared file contents with the public recipients in
+`[history.encryption]`. These files never enter plaintext remote backups.
 
 `*.local.toml` files are private by default (`share = false`) wherever they
 are found, and credential stores under the config directory
@@ -535,3 +537,71 @@ their journals without content; `mise bootstrap dotfiles status` says so.
 | `history.keep.age`   | `90d`   | `MISE_HISTORY_KEEP_AGE`   |
 
 Deleting `$MISE_STATE_DIR/history/` discards everything recorded.
+
+## Encrypted shared files
+
+Set `encrypt = true` on a dotfile declaration to encrypt its contents on the
+setup branch. All encrypted files use one shared public-recipient list:
+
+```toml
+[history.encryption]
+recipients = ["<age-or-plugin-public-recipient>", "<recovery-public-recipient>"]
+
+[dotfiles]
+"~/.config/app/credentials" = { mode = "track", encrypt = true }
+"~/.config/app/config" = { source = "templates/app.tera", mode = "template", encrypt = true }
+```
+
+Tracked files and external sources are encrypted before publication and decrypted
+before application or template rendering. Filenames, public recipients, and mise
+configuration remain visible. Inline `content` and managed blocks cannot use this
+option: move sensitive contents into an external source. Encryption does not
+change `share = false` or privacy exclusions.
+
+Live files, template outputs, local history, and decrypted recovery caches remain
+plaintext. Encrypted files are excluded from plaintext remote recovery backups;
+encrypted recovery backups use the machine-local recipients configured through
+`origin set --encrypt-backups --recipient …`, independently of shared-file readers.
+
+If an incoming file cannot be decrypted, publication and application pause for the
+whole setup. Local history and fetching continue. Run `mise bootstrap dotfiles
+pull` with a matching identity to unlock incoming content. Unchanged encrypted
+content does not create a fresh commit on every sync.
+
+Changing the shared recipient list re-encrypts current encrypted files in one
+branch update. Existing Git history and clones are not rewritten: enabling
+encryption cannot erase earlier plaintext, and removing a recipient cannot revoke
+access to copies already encrypted for it. Repositories using encrypted shared
+files use setup format 2; older mise clients stop with an upgrade message.
+
+### Hardware identities
+
+Install an age plugin yourself and generate its identity using the plugin's
+instructions: [Secure Enclave on macOS](https://github.com/remko/age-plugin-se) or
+[TPM on Linux](https://github.com/Foxboron/age-plugin-tpm). Use the exported **public
+recipient** in the shared list or backup `--recipient` options, and configure the
+local identity file with `settings.age.identity_files`. Native `age1tag` public
+recipients from newer TPM plugins are also supported. Plugin binaries must be
+available on PATH. Mise does not provision hardware keys or install plugins.
+
+Multiple recipients can decrypt independently: for example, a Mac's Secure
+Enclave, a Linux TPM, and an offline software recovery identity. Keep an independent
+recovery recipient: losing hardware can make hardware-only data unrecoverable.
+Explicit `--recipient` arguments replace backup defaults rather than adding to them.
+
+Interactive restoration may request Touch ID or a PIN. Background work never
+starts hardware identity plugins; status and doctor report them as configured but
+unverified. Once decrypted, the local cache may be reused without hardware access.
+
+### Encryption limits and backup replacement
+
+Encrypted payloads are limited to 256 MiB of ciphertext/compressed data and 1 GiB
+of decoded data; a backup contains at most 100,000 files. Creation and restoration
+both enforce these limits. Non-UTF-8 Git paths are rejected before publication or
+restoration rather than silently renamed.
+
+Changing backup encryption prepares replacement commits locally and then replaces
+recovery refs using an atomic Git push. The server must support atomic pushes;
+otherwise the operation fails while retaining existing refs. Previously uploaded,
+locally retained eligible checkpoints remain included when reconfiguring the same
+origin, even without `--include-existing`.

--- a/e2e/cli/test_dotfiles_sync_encrypted
+++ b/e2e/cli/test_dotfiles_sync_encrypted
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# `mise bootstrap dotfiles origin set --encrypt-backups`: this machine's recovery
+# refs are age-encrypted for its recipients. Another machine lists them
+# without a key and restores them with one; changing the scheme replaces the
+# refs on the origin; a machine with no key anywhere gets an identity
+# generated. All of it with experimental off: encrypted backups are not an
+# experimental feature (the `[env]` age directives still are).
+# shellcheck disable=SC2016
+
+require_cmd git
+
+export MISE_EXPERIMENTAL=0
+
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+
+# two age identities: A's own, and one that stands for another machine
+KEY="AGE-SECRET-KEY-142E7VJ8GUWR94MXDCYQJ7ZTQZRXKQSP9PUJU8HUQJ206QN7QPV4SM5QRL8"
+PUB="age1fuvsfq02qr5ju0nhh3rulrwracymjljlr5j49kres24ltd3fjq0s9z9d8l"
+KEY2="AGE-SECRET-KEY-12LCM5FM5DQ7HZDGYUZWMJ6QHM66J07NZ75VVP2VVGCZX53HYD5PQUXUN8K"
+PUB2="age15myzzpkenzud22ag88x5ksqd80g4tkwtruu976uev57l4r240qcqcuqnt9"
+
+# other machines are HOMEs outside A's home (so none of A's files is found as
+# a project config of theirs), reached through wrapper scripts (functions are
+# not visible inside assert subshells)
+wrapper() { # name dir
+  mkdir -p "$2/.config/mise"
+  cat <<EOF >"$PWD/$1"
+#!/usr/bin/env bash
+export HOME="$2" XDG_CONFIG_HOME="$2/.config" MISE_CONFIG_DIR="$2/.config/mise" \\
+  MISE_STATE_DIR="$2/.local/state/mise" MISE_DATA_DIR="$2/.local/share/mise" \\
+  MISE_CACHE_DIR="$2/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$2" MISE_EXPERIMENTAL=0
+cd "\$HOME" && exec mise "\$@"
+EOF
+  chmod +x "$PWD/$1"
+}
+B="$(dirname "$HOME")/b-home"
+wrapper b "$B"
+b="$PWD/b"
+C="$(dirname "$HOME")/c-home"
+wrapper c "$C"
+c="$PWD/c"
+perm_of="$PWD/perm_of"
+cat <<'EOF2' >"$perm_of"
+#!/usr/bin/env bash
+stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1"
+EOF2
+chmod +x "$perm_of"
+refs() { git --git-dir="$origin" for-each-ref --format='%(refname)' "${1:-refs/mise-history}"; }
+
+# ---- machine A: a tracked directory, its own age identity, a plaintext connection
+mkdir -p ~/.config/hypr
+echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
+printf '# public key: %s\n%s\n' "$PUB" "$KEY" >"$MISE_CONFIG_DIR/age.txt"
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+# the secrets feature keeps its gate
+assert_fail "mise set --age-encrypt X=1 --age-recipient $PUB 2>&1" "experimental"
+
+mise bootstrap dotfiles origin set "file://$origin" --name laptop --include-existing --yes >"$PWD/connect1.log" 2>&1
+assert_contains "cat $PWD/connect1.log" "in plain form"
+plain_refs=$(refs | wc -l | tr -d ' ')
+assert_succeed "test $plain_refs -ge 1"
+ref=$(refs | head -1)
+assert "git --git-dir=$origin ls-tree --name-only $ref | tr '\n' ' '" "meta.json snapshot "
+assert_contains "mise bootstrap dotfiles status" "machine backups: plaintext"
+
+# ---- the same connection, encrypted: the plaintext refs are replaced, the
+# payload hides names, descriptions, and content
+mise bootstrap dotfiles origin set "file://$origin" --name laptop --include-existing --encrypt-backups --yes >"$PWD/connect2.log" 2>&1
+assert_contains "cat $PWD/connect2.log" "backed up encrypted (age)"
+assert_contains "cat $PWD/connect2.log" "$PUB"
+assert_contains "cat $PWD/connect2.log" "existing recovery ref(s) on the repository are replaced: the plaintext ones are deleted"
+assert_not_contains "cat $PWD/connect2.log" "experimental"
+# every eligible checkpoint went up again (the connection's own capture may
+# have added one: config.local.toml changed when the first one was recorded)
+enc_refs=$(refs | wc -l | tr -d ' ')
+assert_succeed "test $enc_refs -ge $plain_refs"
+aid=$(jq -r .id "$MISE_STATE_DIR/history/machine.json")
+for ref in $(refs); do
+  assert "git --git-dir=$origin ls-tree --name-only $ref | tr '\n' ' '" "backup.toml payload.age "
+  assert_fail "git --git-dir=$origin show $ref:payload.age | grep -q kitty"
+  assert_fail "git --git-dir=$origin show $ref:payload.age | grep -q bindings"
+  assert_contains "git --git-dir=$origin show $ref:backup.toml" 'encryption = "age"'
+  assert_contains "git --git-dir=$origin show $ref:backup.toml" "id = \"$aid\""
+  assert_not_contains "git --git-dir=$origin log -1 --format=%B $ref" "bindings"
+done
+assert_contains "cat $MISE_CONFIG_DIR/config.local.toml" "encrypt_backups = true"
+assert_contains "cat $MISE_CONFIG_DIR/config.local.toml" "$PUB"
+assert_contains "mise bootstrap dotfiles status" "machine backups: encrypted (age) for 1 recipient(s)"
+assert_contains "mise bootstrap dotfiles origin 2>&1" "encrypted (age) for 1 recipient(s)"
+assert_contains "mise doctor 2>&1 || true" "machine backups encrypted (age); an identity here can restore them"
+# a later save goes up encrypted too
+echo 'monitor=DP-1' >~/.config/hypr/monitors.lua
+assert_contains "mise bootstrap dotfiles sync 2>&1" "uploaded 1 checkpoint"
+assert "git --git-dir=$origin for-each-ref refs/mise-history | wc -l | tr -d ' '" "$((enc_refs + 1))"
+
+# ---- machine B: no key. It lists laptop's backups, cannot restore them,
+# restores them with the key; the decrypted copy stays local
+mkdir -p "$B/.config/hypr"
+echo 'bind = SUPER, Q, exec, kitty' >"$B/.config/hypr/bindings.lua"
+printf '[dotfiles]\n"~/.config/hypr" = { mode = "track" }\n' >"$B/.config/mise/config.toml"
+assert_succeed "$b bootstrap dotfiles origin set file://$origin --name desktop --yes"
+assert_contains "$b bootstrap dotfiles machines" "laptop"
+assert "$b bootstrap dotfiles machines --json | jq -r '.[] | select(.name == \"laptop\") | .encrypted == .checkpoints'" "true"
+assert "$b bootstrap dotfiles machines --json | jq -r '.[] | select(.name == \"desktop\") | .encrypted'" "0"
+assert_fail "$b bootstrap dotfiles rollback --to laptop/latest --all --dry-run 2>&1" "no age identity"
+assert_fail "MISE_AGE_KEY=$KEY2 $b bootstrap dotfiles rollback --to laptop/latest --all --dry-run 2>&1" "none of this machine's identities can decrypt it"
+assert_contains "MISE_AGE_KEY=$KEY $b bootstrap dotfiles rollback --to laptop/latest --all --dry-run" "monitors.lua"
+bstore="$B/.local/state/mise/history/repo.git"
+assert_succeed "git --git-dir=$bstore for-each-ref refs/machines-plain | grep -q ."
+assert_fail "git --git-dir=$origin for-each-ref | grep -q machines-plain"
+# B's own backups are plaintext: nothing about restoring them in doctor
+assert_not_contains "$b doctor 2>&1 || true" "could not restore"
+
+# ---- an explicit recipient that is not this machine: the refs are replaced
+# again, A is told it could not restore its own backups, B needs that key
+mise bootstrap dotfiles origin set "file://$origin" --name laptop --include-existing --encrypt-backups --recipient "$PUB2" --yes >"$PWD/connect3.log" 2>&1
+assert_contains "cat $PWD/connect3.log" "$PUB2"
+assert_contains "cat $PWD/connect3.log" "none of this machine's identities is among the recipients"
+assert_contains "cat $PWD/connect3.log" "the previously encrypted ones are deleted"
+assert_contains "cat $MISE_CONFIG_DIR/config.local.toml" "$PUB2"
+assert_not_contains "cat $MISE_CONFIG_DIR/config.local.toml" "$PUB"
+assert_contains "mise doctor 2>&1 || true" "could not restore its own backups"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_fail "MISE_AGE_KEY=$KEY $b bootstrap dotfiles rollback --to laptop/latest --all --dry-run 2>&1" "none of this machine's identities can decrypt it"
+assert_contains "MISE_AGE_KEY=$KEY2 $b bootstrap dotfiles rollback --to laptop/latest --all --dry-run" "monitors.lua"
+
+# ---- back to plaintext, said in capitals
+mise bootstrap dotfiles origin set "file://$origin" --name laptop --include-existing --yes >"$PWD/connect4.log" 2>&1
+assert_contains "cat $PWD/connect4.log" "uploaded again IN PLAIN FORM"
+ref=$(refs | head -1)
+assert "git --git-dir=$origin ls-tree --name-only $ref | tr '\n' ' '" "meta.json snapshot "
+assert_not_contains "cat $MISE_CONFIG_DIR/config.local.toml" "encrypt_backups"
+assert_contains "mise bootstrap dotfiles status" "machine backups: plaintext"
+
+# ---- machine C: no age key, no SSH key. An identity is generated, kept
+# private, never uploaded; its backups are encrypted from the first one
+mkdir -p "$C/.config/nvim"
+echo 'set number' >"$C/.config/nvim/init.vim"
+assert_succeed "$c bootstrap dotfiles track $C/.config/nvim"
+$c bootstrap dotfiles origin set "file://$origin" --name fresh --encrypt-backups --include-existing --yes >"$PWD/connect5.log" 2>&1
+assert_contains "cat $PWD/connect5.log" "an age identity will be generated at"
+assert_contains "cat $PWD/connect5.log" "Generated an age identity at"
+assert_contains "cat $PWD/connect5.log" "public key is age1"
+assert_succeed "test -f $C/.config/mise/age.txt"
+assert "$perm_of $C/.config/mise/age.txt" "600"
+assert_contains "cat $C/.config/mise/config.local.toml" "encrypt_backups = true"
+assert_fail "git --git-dir=$origin ls-tree -r --name-only main | grep -q age.txt"
+cid=$(jq -r .id "$C/.local/state/mise/history/machine.json")
+assert_succeed "test \$(git --git-dir=$origin for-each-ref refs/mise-history/$cid | wc -l) -ge 1"
+for ref in $(refs "refs/mise-history/$cid"); do
+  assert "git --git-dir=$origin ls-tree --name-only $ref | tr '\n' ' '" "backup.toml payload.age "
+  assert_fail "git --git-dir=$origin show $ref:payload.age | grep -q 'set number'"
+done
+assert_contains "$c bootstrap dotfiles machines" "fresh (this machine)"
+assert "$c bootstrap dotfiles machines --json | jq -r '.[] | select(.this) | .encrypted == .checkpoints'" "true"

--- a/e2e/cli/test_dotfiles_sync_encrypted
+++ b/e2e/cli/test_dotfiles_sync_encrypted
@@ -3,12 +3,12 @@
 # refs are age-encrypted for its recipients. Another machine lists them
 # without a key and restores them with one; changing the scheme replaces the
 # refs on the origin; a machine with no key anywhere gets an identity
-# generated. Runs with experimental settings disabled.
+# generated. Dotfile tracking and synchronization require experimental mode.
 # shellcheck disable=SC2016
 
 require_cmd git
 
-export MISE_EXPERIMENTAL=0
+export MISE_EXPERIMENTAL=1
 
 origin="$PWD/origin.git"
 git init -q --bare -b main "$origin"
@@ -28,7 +28,7 @@ wrapper() { # name dir
 #!/usr/bin/env bash
 export HOME="$2" XDG_CONFIG_HOME="$2/.config" MISE_CONFIG_DIR="$2/.config/mise" \\
   MISE_STATE_DIR="$2/.local/state/mise" MISE_DATA_DIR="$2/.local/share/mise" \\
-  MISE_CACHE_DIR="$2/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$2" MISE_EXPERIMENTAL=0
+  MISE_CACHE_DIR="$2/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$2" MISE_EXPERIMENTAL=1
 cd "\$HOME" && exec mise "\$@"
 EOF
   chmod +x "$PWD/$1"
@@ -53,7 +53,7 @@ echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
 printf '# public key: %s\n%s\n' "$PUB" "$KEY" >"$MISE_CONFIG_DIR/age.txt"
 assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
 # the secrets feature keeps its gate
-assert_fail "mise set --age-encrypt X=1 --age-recipient $PUB 2>&1" "experimental"
+assert_fail "MISE_EXPERIMENTAL=0 mise set --age-encrypt X=1 --age-recipient $PUB 2>&1" "experimental"
 
 mise bootstrap dotfiles origin set "file://$origin" --name laptop --include-existing --yes >"$PWD/connect1.log" 2>&1
 assert_contains "cat $PWD/connect1.log" "in plain form"

--- a/e2e/cli/test_dotfiles_sync_encrypted
+++ b/e2e/cli/test_dotfiles_sync_encrypted
@@ -3,8 +3,7 @@
 # refs are age-encrypted for its recipients. Another machine lists them
 # without a key and restores them with one; changing the scheme replaces the
 # refs on the origin; a machine with no key anywhere gets an identity
-# generated. All of it with experimental off: encrypted backups are not an
-# experimental feature (the `[env]` age directives still are).
+# generated. Runs with experimental settings disabled.
 # shellcheck disable=SC2016
 
 require_cmd git
@@ -105,16 +104,34 @@ assert "$b bootstrap dotfiles machines --json | jq -r '.[] | select(.name == \"l
 assert "$b bootstrap dotfiles machines --json | jq -r '.[] | select(.name == \"desktop\") | .encrypted'" "0"
 assert_fail "$b bootstrap dotfiles rollback --to laptop/latest --all --dry-run 2>&1" "no age identity"
 assert_fail "MISE_AGE_KEY=$KEY2 $b bootstrap dotfiles rollback --to laptop/latest --all --dry-run 2>&1" "none of this machine's identities can decrypt it"
+# A damaged older sibling must not prevent selecting a healthy latest ref.
+bstore="$B/.local/state/mise/history/repo.git"
+older=$(git --git-dir="$bstore" for-each-ref --format='%(refname)' "refs/machines/$aid" | head -1)
+old_commit=$(git --git-dir="$bstore" rev-parse "$older")
+header=$(git --git-dir="$bstore" rev-parse "$older:backup.toml")
+broken=$(printf 'broken payload' | git --git-dir="$bstore" hash-object -w --stdin)
+broken_tree=$(printf '100644 blob %s\tbackup.toml\n100644 blob %s\tpayload.age\n' "$header" "$broken" | git --git-dir="$bstore" mktree)
+broken_commit=$(printf 'damaged sibling\n' | git --git-dir="$bstore" commit-tree "$broken_tree")
+git --git-dir="$bstore" update-ref "$older" "$broken_commit"
 assert_contains "MISE_AGE_KEY=$KEY $b bootstrap dotfiles rollback --to laptop/latest --all --dry-run" "monitors.lua"
+assert_fail "MISE_AGE_KEY=$KEY $b bootstrap dotfiles rollback --to laptop/${older##*/} --all --dry-run 2>&1" "damaged"
+git --git-dir="$bstore" update-ref "$older" "$old_commit"
 bstore="$B/.local/state/mise/history/repo.git"
 assert_succeed "git --git-dir=$bstore for-each-ref refs/machines-plain | grep -q ."
 assert_fail "git --git-dir=$origin for-each-ref | grep -q machines-plain"
 # B's own backups are plaintext: nothing about restoring them in doctor
 assert_not_contains "$b doctor 2>&1 || true" "could not restore"
 
+# An unsupported atomic transaction leaves all existing recovery refs intact.
+refs_before=$(git --git-dir="$origin" for-each-ref --format='%(refname) %(objectname)' "refs/mise-history/$aid")
+git --git-dir="$origin" config receive.advertiseAtomic false
+assert_fail "mise bootstrap dotfiles origin set file://$origin --name laptop --encrypt-backups --recipient $PUB2 --yes 2>&1" "atomic backup replacement failed"
+assert "git --git-dir=$origin for-each-ref --format='%(refname) %(objectname)' refs/mise-history/$aid" "$refs_before"
+git --git-dir="$origin" config receive.advertiseAtomic true
+
 # ---- an explicit recipient that is not this machine: the refs are replaced
 # again, A is told it could not restore its own backups, B needs that key
-mise bootstrap dotfiles origin set "file://$origin" --name laptop --include-existing --encrypt-backups --recipient "$PUB2" --yes >"$PWD/connect3.log" 2>&1
+mise bootstrap dotfiles origin set "file://$origin" --name laptop --encrypt-backups --recipient "$PUB2" --yes >"$PWD/connect3.log" 2>&1
 assert_contains "cat $PWD/connect3.log" "$PUB2"
 assert_contains "cat $PWD/connect3.log" "none of this machine's identities is among the recipients"
 assert_contains "cat $PWD/connect3.log" "the previously encrypted ones are deleted"
@@ -154,3 +171,8 @@ for ref in $(refs "refs/mise-history/$cid"); do
 done
 assert_contains "$c bootstrap dotfiles machines" "fresh (this machine)"
 assert "$c bootstrap dotfiles machines --json | jq -r '.[] | select(.this) | .encrypted == .checkpoints'" "true"
+# Losing the local declaration must preserve encrypted status and fail closed.
+mv "$C/.config/mise/config.local.toml" "$PWD/c-origin.saved"
+assert_succeed "$c bootstrap dotfiles sync"
+assert_contains "$c bootstrap dotfiles status" 'encrypted'
+assert_contains "$c doctor 2>&1 || true" 'machine backups are not being uploaded'

--- a/e2e/cli/test_dotfiles_sync_files_encrypted
+++ b/e2e/cli/test_dotfiles_sync_files_encrypted
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Shared encrypted files use one recipient list; local files stay plaintext.
+# shellcheck disable=SC2016
+require_cmd git
+export MISE_EXPERIMENTAL=0
+KEY="AGE-SECRET-KEY-142E7VJ8GUWR94MXDCYQJ7ZTQZRXKQSP9PUJU8HUQJ206QN7QPV4SM5QRL8"
+PUB="age1fuvsfq02qr5ju0nhh3rulrwracymjljlr5j49kres24ltd3fjq0s9z9d8l"
+KEY2="AGE-SECRET-KEY-12LCM5FM5DQ7HZDGYUZWMJ6QHM66J07NZ75VVP2VVGCZX53HYD5PQUXUN8K"
+PUB2="age15myzzpkenzud22ag88x5ksqd80g4tkwtruu976uev57l4r240qcqcuqnt9"
+export MISE_AGE_KEY="$KEY"
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+mkdir -p "$HOME/.config/app" "$MISE_CONFIG_DIR/templates" "$MISE_CONFIG_DIR/assets"
+printf 'private-value-123\n' >"$HOME/.config/app/value"
+printf '#!/bin/sh\necho private-script-123\n' >"$HOME/.config/app/script"
+chmod +x "$HOME/.config/app/script"
+ln -s value "$HOME/.config/app/link"
+printf 'template-private-123\n' >"$MISE_CONFIG_DIR/templates/app.tera"
+printf 'copy-private-123\n' >"$MISE_CONFIG_DIR/assets/copy"
+printf 'symlink-private-123\n' >"$MISE_CONFIG_DIR/assets/link"
+cat >"$MISE_CONFIG_DIR/config.toml" <<TOML
+[history.encryption]
+recipients = ["$PUB", "$PUB2"]
+[dotfiles]
+"~/.config/app/value" = { mode = "track", encrypt = true }
+"~/.config/app/script" = { mode = "track", encrypt = true }
+"~/.config/app/link" = { mode = "track", encrypt = true }
+"~/.config/app/copied" = { mode = "copy", source = "assets/copy", encrypt = true }
+"~/.config/app/linked" = { mode = "symlink", source = "assets/link", encrypt = true }
+"~/.config/app/rendered" = { mode = "template", source = "templates/app.tera", encrypt = true }
+TOML
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --name laptop --include-existing --yes"
+assert_contains "git --git-dir=$origin show main:.mise-history/format.toml" 'format = 2'
+assert_contains "git --git-dir=$origin show main:tracked/home/.config/app/value | head -1" 'mise-encrypted-file-v1'
+assert_not_contains "git --git-dir=$origin show main:tracked/home/.config/app/value" 'private-value-123'
+assert_not_contains "git --git-dir=$origin show main:templates/app.tera" 'template-private-123'
+head_before=$(git --git-dir="$origin" rev-parse main)
+assert_succeed "mise bootstrap dotfiles sync"
+assert "git --git-dir=$origin rev-parse main" "$head_before"
+# No remote ref, including plaintext backups, carries the protected bytes.
+for commit in $(git --git-dir="$origin" rev-list --all); do
+  assert_not_contains "git --git-dir=$origin grep -a private-value-123 $commit || true" 'private-value-123'
+  assert_not_contains "git --git-dir=$origin grep -a template-private-123 $commit || true" 'template-private-123'
+  assert_not_contains "git --git-dir=$origin grep -a copy-private-123 $commit || true" 'copy-private-123'
+  assert_not_contains "git --git-dir=$origin grep -a symlink-private-123 $commit || true" 'symlink-private-123'
+done
+B="$(dirname "$HOME")/encrypted-files-b"
+mkdir -p "$B/.config/mise"
+cat >"$PWD/b" <<WRAPPER
+#!/usr/bin/env bash
+export HOME="$B" XDG_CONFIG_HOME="$B/.config" MISE_CONFIG_DIR="$B/.config/mise" \\
+ MISE_STATE_DIR="$B/.local/state/mise" MISE_DATA_DIR="$B/.local/share/mise" \\
+ MISE_CACHE_DIR="$B/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$B" MISE_AGE_KEY="$KEY2"
+cd "\$HOME" && exec mise "\$@"
+WRAPPER
+chmod +x "$PWD/b"
+b="$PWD/b"
+assert_succeed "$b bootstrap --from-git file://$origin --yes --only dotfiles"
+assert "cat $B/.config/app/value" 'private-value-123'
+assert "cat $B/.config/app/rendered" 'template-private-123'
+assert "cat $B/.config/app/copied" 'copy-private-123'
+assert "cat $B/.config/app/linked" 'symlink-private-123'
+assert_succeed "test -L $B/.config/app/linked"
+assert "readlink $B/.config/app/link" 'value'
+assert_succeed "test -x $B/.config/app/script"
+printf 'changed-by-b\n' >"$B/.config/app/value"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_succeed "mise bootstrap dotfiles sync --fetch-only"
+assert_succeed "mise bootstrap dotfiles pull --yes"
+assert "cat $HOME/.config/app/value" 'changed-by-b'
+# A changed ciphertext cannot be applied without an identity or cached copy.
+printf 'needs-unlock\n' >"$B/.config/app/value"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_fail "MISE_AGE_KEY= mise bootstrap dotfiles sync --fetch-only 2>&1" 'cannot unlock'
+assert_fail "MISE_AGE_KEY= mise bootstrap dotfiles pull --yes 2>&1" 'cannot unlock'
+assert "cat $HOME/.config/app/value" 'changed-by-b'
+assert_succeed "mise bootstrap dotfiles pull --yes"
+assert "cat $HOME/.config/app/value" 'needs-unlock'
+# Reconciliation and conflict decisions operate on plaintext, never ciphertext.
+printf 'local-conflict\n' >"$HOME/.config/app/value"
+printf 'remote-conflict\n' >"$B/.config/app/value"
+assert_succeed "$b bootstrap dotfiles sync"
+conflict_head=$(git --git-dir="$origin" rev-parse main)
+assert_succeed "mise bootstrap dotfiles sync"
+assert_contains "mise bootstrap dotfiles status" 'sync paused'
+assert "git --git-dir=$origin rev-parse main" "$conflict_head"
+assert_succeed "mise bootstrap dotfiles pull --take-remote $HOME/.config/app/value --yes"
+assert "cat $HOME/.config/app/value" 'remote-conflict'
+# Deleting an encrypted file removes it remotely and at the other consumer.
+rm "$B/.config/app/script"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_succeed "mise bootstrap dotfiles sync --fetch-only && mise bootstrap dotfiles pull --yes"
+assert_fail "test -e $HOME/.config/app/script"
+assert_fail "git --git-dir=$origin cat-file -e main:tracked/home/.config/app/script"
+# Explicit recipient rotation rewrites unchanged encrypted files once.
+old_payload=$(git --git-dir="$origin" rev-parse main:tracked/home/.config/app/value)
+sed -i.bak "s/\"$PUB\", \"$PUB2\"/\"$PUB\"/" "$MISE_CONFIG_DIR/config.toml"
+assert_succeed "mise bootstrap dotfiles sync"
+new_payload=$(git --git-dir="$origin" rev-parse main:tracked/home/.config/app/value)
+assert_fail "test $old_payload = $new_payload"
+head_before=$(git --git-dir="$origin" rev-parse main)
+assert_succeed "mise bootstrap dotfiles sync"
+assert "git --git-dir=$origin rev-parse main" "$head_before"
+
+# No recipients and inline encrypted secrets both fail closed.
+cp "$MISE_CONFIG_DIR/config.toml" "$PWD/valid-config.toml"
+sed -i.bak "s/recipients = .*/recipients = []/" "$MISE_CONFIG_DIR/config.toml"
+assert_fail "mise bootstrap dotfiles sync 2>&1" '[history.encryption].recipients'
+assert "git --git-dir=$origin rev-parse main" "$head_before"
+cp "$PWD/valid-config.toml" "$MISE_CONFIG_DIR/config.toml"
+printf '\n"~/.config/app/inline" = { content = "must-not-upload", encrypt = true }\n' >>"$MISE_CONFIG_DIR/config.toml"
+assert_fail "mise bootstrap dotfiles sync 2>&1" 'invalid dotfile declarations'
+assert "git --git-dir=$origin rev-parse main" "$head_before"
+# Malformed encryption flags must never silently fall back to plaintext.
+cp "$PWD/valid-config.toml" "$MISE_CONFIG_DIR/config.toml"
+printf '\n"~/.config/app/malformed" = { mode = "track", encrypt = "true" }\n' >>"$MISE_CONFIG_DIR/config.toml"
+assert_fail "mise bootstrap dotfiles sync 2>&1" 'invalid dotfile declarations'
+assert "git --git-dir=$origin rev-parse main" "$head_before"

--- a/e2e/cli/test_dotfiles_sync_files_encrypted
+++ b/e2e/cli/test_dotfiles_sync_files_encrypted
@@ -2,7 +2,7 @@
 # Shared encrypted files use one recipient list; local files stay plaintext.
 # shellcheck disable=SC2016
 require_cmd git
-export MISE_EXPERIMENTAL=0
+export MISE_EXPERIMENTAL=1
 KEY="AGE-SECRET-KEY-142E7VJ8GUWR94MXDCYQJ7ZTQZRXKQSP9PUJU8HUQJ206QN7QPV4SM5QRL8"
 PUB="age1fuvsfq02qr5ju0nhh3rulrwracymjljlr5j49kres24ltd3fjq0s9z9d8l"
 KEY2="AGE-SECRET-KEY-12LCM5FM5DQ7HZDGYUZWMJ6QHM66J07NZ75VVP2VVGCZX53HYD5PQUXUN8K"

--- a/e2e/config/test_schema_dotfiles_encryption
+++ b/e2e/config/test_schema_dotfiles_encryption
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+TOMBI_VERSION="0.9.22"
+mise use -g tombi@$TOMBI_VERSION
+TOMBI_LINT="mise x tombi@$TOMBI_VERSION -- tombi lint --offline --no-cache --error-on-warnings --quiet"
+cat >"$HOME/tombi.toml" <<TOML
+[schema]
+enabled = true
+strict = true
+[[schemas]]
+path = "file://$ROOT/schema/mise.json"
+include = ["encrypted-valid.toml", "encrypted-invalid.toml"]
+TOML
+cat >encrypted-valid.toml <<'TOML'
+[history.encryption]
+recipients = ["public-recipient"]
+[dotfiles]
+"~/.app" = { mode = "template", source = "secret.tera", encrypt = true }
+TOML
+assert_succeed "$TOMBI_LINT encrypted-valid.toml"
+for field in content block line template; do
+  printf '[dotfiles]\n"~/.app" = { %s = "inline", encrypt = false }\n' "$field" >encrypted-valid.toml
+  assert_succeed "$TOMBI_LINT encrypted-valid.toml"
+  printf '[dotfiles]\n"~/.app" = { %s = "inline", encrypt = true }\n' "$field" >encrypted-invalid.toml
+  assert_fail "$TOMBI_LINT encrypted-invalid.toml"
+done

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1791,7 +1791,7 @@ Continue although the repository's history holds private content
 \fB\-\-encrypt\-backups\fR
 Encrypt this machine's recovery refs with age for its recipients (see \-\-recipient)
 
-Every backed\-up checkpoint becomes one age payload: file names, descriptions, and content are readable only with a recipient's identity. The setup branch itself is always plaintext.
+Every backed\-up checkpoint becomes one age payload: file names, descriptions, and content are readable only with a recipient's identity. Setup configuration stays plaintext; dotfiles can use `encrypt = true`.
 .TP
 \fB\-\-recipient\fR \fI<RECIPIENT>\fR
 A backup recipient (repeatable): an age public key (`age1…`), an SSH public key (`ssh\-ed25519 …`), or a path to a `.pub` file or an age identity file

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1716,6 +1716,8 @@ This machine first, then every machine whose refs the last
 `mise bootstrap dotfiles sync` fetched. Their checkpoints are addressed as
 `<machine>/<ref>`: `mise bootstrap dotfiles rollback \-\-to laptop/latest \-\-all`
 recovers a machine's backed\-up files; their journals are data only.
+Encrypted backups are listed without a key; restoring one needs an
+identity among its recipients.
 .PP
 \fBUsage:\fR mise bootstrap dotfiles machines [OPTIONS]
 .PP
@@ -1735,11 +1737,11 @@ Experimental: enable with `mise settings experimental=true`.
 `set <url>` connects one repository that holds the shared setup branch
 and this machine's recovery refs. Before anything leaves the machine it
 prints exactly what will happen: the sync mode, what is shared per
-stream, what is not and why, what is backed up (in plain form), names
-that look like secrets, private content already committed upstream,
-and how an existing repository would be adopted. The declaration goes
-to `[history.origin]` in the global config; the mode to
-`settings.history.sync`.
+stream, what is not and why, what is backed up (in plain form, or
+encrypted with `\-\-encrypt\-backups`), names that look like secrets,
+private content already committed upstream, and how an existing
+repository would be adopted. The declaration goes to `[history.origin]`
+in the global config; the mode to `settings.history.sync`.
 .PP
 \fBUsage:\fR mise bootstrap dotfiles origin [OPTIONS] [COMMAND]
 .PP
@@ -1787,7 +1789,14 @@ Upload the checkpoints recorded before now too
 Continue although the repository's history holds private content
 .TP
 \fB\-\-encrypt\-backups\fR
-Encrypt machine recovery refs (not supported yet)
+Encrypt this machine's recovery refs with age for its recipients (see \-\-recipient)
+
+Every backed\-up checkpoint becomes one age payload: file names, descriptions, and content are readable only with a recipient's identity. The setup branch itself is always plaintext.
+.TP
+\fB\-\-recipient\fR \fI<RECIPIENT>\fR
+A backup recipient (repeatable): an age public key (`age1…`), an SSH public key (`ssh\-ed25519 …`), or a path to a `.pub` file or an age identity file
+
+Default: this machine's own age key (`~/.config/mise/age.txt` or `settings.age.key_file`) and `~/.ssh/id_ed25519.pub` / `id_rsa.pub`. When none exists, an age identity is generated at the key file path.
 .TP
 \fB\-y, \-\-yes\fR
 Skip the confirmation prompt

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -804,6 +804,8 @@ This machine first, then every machine whose refs the last
 `mise bootstrap dotfiles sync` fetched. Their checkpoints are addressed as
 `<machine>/<ref>`: `mise bootstrap dotfiles rollback --to laptop/latest --all`
 recovers a machine's backed-up files; their journals are data only.
+Encrypted backups are listed without a key; restoring one needs an
+identity among its recipients.
 """#
             flag "-J --json" help="Output in JSON format"
             flag "-h --help" help="Print help" action=help builtin=#true
@@ -817,13 +819,13 @@ Experimental: enable with `mise settings experimental=true`.
 `set <url>` connects one repository that holds the shared setup branch
 and this machine's recovery refs. Before anything leaves the machine it
 prints exactly what will happen: the sync mode, what is shared per
-stream, what is not and why, what is backed up (in plain form), names
-that look like secrets, private content already committed upstream,
-and how an existing repository would be adopted. The declaration goes
-to `[history.origin]` in the global config; the mode to
-`settings.history.sync`.
+stream, what is not and why, what is backed up (in plain form, or
+encrypted with `--encrypt-backups`), names that look like secrets,
+private content already committed upstream, and how an existing
+repository would be adopted. The declaration goes to `[history.origin]`
+in the global config; the mode to `settings.history.sync`.
 """#
-            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles origin set https://github.com/you/setup.git\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles origin set git@github.com:you/setup.git --name laptop --sync manual\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles origin\u{1b}[22m              # what is connected\n    $ \u{1b}[1mmise bootstrap dotfiles origin --remove\u{1b}[22m\n"
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles origin set https://github.com/you/setup.git\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles origin set git@github.com:you/setup.git --name laptop --sync manual\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles origin set git@github.com:you/setup.git --encrypt-backups\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles origin set git@github.com:you/setup.git --encrypt-backups --recipient age1… --recipient ~/.ssh/id_ed25519.pub\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles origin\u{1b}[22m              # what is connected\n    $ \u{1b}[1mmise bootstrap dotfiles origin --remove\u{1b}[22m\n"
             flag --remove help="Disconnect: remove `[history.origin]` (local checkpoints and fetched refs stay)" effect=destructive
             flag --purge help="Delete this machine's recovery refs from the origin, then disconnect" effect=destructive
             flag "-y --yes" help="Skip the confirmation prompt"
@@ -840,7 +842,21 @@ to `[history.origin]` in the global config; the mode to
                 }
                 flag --include-existing help="Upload the checkpoints recorded before now too"
                 flag --allow-committed-private help="Continue although the repository's history holds private content"
-                flag --encrypt-backups help="Encrypt machine recovery refs (not supported yet)"
+                flag --encrypt-backups help="Encrypt this machine's recovery refs with age for its recipients (see --recipient)" {
+                    long_help #"""
+Encrypt this machine's recovery refs with age for its recipients (see --recipient)
+
+Every backed-up checkpoint becomes one age payload: file names, descriptions, and content are readable only with a recipient's identity. Setup configuration stays plaintext; dotfiles can use `encrypt = true`.
+"""#
+                }
+                flag --recipient help="A backup recipient (repeatable): an age public key (`age1…`), an SSH public key (`ssh-ed25519 …`), or a path to a `.pub` file or an age identity file" var=#true requires=--encrypt-backups {
+                    long_help #"""
+A backup recipient (repeatable): an age public key (`age1…`), an SSH public key (`ssh-ed25519 …`), or a path to a `.pub` file or an age identity file
+
+Default: this machine's own age key (`~/.config/mise/age.txt` or `settings.age.key_file`) and `~/.ssh/id_ed25519.pub` / `id_rsa.pub`. When none exists, an age identity is generated at the key file path.
+"""#
+                    arg <RECIPIENT>
+                }
                 flag "-y --yes" help="Skip the confirmation prompt"
                 flag "-h --help" help="Print help" action=help builtin=#true
                 arg <URL> help="The repository url (any git url; a private repository is recommended)"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -526,18 +526,18 @@
           "unevaluatedProperties": false,
           "properties": {
             "identity_files": {
-              "description": "List of age identity files to use for decryption (encrypted machine backups, and the experimental `[env]` age directives).",
+              "description": "List of age identity files to use for decryption (encrypted shared dotfiles, encrypted machine backups, and the experimental `[env]` age directives).",
               "type": "array",
               "items": {
                 "type": "string"
               }
             },
             "key_file": {
-              "description": "Path to the age private key file to use for encryption/decryption: the default recipient and identity for encrypted machine backups, and the key for the experimental `[env]` age directives.",
+              "description": "Path to the age private key file to use for encryption/decryption: the default recipient and identity for encrypted shared dotfiles, encrypted machine backups, and the key for the experimental `[env]` age directives.",
               "type": "string"
             },
             "ssh_identity_files": {
-              "description": "List of SSH identity files to use for age decryption (encrypted machine backups, and the experimental `[env]` age directives).",
+              "description": "List of SSH identity files to use for age decryption (encrypted shared dotfiles, encrypted machine backups, and the experimental `[env]` age directives).",
               "type": "array",
               "items": {
                 "type": "string"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4211,6 +4211,23 @@
                   "content": false
                 }
               }
+            ],
+            "anyOf": [
+              {
+                "properties": {
+                  "encrypt": {
+                    "const": false
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "content": false,
+                  "block": false,
+                  "line": false,
+                  "template": false
+                }
+              }
             ]
           }
         ]

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -526,18 +526,18 @@
           "unevaluatedProperties": false,
           "properties": {
             "identity_files": {
-              "description": "[experimental] List of age identity files to use for decryption.",
+              "description": "List of age identity files to use for decryption (encrypted machine backups, and the experimental `[env]` age directives).",
               "type": "array",
               "items": {
                 "type": "string"
               }
             },
             "key_file": {
-              "description": "[experimental] Path to the age private key file to use for encryption/decryption.",
+              "description": "Path to the age private key file to use for encryption/decryption: the default recipient and identity for encrypted machine backups, and the key for the experimental `[env]` age directives.",
               "type": "string"
             },
             "ssh_identity_files": {
-              "description": "[experimental] List of SSH identity files to use for age decryption.",
+              "description": "List of SSH identity files to use for age decryption (encrypted machine backups, and the experimental `[env]` age directives).",
               "type": "array",
               "items": {
                 "type": "string"
@@ -5213,7 +5213,7 @@
     },
     "history": {
       "type": "object",
-      "description": "dotfiles history: what is never captured (https://mise.jdx.dev/history.html)",
+      "description": "dotfiles history: what is never captured, reload commands, and the setup repository (https://mise.jdx.dev/history.html)",
       "properties": {
         "exclude": {
           "type": "array",
@@ -5221,6 +5221,42 @@
           "items": {
             "type": "string"
           }
+        },
+        "reload": {
+          "type": "object",
+          "description": "commands run once after a rollback or undo writes a path matching the glob (trusted global or system config only)",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "origin": {
+          "type": "object",
+          "description": "the setup repository this machine publishes to and fetches from; machine-local, written by `mise bootstrap dotfiles origin set`",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "the repository url"
+            },
+            "branch": {
+              "type": "string",
+              "description": "the setup branch",
+              "default": "main"
+            },
+            "encrypt_backups": {
+              "type": "boolean",
+              "description": "encrypt this machine's recovery refs with age for `recipients`; on without recipients, nothing is uploaded",
+              "default": false
+            },
+            "recipients": {
+              "type": "array",
+              "description": "age public keys (`age1…`) and SSH public keys the backups are encrypted for",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["url"],
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4135,6 +4135,11 @@
             "type": "object",
             "description": "whole-file dotfile entry or file edit entry",
             "properties": {
+              "encrypt": {
+                "type": "boolean",
+                "default": false,
+                "description": "encrypt this file or external source when sharing; local files and history stay plaintext"
+              },
               "source": {
                 "type": "string",
                 "description": "source file or directory"
@@ -5215,6 +5220,19 @@
       "type": "object",
       "description": "dotfiles history: what is never captured, reload commands, and the setup repository (https://mise.jdx.dev/history.html)",
       "properties": {
+        "encryption": {
+          "type": "object",
+          "properties": {
+            "recipients": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "shared age, SSH, or age-plugin public recipients for all encrypted dotfiles"
+            }
+          },
+          "additionalProperties": false
+        },
         "exclude": {
           "type": "array",
           "description": "globs never captured by dotfiles history; a `!glob` entry re-includes a path an earlier glob excluded",

--- a/settings.toml
+++ b/settings.toml
@@ -30,7 +30,7 @@ env = "MISE_ACTIVATE_AGGRESSIVE"
 type = "Bool"
 
 [age.identity_files]
-description = "List of age identity files to use for decryption (encrypted machine backups, and the experimental `[env]` age directives)."
+description = "List of age identity files to use for decryption (encrypted shared dotfiles, encrypted machine backups, and the experimental `[env]` age directives)."
 env = "MISE_AGE_IDENTITY_FILES"
 optional = true
 parse_env = "list_by_os_path_separator"
@@ -39,13 +39,13 @@ type = "ListPath"
 
 [age.key_file]
 default_docs = "~/.config/mise/age.txt"
-description = "Path to the age private key file to use for encryption/decryption: the default recipient and identity for encrypted machine backups, and the key for the experimental `[env]` age directives."
+description = "Path to the age private key file to use for encryption/decryption: the default recipient and identity for encrypted shared dotfiles, encrypted machine backups, and the key for the experimental `[env]` age directives."
 env = "MISE_AGE_KEY_FILE"
 optional = true
 type = "Path"
 
 [age.ssh_identity_files]
-description = "List of SSH identity files to use for age decryption (encrypted machine backups, and the experimental `[env]` age directives)."
+description = "List of SSH identity files to use for age decryption (encrypted shared dotfiles, encrypted machine backups, and the experimental `[env]` age directives)."
 env = "MISE_AGE_SSH_IDENTITY_FILES"
 optional = true
 parse_env = "list_by_os_path_separator"

--- a/settings.toml
+++ b/settings.toml
@@ -30,7 +30,7 @@ env = "MISE_ACTIVATE_AGGRESSIVE"
 type = "Bool"
 
 [age.identity_files]
-description = "[experimental] List of age identity files to use for decryption."
+description = "List of age identity files to use for decryption (encrypted machine backups, and the experimental `[env]` age directives)."
 env = "MISE_AGE_IDENTITY_FILES"
 optional = true
 parse_env = "list_by_os_path_separator"
@@ -39,13 +39,13 @@ type = "ListPath"
 
 [age.key_file]
 default_docs = "~/.config/mise/age.txt"
-description = "[experimental] Path to the age private key file to use for encryption/decryption."
+description = "Path to the age private key file to use for encryption/decryption: the default recipient and identity for encrypted machine backups, and the key for the experimental `[env]` age directives."
 env = "MISE_AGE_KEY_FILE"
 optional = true
 type = "Path"
 
 [age.ssh_identity_files]
-description = "[experimental] List of SSH identity files to use for age decryption."
+description = "List of SSH identity files to use for age decryption (encrypted machine backups, and the experimental `[env]` age directives)."
 env = "MISE_AGE_SSH_IDENTITY_FILES"
 optional = true
 parse_env = "list_by_os_path_separator"

--- a/src/agecrypt.rs
+++ b/src/agecrypt.rs
@@ -1,19 +1,33 @@
+//! age encryption shared by two features: encrypted machine backups
+//! (`mise bootstrap dotfiles origin set --encrypt-backups`) and the
+//! experimental `[env]` age directives (`mise set --age-encrypt`, decrypted
+//! when the environment is resolved).
+//!
+//! This module is the stable core: identity discovery (`MISE_AGE_KEY`, the
+//! `age.*` settings, `~/.config/mise/age.txt`, the default SSH keys),
+//! recipient parsing, identity generation, and byte-level encryption.
+//! Nothing here is gated behind `settings.experimental`. The directive layer
+//! in `directive` keeps its own gate and its own wording.
+
 use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 
 use age::ssh;
 use age::{Decryptor, Encryptor, Identity, IdentityFile, Recipient};
-use base64::Engine;
-use eyre::{Result, WrapErr, eyre};
+use eyre::{Result, WrapErr, bail, eyre};
 use indexmap::IndexSet;
 
 use crate::config::Settings;
-use crate::config::env_directive::{AgeFormat, EnvDirective, EnvDirectiveOptions};
-use crate::file::{self, replace_path};
+use crate::file::{self, display_path, replace_path};
 use crate::{dirs, env};
 
-const ZSTD_COMPRESSION_LEVEL: i32 = 3;
-const COMPRESSION_THRESHOLD: usize = 1024; // 1KB
+mod directive;
+pub(crate) use directive::{
+    create_age_directive, decrypt_age_directive, load_recipients_from_defaults,
+    load_recipients_from_key_file, load_ssh_recipient_from_path,
+};
+
+pub(crate) const ZSTD_COMPRESSION_LEVEL: i32 = 3;
 
 /// Why an SSH identity mise loaded cannot actually decrypt anything.
 ///
@@ -22,7 +36,7 @@ const COMPRESSION_THRESHOLD: usize = 1024; // 1KB
 /// reports "No matching keys found", which blames the recipient when the real
 /// problem is that the identity could not be read at all.
 #[derive(Debug, PartialEq, Eq)]
-enum UnusableSshIdentity {
+pub(crate) enum UnusableSshIdentity {
     Passphrase,
     EncryptedPem,
     EncryptedCipher(String),
@@ -65,7 +79,7 @@ impl UnusableSshIdentity {
 ///
 /// Only worth saying once decryption has already failed: an unreadable key
 /// sitting beside a working one costs the user nothing.
-fn unusable_identity_hint(unusable: &[(PathBuf, UnusableSshIdentity)]) -> String {
+pub(crate) fn unusable_identity_hint(unusable: &[(PathBuf, UnusableSshIdentity)]) -> String {
     if unusable.is_empty() {
         return String::new();
     }
@@ -73,7 +87,7 @@ fn unusable_identity_hint(unusable: &[(PathBuf, UnusableSshIdentity)]) -> String
     for (path, reason) in unusable {
         hint.push_str(&format!(
             "\nhint: {} {}, so it could not be used",
-            file::display_path(path),
+            display_path(path),
             reason.reason()
         ));
     }
@@ -83,103 +97,148 @@ fn unusable_identity_hint(unusable: &[(PathBuf, UnusableSshIdentity)]) -> String
     hint
 }
 
-pub(crate) async fn create_age_directive(
-    key: String,
-    value: &str,
-    recipients: &[Box<dyn Recipient + Send>],
-) -> Result<EnvDirective> {
-    if recipients.is_empty() {
-        return Err(eyre!(
-            "[experimental] No age recipients provided for encryption"
-        ));
-    }
-
-    let encryptor =
-        match Encryptor::with_recipients(recipients.iter().map(|r| r.as_ref() as &dyn Recipient)) {
-            Ok(encryptor) => encryptor,
-            Err(e) => return Err(eyre!("[experimental] Failed to create encryptor: {}", e)),
-        };
-
-    let mut encrypted = Vec::new();
-    let mut writer = encryptor.wrap_output(&mut encrypted)?;
-    writer.write_all(value.as_bytes())?;
-    writer.finish()?;
-
-    // Determine format based on size and compression
-    let (encoded, format) = if encrypted.len() > COMPRESSION_THRESHOLD {
-        let compressed = zstd::encode_all(&encrypted[..], ZSTD_COMPRESSION_LEVEL)?;
-        let encoded = base64::engine::general_purpose::STANDARD_NO_PAD.encode(&compressed);
-        (encoded, Some(AgeFormat::Zstd))
-    } else {
-        let encoded = base64::engine::general_purpose::STANDARD_NO_PAD.encode(&encrypted);
-        (encoded, None) // Use None for raw format (default)
-    };
-
-    Ok(EnvDirective::Age {
-        key,
-        value: encoded,
-        format,
-        options: EnvDirectiveOptions::default(),
-    })
+/// Every identity this machine can decrypt with, in the order they were
+/// found, plus what is known about the ones that cannot.
+#[derive(Default)]
+pub(crate) struct LoadedIdentities {
+    pub identities: Vec<Box<dyn Identity + Send + Sync>>,
+    pub unusable: Vec<(PathBuf, UnusableSshIdentity)>,
+    /// The public keys of the x25519 identities among them (`age1…`), so a
+    /// caller can tell whether this machine is among a set of recipients.
+    pub x25519_public: Vec<String>,
 }
 
-pub(crate) async fn decrypt_age_directive(directive: &EnvDirective) -> Result<String> {
-    Settings::get().ensure_experimental("age encryption")?;
-    match directive {
-        EnvDirective::Age { value, format, .. } => {
-            let decoded = base64::engine::general_purpose::STANDARD_NO_PAD
-                .decode(value)
-                .wrap_err("[experimental] Failed to decode base64")?;
+impl LoadedIdentities {
+    /// Identities that can take part in decryption.
+    pub(crate) fn usable(&self) -> usize {
+        self.identities.len().saturating_sub(self.unusable.len())
+    }
+}
 
-            let ciphertext = match format {
-                Some(AgeFormat::Zstd) => zstd::decode_all(&decoded[..])
-                    .wrap_err("[experimental] Failed to decompress zstd")?,
-                Some(AgeFormat::Raw) | None => decoded,
-            };
+/// Why `decrypt_bytes` could not produce the plaintext.
+#[derive(Debug)]
+pub(crate) enum DecryptError {
+    /// No identity at all: nothing to try.
+    NoIdentities,
+    /// Identities were tried and none matched.
+    Failed { error: String, hint: String },
+    /// Not an age file, or a damaged one.
+    Corrupt(String),
+}
 
-            let (identities, unusable) = load_all_identities().await?;
-            if identities.is_empty() {
-                return Err(eyre!(
-                    "[experimental] No age identities found for decryption"
-                ));
-            }
-
-            let decryptor = Decryptor::new(&ciphertext[..])?;
-            let mut decrypted = Vec::new();
-
-            let identity_refs: Vec<&dyn Identity> = identities
-                .iter()
-                .map(|i| i.as_ref() as &dyn Identity)
-                .collect();
-
-            match decryptor.decrypt(identity_refs.into_iter()) {
-                Ok(mut reader) => {
-                    reader.read_to_end(&mut decrypted)?;
-                }
-                Err(e) => {
-                    return Err(eyre!(
-                        "[experimental] Failed to decrypt: {e}{}",
-                        unusable_identity_hint(&unusable)
-                    ));
-                }
-            }
-
-            String::from_utf8(decrypted)
-                .wrap_err("[experimental] Decrypted value is not valid UTF-8")
+impl std::fmt::Display for DecryptError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoIdentities => write!(f, "no age identity is available on this machine"),
+            Self::Failed { error, hint } => write!(f, "{error}{hint}"),
+            Self::Corrupt(reason) => write!(f, "{reason}"),
         }
-        _ => Err(eyre!("[experimental] Not an Age directive")),
     }
 }
 
-pub(crate) async fn load_recipients_from_defaults() -> Result<Vec<Box<dyn Recipient + Send>>> {
-    let mut recipients: IndexSet<String> = IndexSet::new();
+impl std::error::Error for DecryptError {}
 
-    // Try to load from age key file
+/// zstd-compressed, then age-encrypted for `recipients`.
+pub(crate) fn encrypt_bytes(
+    plaintext: &[u8],
+    recipients: &[Box<dyn Recipient + Send>],
+) -> Result<Vec<u8>> {
+    if recipients.is_empty() {
+        bail!("no age recipients to encrypt for");
+    }
+    let compressed = zstd::encode_all(plaintext, ZSTD_COMPRESSION_LEVEL)?;
+    let encryptor =
+        Encryptor::with_recipients(recipients.iter().map(|r| r.as_ref() as &dyn Recipient))
+            .map_err(|e| eyre!("creating the age encryptor: {e}"))?;
+    let mut out = Vec::new();
+    let mut writer = encryptor.wrap_output(&mut out)?;
+    writer.write_all(&compressed)?;
+    writer.finish()?;
+    Ok(out)
+}
+
+/// The inverse of `encrypt_bytes`, with every identity this machine has.
+pub(crate) async fn decrypt_bytes(ciphertext: &[u8]) -> Result<Vec<u8>, DecryptError> {
+    let loaded = load_all_identities().await;
+    if loaded.identities.is_empty() {
+        return Err(DecryptError::NoIdentities);
+    }
+    let decryptor = Decryptor::new(ciphertext)
+        .map_err(|e| DecryptError::Corrupt(format!("not an age file: {e}")))?;
+    let refs: Vec<&dyn Identity> = loaded
+        .identities
+        .iter()
+        .map(|i| i.as_ref() as &dyn Identity)
+        .collect();
+    let mut reader = decryptor
+        .decrypt(refs.into_iter())
+        .map_err(|e| DecryptError::Failed {
+            error: e.to_string(),
+            hint: unusable_identity_hint(&loaded.unusable),
+        })?;
+    let mut compressed = Vec::new();
+    reader
+        .read_to_end(&mut compressed)
+        .map_err(|e| DecryptError::Corrupt(format!("reading the age payload: {e}")))?;
+    zstd::decode_all(&compressed[..])
+        .map_err(|e| DecryptError::Corrupt(format!("decompressing the payload: {e}")))
+}
+
+/// Where a generated identity goes: `settings.age.key_file`, else the
+/// default `~/.config/mise/age.txt` (whether or not it exists yet).
+pub(crate) fn default_identity_file() -> PathBuf {
+    Settings::get()
+        .age
+        .key_file
+        .clone()
+        .map(replace_path)
+        .unwrap_or_else(|| dirs::CONFIG.join("age.txt"))
+}
+
+/// Generates an x25519 identity into `path` (created private, 0600 on
+/// unix, never overwriting) and returns its public key.
+pub(crate) fn generate_identity_file(path: &Path) -> Result<String> {
+    use age::secrecy::ExposeSecret;
+    if path.exists() {
+        bail!(
+            "{} exists already and is not overwritten",
+            display_path(path)
+        );
+    }
+    if let Some(parent) = path.parent() {
+        file::create_dir_all(parent)?;
+    }
+    let identity = age::x25519::Identity::generate();
+    let public = identity.to_public().to_string();
+    let content = format!(
+        "# created: {}\n# public key: {public}\n{}\n",
+        chrono::Utc::now().to_rfc3339(),
+        identity.to_string().expose_secret()
+    );
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut out = options
+        .open(path)
+        .wrap_err_with(|| format!("creating {}", display_path(path)))?;
+    out.write_all(content.as_bytes())
+        .wrap_err_with(|| format!("writing {}", display_path(path)))?;
+    Ok(public)
+}
+
+/// The recipients this machine's own identities imply: the public key of
+/// every x25519 identity in the key file, and the `.pub` of every default
+/// SSH key. Empty when there is none; not an error.
+pub(crate) async fn default_recipient_strings() -> Result<Vec<String>> {
+    let mut recipients: IndexSet<String> = IndexSet::new();
     if let Some(key_file) = get_default_key_file().await
         && key_file.exists()
     {
         let content = file::read_to_string(&key_file)?;
-        // For age keys, we need to parse them as x25519 identities to get public keys
         for line in content.lines() {
             let line = line.trim();
             if line.starts_with("AGE-SECRET-KEY-")
@@ -189,124 +248,86 @@ pub(crate) async fn load_recipients_from_defaults() -> Result<Vec<Box<dyn Recipi
             }
         }
     }
-
-    // Try to load from SSH private keys
-    let ssh_key_paths = get_default_ssh_key_paths();
-    for path in ssh_key_paths {
+    for path in get_default_ssh_key_paths() {
         if path.exists()
-            && let Ok(recipient) = load_ssh_recipient_from_private_key(&path).await
+            && let Ok(recipient) = ssh_public_key_for_private(&path).await
         {
             recipients.insert(recipient);
         }
     }
-
-    let mut parsed_recipients: Vec<Box<dyn Recipient + Send>> = Vec::new();
-    for recipient_str in recipients {
-        if let Some(recipient) = parse_recipient(&recipient_str)? {
-            parsed_recipients.push(recipient);
-        }
-    }
-
-    if parsed_recipients.is_empty() {
-        return Err(eyre!(
-            "[experimental] No age recipients found. Provide --age-recipient, --age-ssh-recipient, or configure settings.age.key_file"
-        ));
-    }
-
-    Ok(parsed_recipients)
+    Ok(recipients.into_iter().collect())
 }
 
-pub(crate) async fn load_recipients_from_key_file(
-    path: &Path,
-) -> Result<Vec<Box<dyn Recipient + Send>>> {
-    let mut recipients: Vec<Box<dyn Recipient + Send>> = Vec::new();
-
-    if !path.exists() {
-        return Err(eyre!(
-            "[experimental] Age key file not found: {}",
-            path.display()
-        ));
+/// One `--recipient` argument: an age public key, an SSH public key, or a
+/// path to a file holding either (a `.pub` file, or an age identity file
+/// whose secret keys are turned into their public keys).
+pub(crate) async fn resolve_recipient_arg(arg: &str) -> Result<Vec<String>> {
+    let trimmed = arg.trim();
+    if trimmed.starts_with("age1") || trimmed.starts_with("ssh-") {
+        parse_recipient(trimmed)?;
+        return Ok(vec![trimmed.to_string()]);
     }
-
-    let content = file::read_to_string(path)?;
-
-    // Parse age x25519 identities and convert to recipients
+    let path = replace_path(trimmed);
+    if !path.is_file() {
+        bail!(
+            "{arg} is not an age recipient (age1…), an SSH public key (ssh-…), or a readable key file"
+        );
+    }
+    let content = file::read_to_string(&path)?;
+    let mut out = vec![];
     for line in content.lines() {
         let line = line.trim();
-        if line.starts_with("AGE-SECRET-KEY-")
-            && let Ok(identity) = line.parse::<age::x25519::Identity>()
-        {
-            let public_key = identity.to_public();
-            recipients.push(Box::new(public_key));
+        if line.starts_with("ssh-") {
+            // the key type and material only: a `.pub` file's comment is
+            // not part of the recipient
+            let key = line
+                .split_whitespace()
+                .take(2)
+                .collect::<Vec<_>>()
+                .join(" ");
+            parse_recipient(&key).wrap_err_with(|| display_path(&path))?;
+            out.push(key);
+        } else if line.starts_with("age1") {
+            parse_recipient(line).wrap_err_with(|| display_path(&path))?;
+            out.push(line.to_string());
+        } else if line.starts_with("AGE-SECRET-KEY-") {
+            let identity = line
+                .parse::<age::x25519::Identity>()
+                .map_err(|e| eyre!("{}: {e}", display_path(&path)))?;
+            out.push(identity.to_public().to_string());
         }
     }
-
-    if recipients.is_empty() {
-        return Err(eyre!(
-            "[experimental] No valid age identities found in {}",
-            path.display()
-        ));
+    if out.is_empty() {
+        bail!(
+            "{} holds no age identity, age recipient, or SSH public key",
+            display_path(&path)
+        );
     }
-
-    Ok(recipients)
+    Ok(out)
 }
 
+/// `age1…` or `ssh-…`; `None` for anything else.
 pub(crate) fn parse_recipient(recipient_str: &str) -> Result<Option<Box<dyn Recipient + Send>>> {
     let trimmed = recipient_str.trim();
-
     if trimmed.starts_with("age1") {
         match trimmed.parse::<age::x25519::Recipient>() {
             Ok(r) => Ok(Some(Box::new(r))),
-            Err(e) => Err(eyre!("[experimental] Invalid age recipient: {}", e)),
+            Err(e) => Err(eyre!("invalid age recipient {trimmed:?}: {e}")),
         }
     } else if trimmed.starts_with("ssh-") {
-        // SSH recipient parsing - the age crate will validate it
+        // the age crate validates the key material
         match trimmed.parse::<ssh::Recipient>() {
             Ok(r) => Ok(Some(Box::new(r))),
-            Err(e) => Err(eyre!("[experimental] Invalid SSH recipient: {:?}", e)),
+            Err(e) => Err(eyre!("invalid SSH recipient: {e:?}")),
         }
     } else {
         Ok(None)
     }
 }
 
-pub(crate) async fn load_ssh_recipient_from_path(path: &Path) -> Result<Box<dyn Recipient + Send>> {
-    let content = file::read_to_string(path)?;
-    let trimmed = content.trim();
-
-    // Check if it's a public key
-    if trimmed.starts_with("ssh-") {
-        match trimmed.parse::<ssh::Recipient>() {
-            Ok(r) => return Ok(Box::new(r)),
-            Err(e) => {
-                return Err(eyre!(
-                    "[experimental] Invalid SSH public key at {}: {:?}",
-                    path.display(),
-                    e
-                ));
-            }
-        }
-    }
-
-    // Try to load as private key and derive public
-    if path.extension().and_then(|s| s.to_str()) == Some("pub") {
-        Err(eyre!(
-            "[experimental] Invalid SSH public key at {}",
-            path.display()
-        ))
-    } else {
-        load_ssh_recipient_from_private_key(path)
-            .await
-            .and_then(|s| {
-                parse_recipient(&s)?
-                    .ok_or_else(|| eyre!("[experimental] Failed to parse SSH recipient"))
-            })
-    }
-}
-
-async fn load_ssh_recipient_from_private_key(path: &Path) -> Result<String> {
-    // For SSH keys, we can't easily derive the public key from the private key using the age crate
-    // So we'll try to read the corresponding .pub file
+/// The public key beside an SSH private key: age cannot derive it, so the
+/// `.pub` file must exist.
+pub(crate) async fn ssh_public_key_for_private(path: &Path) -> Result<String> {
     let pub_path = path.with_extension("pub");
     if pub_path.exists() {
         let content = file::read_to_string(&pub_path)?;
@@ -315,108 +336,98 @@ async fn load_ssh_recipient_from_private_key(path: &Path) -> Result<String> {
             return Ok(trimmed.to_string());
         }
     }
-
-    Err(eyre!(
-        "[experimental] Could not find public key for SSH private key at {}. Expected {}.pub",
-        path.display(),
-        path.display()
-    ))
+    bail!(
+        "no public key for the SSH private key at {}; expected {}",
+        display_path(path),
+        display_path(&pub_path)
+    )
 }
 
-type LoadedIdentities = (
-    Vec<Box<dyn Identity + Send + Sync>>,
-    Vec<(PathBuf, UnusableSshIdentity)>,
-);
-
-async fn load_all_identities() -> Result<LoadedIdentities> {
-    // Get identity files first
+/// Every identity this machine has: `MISE_AGE_KEY`, the identity files
+/// named by the settings and the default `age.txt`, and the SSH keys named
+/// by the settings and the default `~/.ssh/id_ed25519` / `id_rsa`.
+pub(crate) async fn load_all_identities() -> LoadedIdentities {
     let identity_files = get_all_identity_files().await;
     let ssh_identity_files = get_all_ssh_identity_files();
+    let mut loaded = LoadedIdentities::default();
 
-    // Now process identities without holding them across await points
-    let mut identities: Vec<Box<dyn Identity + Send + Sync>> = Vec::new();
-    let mut unusable: Vec<(PathBuf, UnusableSshIdentity)> = Vec::new();
-
-    // Check MISE_AGE_KEY environment variable
     if let Ok(age_key) = env::var("MISE_AGE_KEY")
         && !age_key.is_empty()
     {
-        // First try to parse as a raw age secret key
+        // raw secret keys first
         for line in age_key.lines() {
             let line = line.trim();
             if line.starts_with("AGE-SECRET-KEY-")
                 && let Ok(identity) = line.parse::<age::x25519::Identity>()
             {
-                identities.push(Box::new(identity));
+                loaded.x25519_public.push(identity.to_public().to_string());
+                loaded.identities.push(Box::new(identity));
             }
         }
-
-        // If no keys were found, try parsing as an identity file
-        if identities.is_empty()
+        // else the whole value as an identity file
+        if loaded.identities.is_empty()
             && let Ok(identity_file) = IdentityFile::from_buffer(age_key.as_bytes())
             && let Ok(mut file_identities) = identity_file.into_identities()
         {
-            identities.append(&mut file_identities);
+            loaded.identities.append(&mut file_identities);
         }
     }
 
-    // Load from identity files
     for path in identity_files {
-        if path.exists() {
-            match file::read_to_string(&path) {
-                Ok(content) => {
-                    if let Ok(identity_file) = IdentityFile::from_buffer(content.as_bytes())
-                        && let Ok(mut file_identities) = identity_file.into_identities()
+        if !path.exists() {
+            continue;
+        }
+        match file::read_to_string(&path) {
+            Ok(content) => {
+                if let Ok(identity_file) = IdentityFile::from_buffer(content.as_bytes())
+                    && let Ok(mut file_identities) = identity_file.into_identities()
+                {
+                    loaded.identities.append(&mut file_identities);
+                }
+                for line in content.lines() {
+                    let line = line.trim();
+                    if line.starts_with("AGE-SECRET-KEY-")
+                        && let Ok(identity) = line.parse::<age::x25519::Identity>()
                     {
-                        identities.append(&mut file_identities);
+                        loaded.x25519_public.push(identity.to_public().to_string());
                     }
                 }
-                Err(e) => {
-                    debug!(
-                        "[experimental] Failed to read identity file {:?}: {}",
-                        path, e
-                    );
-                }
+            }
+            Err(e) => {
+                debug!("age: failed to read identity file {:?}: {}", path, e);
             }
         }
     }
 
-    // Load SSH identities
     for path in ssh_identity_files {
-        if path.exists() {
-            match std::fs::File::open(&path) {
-                Ok(file) => {
-                    let mut reader = BufReader::new(file);
-                    match ssh::Identity::from_buffer(&mut reader, Some(path.display().to_string()))
-                    {
-                        Ok(identity) => {
-                            if let Some(reason) = UnusableSshIdentity::classify(&identity) {
-                                // Still keep it: dropping the only identity would
-                                // report "No age identities found" instead, which is
-                                // just as misleading as the message being fixed here.
-                                unusable.push((path.clone(), reason));
-                            }
-                            identities.push(Box::new(identity));
+        if !path.exists() {
+            continue;
+        }
+        match std::fs::File::open(&path) {
+            Ok(file) => {
+                let mut reader = BufReader::new(file);
+                match ssh::Identity::from_buffer(&mut reader, Some(path.display().to_string())) {
+                    Ok(identity) => {
+                        if let Some(reason) = UnusableSshIdentity::classify(&identity) {
+                            // Still keep it: dropping the only identity would
+                            // report "no identities" instead, which is just
+                            // as misleading as the message being fixed here.
+                            loaded.unusable.push((path.clone(), reason));
                         }
-                        Err(e) => {
-                            debug!(
-                                "[experimental] Failed to parse SSH identity from {:?}: {}",
-                                path, e
-                            );
-                        }
+                        loaded.identities.push(Box::new(identity));
+                    }
+                    Err(e) => {
+                        debug!("age: failed to parse SSH identity from {:?}: {}", path, e);
                     }
                 }
-                Err(e) => {
-                    debug!(
-                        "[experimental] Failed to read SSH identity file {:?}: {}",
-                        path, e
-                    );
-                }
+            }
+            Err(e) => {
+                debug!("age: failed to read SSH identity file {:?}: {}", path, e);
             }
         }
     }
 
-    Ok((identities, unusable))
+    loaded
 }
 
 async fn get_default_key_file() -> Option<PathBuf> {
@@ -524,99 +535,130 @@ mod tests {
         let hint = unusable_identity_hint(&[(path.clone(), UnusableSshIdentity::Passphrase)]);
         // Compare against the rendered form: display_path uses the host
         // separator, so a literal "/keys/..." never matches on Windows.
-        assert!(hint.contains(&file::display_path(&path)), "{hint}");
+        assert!(hint.contains(&display_path(&path)), "{hint}");
         assert!(hint.contains("passphrase"), "{hint}");
         assert!(hint.contains("settings.age.key_file"), "{hint}");
-    }
-
-    #[tokio::test]
-    async fn test_age_x25519_round_trip_small() -> Result<()> {
-        let key = age::x25519::Identity::generate();
-        let recipient = key.to_public();
-
-        // Small value should not be compressed
-        let plaintext = "secret value";
-        let recipients: Vec<Box<dyn Recipient + Send>> = vec![Box::new(recipient)];
-        let directive =
-            create_age_directive("TEST_VAR".to_string(), plaintext, &recipients).await?;
-
-        if let crate::config::env_directive::EnvDirective::Age { value, format, .. } = directive {
-            // Small value should not be compressed (format should be None/Raw)
-            assert!(
-                format.is_none()
-                    || matches!(format, Some(crate::config::env_directive::AgeFormat::Raw))
-            );
-
-            use age::secrecy::ExposeSecret;
-            env::set_var("MISE_AGE_KEY", key.to_string().expose_secret());
-            let decrypted =
-                decrypt_age_directive(&crate::config::env_directive::EnvDirective::Age {
-                    key: "TEST_VAR".to_string(),
-                    value,
-                    format,
-                    options: Default::default(),
-                })
-                .await?;
-            env::remove_var("MISE_AGE_KEY");
-
-            assert_eq!(decrypted, plaintext);
-        } else {
-            panic!("Expected Age directive");
-        }
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_age_x25519_round_trip_large() -> Result<()> {
-        let key = age::x25519::Identity::generate();
-        let recipient = key.to_public();
-
-        // Large value should be compressed (>1KB)
-        let plaintext = "x".repeat(2000);
-        let recipients: Vec<Box<dyn Recipient + Send>> = vec![Box::new(recipient)];
-        let directive =
-            create_age_directive("TEST_VAR".to_string(), &plaintext, &recipients).await?;
-
-        if let crate::config::env_directive::EnvDirective::Age { value, format, .. } = directive {
-            // Large value should be compressed
-            assert_eq!(format, Some(crate::config::env_directive::AgeFormat::Zstd));
-
-            use age::secrecy::ExposeSecret;
-            env::set_var("MISE_AGE_KEY", key.to_string().expose_secret());
-            let decrypted =
-                decrypt_age_directive(&crate::config::env_directive::EnvDirective::Age {
-                    key: "TEST_VAR".to_string(),
-                    value,
-                    format,
-                    options: Default::default(),
-                })
-                .await?;
-            env::remove_var("MISE_AGE_KEY");
-
-            assert_eq!(decrypted, plaintext);
-        } else {
-            panic!("Expected Age directive");
-        }
-        Ok(())
     }
 
     #[test]
     fn test_parse_recipient() -> Result<()> {
         let age_recipient = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p";
-        let parsed = parse_recipient(age_recipient)?;
-        assert!(parsed.is_some());
-
-        // Note: The SSH recipient parser in the age crate is strict about format
-        // This is a valid format example
+        assert!(parse_recipient(age_recipient)?.is_some());
         let ssh_recipient =
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJmkfJ8VZq4m5k7tJVts7+nR01fbRvLHLgeQCF6FWYr5";
-        let parsed = parse_recipient(ssh_recipient)?;
-        assert!(parsed.is_some());
+        assert!(parse_recipient(ssh_recipient)?.is_some());
+        assert!(parse_recipient("invalid_recipient")?.is_none());
+        let err = match parse_recipient("age1notakey") {
+            Err(err) => err.to_string(),
+            Ok(_) => panic!("age1notakey was accepted"),
+        };
+        assert!(!err.contains("experimental"), "{err}");
+        Ok(())
+    }
 
-        let invalid = "invalid_recipient";
-        let parsed = parse_recipient(invalid)?;
-        assert!(parsed.is_none());
+    #[tokio::test]
+    async fn test_encrypt_bytes_round_trips_and_compresses() -> Result<()> {
+        use age::secrecy::ExposeSecret;
+        let key = age::x25519::Identity::generate();
+        let recipients: Vec<Box<dyn Recipient + Send>> = vec![Box::new(key.to_public())];
 
+        let small = b"a few bytes".to_vec();
+        let ciphertext = encrypt_bytes(&small, &recipients)?;
+        assert_ne!(ciphertext, small);
+
+        // compressible: the ciphertext ends up shorter than the plaintext
+        let large = "the same line again\n".repeat(5000).into_bytes();
+        let large_ciphertext = encrypt_bytes(&large, &recipients)?;
+        assert!(large_ciphertext.len() < large.len());
+
+        env::set_var("MISE_AGE_KEY", key.to_string().expose_secret());
+        let decrypted = decrypt_bytes(&ciphertext).await;
+        let decrypted_large = decrypt_bytes(&large_ciphertext).await;
+        env::remove_var("MISE_AGE_KEY");
+        assert_eq!(decrypted.unwrap(), small);
+        assert_eq!(decrypted_large.unwrap(), large);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_decrypt_bytes_reports_the_wrong_identity() -> Result<()> {
+        use age::secrecy::ExposeSecret;
+        let key = age::x25519::Identity::generate();
+        let other = age::x25519::Identity::generate();
+        let recipients: Vec<Box<dyn Recipient + Send>> = vec![Box::new(key.to_public())];
+        let ciphertext = encrypt_bytes(b"payload", &recipients)?;
+
+        env::set_var("MISE_AGE_KEY", other.to_string().expose_secret());
+        let result = decrypt_bytes(&ciphertext).await;
+        let corrupt = decrypt_bytes(b"not an age file at all").await;
+        env::remove_var("MISE_AGE_KEY");
+        assert!(
+            matches!(result, Err(DecryptError::Failed { .. })),
+            "{result:?}"
+        );
+        assert!(
+            matches!(corrupt, Err(DecryptError::Corrupt(_))),
+            "{corrupt:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_encrypt_bytes_needs_a_recipient() {
+        let err = encrypt_bytes(b"x", &[]).unwrap_err().to_string();
+        assert!(err.contains("no age recipients"), "{err}");
+        assert!(!err.contains("experimental"), "{err}");
+    }
+
+    #[test]
+    fn test_generate_identity_file_is_private_and_never_overwrites() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("keys").join("age.txt");
+        let public = generate_identity_file(&path)?;
+        assert!(public.starts_with("age1"), "{public}");
+        let content = std::fs::read_to_string(&path)?;
+        assert!(
+            content.contains(&format!("# public key: {public}")),
+            "{content}"
+        );
+        assert!(content.contains("AGE-SECRET-KEY-"), "{content}");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path)?.permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        let err = generate_identity_file(&path).unwrap_err().to_string();
+        assert!(err.contains("not overwritten"), "{err}");
+        assert_eq!(std::fs::read_to_string(&path)?, content);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_resolve_recipient_arg_accepts_keys_and_files() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let identity_file = dir.path().join("age.txt");
+        let public = generate_identity_file(&identity_file)?;
+        // an identity file yields its public key, never the secret
+        let resolved = resolve_recipient_arg(identity_file.to_str().unwrap()).await?;
+        assert_eq!(resolved, vec![public.clone()]);
+
+        let ssh =
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJmkfJ8VZq4m5k7tJVts7+nR01fbRvLHLgeQCF6FWYr5";
+        let pub_file = dir.path().join("id_ed25519.pub");
+        std::fs::write(&pub_file, format!("{ssh} user@host\n"))?;
+        let resolved = resolve_recipient_arg(pub_file.to_str().unwrap()).await?;
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved[0].starts_with("ssh-ed25519 "), "{resolved:?}");
+
+        assert_eq!(resolve_recipient_arg(&public).await?, vec![public]);
+        let err = resolve_recipient_arg("nothing-like-a-key")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not an age recipient"), "{err}");
         Ok(())
     }
 }

--- a/src/agecrypt.rs
+++ b/src/agecrypt.rs
@@ -340,6 +340,13 @@ pub(crate) async fn resolve_recipient_arg(arg: &str) -> Result<Vec<String>> {
 
 /// `age1…` or `ssh-…`; `None` for anything else.
 pub(crate) fn parse_recipient(recipient_str: &str) -> Result<Option<Box<dyn Recipient + Send>>> {
+    parse_recipient_mode(recipient_str, true)
+}
+
+pub(crate) fn parse_recipient_mode(
+    recipient_str: &str,
+    interactive: bool,
+) -> Result<Option<Box<dyn Recipient + Send>>> {
     let trimmed = recipient_str.trim();
     if trimmed.starts_with("age1tag1") {
         return trimmed
@@ -359,6 +366,11 @@ pub(crate) fn parse_recipient(recipient_str: &str) -> Result<Option<Box<dyn Reci
             Err(e) => Err(eyre!("invalid SSH recipient: {e:?}")),
         }
     } else if let Ok(recipient) = trimmed.parse::<age::plugin::Recipient>() {
+        if !interactive {
+            return Err(eyre!(
+                "plugin-dependent age recipients require interactive synchronization; use a native age, SSH, or tagged public recipient for background encryption"
+            ));
+        }
         let plugin = age::plugin::RecipientPluginV1::new(
             recipient.plugin(),
             std::slice::from_ref(&recipient),
@@ -883,6 +895,12 @@ mod plugin_tests {
             .to_string();
         vars.set("MISE_AGE_KEY", &identity);
         let recipient = "age1se1qfn44rsw0xvmez3pky46nghmnd5up0jpj97nd39zptlh83a0nja6skde3ak";
+        let refused = parse_recipient_mode(recipient, false).err().unwrap();
+        assert!(
+            refused
+                .to_string()
+                .contains("require interactive synchronization")
+        );
         let software = age::x25519::Identity::generate();
         let recipients: Vec<Box<dyn Recipient + Send>> = vec![
             parse_recipient(recipient).unwrap().unwrap(),

--- a/src/agecrypt.rs
+++ b/src/agecrypt.rs
@@ -750,10 +750,11 @@ mod tests {
         let large_ciphertext = encrypt_bytes(&large, &recipients)?;
         assert!(large_ciphertext.len() < large.len());
 
-        env::set_var("MISE_AGE_KEY", key.to_string().expose_secret());
+        let mut vars = crate::test::EnvVarGuard::new();
+        vars.set("MISE_AGE_KEY", key.to_string().expose_secret());
         let decrypted = decrypt_bytes(&ciphertext).await;
         let decrypted_large = decrypt_bytes(&large_ciphertext).await;
-        env::remove_var("MISE_AGE_KEY");
+        vars.remove("MISE_AGE_KEY");
         assert_eq!(decrypted.unwrap(), small);
         assert_eq!(decrypted_large.unwrap(), large);
         Ok(())
@@ -767,10 +768,11 @@ mod tests {
         let recipients: Vec<Box<dyn Recipient + Send>> = vec![Box::new(key.to_public())];
         let ciphertext = encrypt_bytes(b"payload", &recipients)?;
 
-        env::set_var("MISE_AGE_KEY", other.to_string().expose_secret());
+        let mut vars = crate::test::EnvVarGuard::new();
+        vars.set("MISE_AGE_KEY", other.to_string().expose_secret());
         let result = decrypt_bytes(&ciphertext).await;
         let corrupt = decrypt_bytes(b"not an age file at all").await;
-        env::remove_var("MISE_AGE_KEY");
+        vars.remove("MISE_AGE_KEY");
         assert!(
             matches!(result, Err(DecryptError::Failed { .. })),
             "{result:?}"
@@ -872,12 +874,14 @@ mod plugin_tests {
         )
         .unwrap();
         std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let mut vars = crate::test::EnvVarGuard::new();
+        vars.remove("MISE_TEST_PLUGIN_MODE");
         let old_path = env::var("PATH").unwrap();
-        env::set_var("PATH", format!("{}:{old_path}", tmp.path().display()));
+        vars.set("PATH", format!("{}:{old_path}", tmp.path().display()));
         let identity = age::plugin::Identity::default_for_plugin("se")
             .unwrap()
             .to_string();
-        env::set_var("MISE_AGE_KEY", &identity);
+        vars.set("MISE_AGE_KEY", &identity);
         let recipient = "age1se1qfn44rsw0xvmez3pky46nghmnd5up0jpj97nd39zptlh83a0nja6skde3ak";
         let software = age::x25519::Identity::generate();
         let recipients: Vec<Box<dyn Recipient + Send>> = vec![
@@ -892,9 +896,9 @@ mod plugin_tests {
             decrypt_bytes_mode(&ciphertext, true).await.unwrap(),
             b"plugin protocol test"
         );
-        env::set_var("MISE_TEST_PLUGIN_MODE", "malformed");
+        vars.set("MISE_TEST_PLUGIN_MODE", "malformed");
         assert!(decrypt_bytes_mode(&ciphertext, true).await.is_err());
-        env::set_var("MISE_TEST_PLUGIN_MODE", "cancel");
+        vars.set("MISE_TEST_PLUGIN_MODE", "cancel");
         assert!(encrypt_bytes(b"cancelled request", &recipients).is_err());
         let plugin_identity = identity.parse::<age::plugin::Identity>().unwrap();
         let noninteractive =
@@ -905,11 +909,11 @@ mod plugin_tests {
                 .decrypt(std::iter::once(&noninteractive as &dyn Identity))
                 .is_err()
         );
-        env::remove_var("MISE_TEST_PLUGIN_MODE");
+        vars.remove("MISE_TEST_PLUGIN_MODE");
         std::fs::remove_file(&executable).unwrap();
         assert!(parse_recipient(recipient).is_err());
         assert!(decrypt_bytes_mode(&ciphertext, true).await.is_err());
-        env::set_var("MISE_AGE_KEY", software.to_string().expose_secret());
+        vars.set("MISE_AGE_KEY", software.to_string().expose_secret());
         assert_eq!(
             decrypt_bytes_mode(&ciphertext, false).await.unwrap(),
             b"plugin protocol test"
@@ -926,7 +930,5 @@ mod plugin_tests {
             .await,
             Some(false)
         );
-        env::remove_var("MISE_AGE_KEY");
-        env::set_var("PATH", old_path);
     }
 }

--- a/src/agecrypt.rs
+++ b/src/agecrypt.rs
@@ -106,13 +106,7 @@ pub(crate) struct LoadedIdentities {
     /// The public keys of the x25519 identities among them (`age1…`), so a
     /// caller can tell whether this machine is among a set of recipients.
     pub x25519_public: Vec<String>,
-}
-
-impl LoadedIdentities {
-    /// Identities that can take part in decryption.
-    pub(crate) fn usable(&self) -> usize {
-        self.identities.len().saturating_sub(self.unusable.len())
-    }
+    pub plugins: usize,
 }
 
 /// Why `decrypt_bytes` could not produce the plaintext.
@@ -138,6 +132,20 @@ impl std::fmt::Display for DecryptError {
 
 impl std::error::Error for DecryptError {}
 
+pub(crate) const MAX_ENCRYPTED_BYTES: u64 = 256 * 1024 * 1024;
+pub(crate) const MAX_PLAINTEXT_BYTES: u64 = 1024 * 1024 * 1024;
+
+pub(crate) fn read_bounded(reader: impl Read, limit: u64) -> std::io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    reader.take(limit + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > limit {
+        return Err(std::io::Error::other(
+            "encrypted content exceeds the size limit",
+        ));
+    }
+    Ok(bytes)
+}
+
 /// zstd-compressed, then age-encrypted for `recipients`.
 pub(crate) fn encrypt_bytes(
     plaintext: &[u8],
@@ -146,7 +154,13 @@ pub(crate) fn encrypt_bytes(
     if recipients.is_empty() {
         bail!("no age recipients to encrypt for");
     }
+    if plaintext.len() as u64 > MAX_PLAINTEXT_BYTES {
+        bail!("plaintext exceeds the size limit");
+    }
     let compressed = zstd::encode_all(plaintext, ZSTD_COMPRESSION_LEVEL)?;
+    if compressed.len() as u64 > MAX_ENCRYPTED_BYTES {
+        bail!("compressed payload exceeds the size limit");
+    }
     let encryptor =
         Encryptor::with_recipients(recipients.iter().map(|r| r.as_ref() as &dyn Recipient))
             .map_err(|e| eyre!("creating the age encryptor: {e}"))?;
@@ -154,13 +168,31 @@ pub(crate) fn encrypt_bytes(
     let mut writer = encryptor.wrap_output(&mut out)?;
     writer.write_all(&compressed)?;
     writer.finish()?;
+    if out.len() as u64 > MAX_ENCRYPTED_BYTES {
+        bail!("encrypted payload exceeds the size limit");
+    }
     Ok(out)
 }
 
 /// The inverse of `encrypt_bytes`, with every identity this machine has.
 pub(crate) async fn decrypt_bytes(ciphertext: &[u8]) -> Result<Vec<u8>, DecryptError> {
-    let loaded = load_all_identities().await;
+    decrypt_bytes_mode(ciphertext, console::user_attended_stderr()).await
+}
+
+pub(crate) async fn decrypt_bytes_mode(
+    ciphertext: &[u8],
+    interactive: bool,
+) -> Result<Vec<u8>, DecryptError> {
+    if ciphertext.len() as u64 > MAX_ENCRYPTED_BYTES {
+        return Err(DecryptError::Corrupt(
+            "encrypted payload exceeds the size limit".into(),
+        ));
+    }
+    let loaded = load_identities(interactive).await;
     if loaded.identities.is_empty() {
+        if loaded.plugins > 0 {
+            return Err(DecryptError::Failed { error: "hardware identity requires an interactive restore with its age plugin installed".into(), hint: String::new() });
+        }
         return Err(DecryptError::NoIdentities);
     }
     let decryptor = Decryptor::new(ciphertext)
@@ -176,11 +208,11 @@ pub(crate) async fn decrypt_bytes(ciphertext: &[u8]) -> Result<Vec<u8>, DecryptE
             error: e.to_string(),
             hint: unusable_identity_hint(&loaded.unusable),
         })?;
-    let mut compressed = Vec::new();
-    reader
-        .read_to_end(&mut compressed)
+    let compressed = read_bounded(&mut reader, MAX_ENCRYPTED_BYTES)
         .map_err(|e| DecryptError::Corrupt(format!("reading the age payload: {e}")))?;
-    zstd::decode_all(&compressed[..])
+    let decoder = zstd::stream::read::Decoder::new(&compressed[..])
+        .map_err(|e| DecryptError::Corrupt(format!("decompressing the payload: {e}")))?;
+    read_bounded(decoder, MAX_PLAINTEXT_BYTES)
         .map_err(|e| DecryptError::Corrupt(format!("decompressing the payload: {e}")))
 }
 
@@ -309,7 +341,13 @@ pub(crate) async fn resolve_recipient_arg(arg: &str) -> Result<Vec<String>> {
 /// `age1…` or `ssh-…`; `None` for anything else.
 pub(crate) fn parse_recipient(recipient_str: &str) -> Result<Option<Box<dyn Recipient + Send>>> {
     let trimmed = recipient_str.trim();
-    if trimmed.starts_with("age1") {
+    if trimmed.starts_with("age1tag1") {
+        return trimmed
+            .parse::<age::tag::Recipient>()
+            .map(|r| Some(Box::new(r) as Box<dyn Recipient + Send>))
+            .map_err(|e| eyre!("invalid tagged age recipient: {e}"));
+    }
+    if trimmed.starts_with("age1") && trimmed.parse::<age::plugin::Recipient>().is_err() {
         match trimmed.parse::<age::x25519::Recipient>() {
             Ok(r) => Ok(Some(Box::new(r))),
             Err(e) => Err(eyre!("invalid age recipient {trimmed:?}: {e}")),
@@ -320,6 +358,15 @@ pub(crate) fn parse_recipient(recipient_str: &str) -> Result<Option<Box<dyn Reci
             Ok(r) => Ok(Some(Box::new(r))),
             Err(e) => Err(eyre!("invalid SSH recipient: {e:?}")),
         }
+    } else if let Ok(recipient) = trimmed.parse::<age::plugin::Recipient>() {
+        let plugin = age::plugin::RecipientPluginV1::new(
+            recipient.plugin(),
+            std::slice::from_ref(&recipient),
+            &[],
+            age::NoCallbacks,
+        )
+        .map_err(|e| eyre!("age recipient plugin is unavailable: {e}"))?;
+        Ok(Some(Box::new(plugin)))
     } else {
         Ok(None)
     }
@@ -347,13 +394,20 @@ pub(crate) async fn ssh_public_key_for_private(path: &Path) -> Result<String> {
 /// named by the settings and the default `age.txt`, and the SSH keys named
 /// by the settings and the default `~/.ssh/id_ed25519` / `id_rsa`.
 pub(crate) async fn load_all_identities() -> LoadedIdentities {
+    load_identities(false).await
+}
+
+async fn load_identities(interactive: bool) -> LoadedIdentities {
     let identity_files = get_all_identity_files().await;
     let ssh_identity_files = get_all_ssh_identity_files();
     let mut loaded = LoadedIdentities::default();
+    let mut plugin_sources = Vec::new();
 
     if let Ok(age_key) = env::var("MISE_AGE_KEY")
         && !age_key.is_empty()
     {
+        plugin_sources.push(age_key.clone());
+        let age_key = software_identity_text(&age_key);
         // raw secret keys first
         for line in age_key.lines() {
             let line = line.trim();
@@ -379,6 +433,8 @@ pub(crate) async fn load_all_identities() -> LoadedIdentities {
         }
         match file::read_to_string(&path) {
             Ok(content) => {
+                plugin_sources.push(content.clone());
+                let content = software_identity_text(&content);
                 if let Ok(identity_file) = IdentityFile::from_buffer(content.as_bytes())
                     && let Ok(mut file_identities) = identity_file.into_identities()
                 {
@@ -427,7 +483,115 @@ pub(crate) async fn load_all_identities() -> LoadedIdentities {
         }
     }
 
+    // Try software recovery identities before touching hardware.
+    for text in plugin_sources {
+        add_plugin_identities(&text, interactive, &mut loaded);
+    }
     loaded
+}
+
+fn software_identity_text(text: &str) -> String {
+    text.lines()
+        .filter(|line| !line.trim().starts_with("AGE-PLUGIN-"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn add_plugin_identities(text: &str, interactive: bool, loaded: &mut LoadedIdentities) {
+    for line in text
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("AGE-PLUGIN-"))
+    {
+        loaded.plugins += 1;
+        // Hardware plugins can display native dialogs without asking callbacks.
+        // Never start them during background work or routine diagnostics.
+        if !interactive {
+            continue;
+        }
+        match line.parse::<age::plugin::Identity>() {
+            Ok(identity) => match age::plugin::IdentityPluginV1::new(
+                identity.plugin(),
+                std::slice::from_ref(&identity),
+                HardwareCallbacks,
+            ) {
+                Ok(plugin) => loaded.identities.push(Box::new(plugin)),
+                Err(err) => warn!("age identity plugin unavailable: {err}"),
+            },
+            Err(_) => warn!("invalid age plugin identity"),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct HardwareCallbacks;
+impl age::Callbacks for HardwareCallbacks {
+    fn display_message(&self, message: &str) {
+        eprintln!("{message}");
+    }
+    fn confirm(&self, message: &str, yes: &str, _no: Option<&str>) -> Option<bool> {
+        let answer = demand::Input::new(format!("{message} ({yes}? y/N)"))
+            .run()
+            .ok()?;
+        Some(answer.eq_ignore_ascii_case("y"))
+    }
+    fn request_public_string(&self, description: &str) -> Option<String> {
+        demand::Input::new(description).run().ok()
+    }
+    fn request_passphrase(&self, description: &str) -> Option<age::secrecy::SecretString> {
+        demand::Input::new(description)
+            .password(true)
+            .run()
+            .ok()
+            .map(Into::into)
+    }
+}
+
+/// A software-only probe; never invokes hardware plugins or their dialogs.
+/// None means hardware is configured but cannot be verified noninteractively.
+pub(crate) async fn restorability(recipients: &[String]) -> Option<bool> {
+    let loaded = load_all_identities().await;
+    let software: Vec<_> = recipients
+        .iter()
+        .filter(|r| r.parse::<age::plugin::Recipient>().is_err())
+        .filter_map(|r| parse_recipient(r).ok().flatten())
+        .collect();
+    if !software.is_empty()
+        && let Ok(ciphertext) = encrypt_bytes(b"mise backup identity check", &software)
+        && let Ok(decryptor) = Decryptor::new(&ciphertext[..])
+        && decryptor
+            .decrypt(
+                loaded
+                    .identities
+                    .iter()
+                    .map(|i| i.as_ref() as &dyn Identity),
+            )
+            .is_ok()
+    {
+        return Some(true);
+    }
+    if loaded.plugins > 0 {
+        None
+    } else {
+        Some(false)
+    }
+}
+
+/// Sync's Git reconciliation is synchronous; isolate the identity loader's
+/// runtime rather than nesting a runtime on a Tokio worker.
+pub(crate) fn decrypt_sync(ciphertext: &[u8], interactive: bool) -> Result<Vec<u8>> {
+    std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()?
+                    .block_on(decrypt_bytes_mode(ciphertext, interactive))
+                    .map_err(Into::into)
+            })
+            .join()
+            .map_err(|_| eyre!("age decryption worker failed"))?
+    })
 }
 
 async fn get_default_key_file() -> Option<PathBuf> {
@@ -447,6 +611,16 @@ async fn get_default_key_file() -> Option<PathBuf> {
 }
 
 async fn get_all_identity_files() -> Vec<PathBuf> {
+    identity_paths_age()
+}
+
+pub(crate) fn identity_paths() -> Vec<PathBuf> {
+    let mut paths = identity_paths_age();
+    paths.extend(get_all_ssh_identity_files());
+    paths
+}
+
+fn identity_paths_age() -> Vec<PathBuf> {
     let mut files = Vec::new();
 
     if let Some(ref identity_files) = Settings::get().age.identity_files {
@@ -544,6 +718,11 @@ mod tests {
     fn test_parse_recipient() -> Result<()> {
         let age_recipient = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p";
         assert!(parse_recipient(age_recipient)?.is_some());
+        // Current age-plugin-tpm exports native tagged recipients. Encryption
+        // must not look for an age-plugin-tag executable or access the TPM.
+        let tpm_recipient = "age1tag1q096edfp3ty6n36fj5kyq0yuesp7rdcmm7sjswzdcrekh6ash8n3uys987t";
+        let tagged = parse_recipient(tpm_recipient)?.unwrap();
+        assert!(encrypt_bytes(b"TPM public recipient", &[tagged]).is_ok());
         let ssh_recipient =
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJmkfJ8VZq4m5k7tJVts7+nR01fbRvLHLgeQCF6FWYr5";
         assert!(parse_recipient(ssh_recipient)?.is_some());
@@ -660,5 +839,94 @@ mod tests {
             .to_string();
         assert!(err.contains("not an age recipient"), "{err}");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod limits_tests {
+    use super::*;
+
+    #[test]
+    fn bounded_reader_accepts_limit_and_refuses_next_byte() {
+        assert_eq!(read_bounded(&b"1234"[..], 4).unwrap(), b"1234");
+        assert!(read_bounded(&b"12345"[..], 4).is_err());
+        let compressed = zstd::encode_all(&vec![0u8; 10000][..], 1).unwrap();
+        let decoder = zstd::stream::read::Decoder::new(&compressed[..]).unwrap();
+        assert!(read_bounded(decoder, 100).is_err());
+    }
+}
+
+#[cfg(all(test, unix))]
+mod plugin_tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[tokio::test]
+    async fn plugin_protocol_roundtrip_and_software_recovery() {
+        use age::secrecy::ExposeSecret;
+        let tmp = tempfile::tempdir().unwrap();
+        let executable = tmp.path().join("age-plugin-se");
+        std::fs::write(
+            &executable,
+            include_str!("agecrypt/fixtures/age-plugin-se.py"),
+        )
+        .unwrap();
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let old_path = env::var("PATH").unwrap();
+        env::set_var("PATH", format!("{}:{old_path}", tmp.path().display()));
+        let identity = age::plugin::Identity::default_for_plugin("se")
+            .unwrap()
+            .to_string();
+        env::set_var("MISE_AGE_KEY", &identity);
+        let recipient = "age1se1qfn44rsw0xvmez3pky46nghmnd5up0jpj97nd39zptlh83a0nja6skde3ak";
+        let software = age::x25519::Identity::generate();
+        let recipients: Vec<Box<dyn Recipient + Send>> = vec![
+            parse_recipient(recipient).unwrap().unwrap(),
+            Box::new(software.to_public()),
+        ];
+        let ciphertext = encrypt_bytes(b"plugin protocol test", &recipients).unwrap();
+        assert_eq!(restorability(&[recipient.into()]).await, None);
+        let locked = decrypt_bytes_mode(&ciphertext, false).await;
+        assert!(locked.is_err());
+        assert_eq!(
+            decrypt_bytes_mode(&ciphertext, true).await.unwrap(),
+            b"plugin protocol test"
+        );
+        env::set_var("MISE_TEST_PLUGIN_MODE", "malformed");
+        assert!(decrypt_bytes_mode(&ciphertext, true).await.is_err());
+        env::set_var("MISE_TEST_PLUGIN_MODE", "cancel");
+        assert!(encrypt_bytes(b"cancelled request", &recipients).is_err());
+        let plugin_identity = identity.parse::<age::plugin::Identity>().unwrap();
+        let noninteractive =
+            age::plugin::IdentityPluginV1::new("se", &[plugin_identity], age::NoCallbacks).unwrap();
+        assert!(
+            Decryptor::new(&ciphertext[..])
+                .unwrap()
+                .decrypt(std::iter::once(&noninteractive as &dyn Identity))
+                .is_err()
+        );
+        env::remove_var("MISE_TEST_PLUGIN_MODE");
+        std::fs::remove_file(&executable).unwrap();
+        assert!(parse_recipient(recipient).is_err());
+        assert!(decrypt_bytes_mode(&ciphertext, true).await.is_err());
+        env::set_var("MISE_AGE_KEY", software.to_string().expose_secret());
+        assert_eq!(
+            decrypt_bytes_mode(&ciphertext, false).await.unwrap(),
+            b"plugin protocol test"
+        );
+        assert_eq!(
+            restorability(&[software.to_public().to_string()]).await,
+            Some(true)
+        );
+        assert_eq!(
+            restorability(&[
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJmkfJ8VZq4m5k7tJVts7+nR01fbRvLHLgeQCF6FWYr5"
+                    .into()
+            ])
+            .await,
+            Some(false)
+        );
+        env::remove_var("MISE_AGE_KEY");
+        env::set_var("PATH", old_path);
     }
 }

--- a/src/agecrypt/directive.rs
+++ b/src/agecrypt/directive.rs
@@ -1,0 +1,271 @@
+//! The experimental `[env]` age directives: `mise set --age-encrypt` writes
+//! them and environment resolution decrypts them. Everything here stays
+//! behind `settings.experimental` (the gate is in `decrypt_age_directive`
+//! and in `mise set`); the encryption of machine backups in the parent
+//! module does not go through this layer.
+//!
+//! The envelope is age, then zstd above a size threshold, then unpadded
+//! base64, and must stay that way: values already written to mise.toml
+//! files are read back with it.
+
+use std::io::{Read, Write};
+use std::path::Path;
+
+use age::{Decryptor, Encryptor, Identity, Recipient};
+use base64::Engine;
+use eyre::{Result, WrapErr, eyre};
+
+use super::{
+    ZSTD_COMPRESSION_LEVEL, default_recipient_strings, load_all_identities, parse_recipient,
+    ssh_public_key_for_private, unusable_identity_hint,
+};
+use crate::config::Settings;
+use crate::config::env_directive::{AgeFormat, EnvDirective, EnvDirectiveOptions};
+use crate::file;
+
+const COMPRESSION_THRESHOLD: usize = 1024; // 1KB
+
+pub(crate) async fn create_age_directive(
+    key: String,
+    value: &str,
+    recipients: &[Box<dyn Recipient + Send>],
+) -> Result<EnvDirective> {
+    if recipients.is_empty() {
+        return Err(eyre!(
+            "[experimental] No age recipients provided for encryption"
+        ));
+    }
+
+    let encryptor =
+        match Encryptor::with_recipients(recipients.iter().map(|r| r.as_ref() as &dyn Recipient)) {
+            Ok(encryptor) => encryptor,
+            Err(e) => return Err(eyre!("[experimental] Failed to create encryptor: {}", e)),
+        };
+
+    let mut encrypted = Vec::new();
+    let mut writer = encryptor.wrap_output(&mut encrypted)?;
+    writer.write_all(value.as_bytes())?;
+    writer.finish()?;
+
+    // Determine format based on size and compression
+    let (encoded, format) = if encrypted.len() > COMPRESSION_THRESHOLD {
+        let compressed = zstd::encode_all(&encrypted[..], ZSTD_COMPRESSION_LEVEL)?;
+        let encoded = base64::engine::general_purpose::STANDARD_NO_PAD.encode(&compressed);
+        (encoded, Some(AgeFormat::Zstd))
+    } else {
+        let encoded = base64::engine::general_purpose::STANDARD_NO_PAD.encode(&encrypted);
+        (encoded, None) // Use None for raw format (default)
+    };
+
+    Ok(EnvDirective::Age {
+        key,
+        value: encoded,
+        format,
+        options: EnvDirectiveOptions::default(),
+    })
+}
+
+pub(crate) async fn decrypt_age_directive(directive: &EnvDirective) -> Result<String> {
+    Settings::get().ensure_experimental("age encryption")?;
+    match directive {
+        EnvDirective::Age { value, format, .. } => {
+            let decoded = base64::engine::general_purpose::STANDARD_NO_PAD
+                .decode(value)
+                .wrap_err("[experimental] Failed to decode base64")?;
+
+            let ciphertext = match format {
+                Some(AgeFormat::Zstd) => zstd::decode_all(&decoded[..])
+                    .wrap_err("[experimental] Failed to decompress zstd")?,
+                Some(AgeFormat::Raw) | None => decoded,
+            };
+
+            let loaded = load_all_identities().await;
+            if loaded.identities.is_empty() {
+                return Err(eyre!(
+                    "[experimental] No age identities found for decryption"
+                ));
+            }
+
+            let decryptor = Decryptor::new(&ciphertext[..])?;
+            let mut decrypted = Vec::new();
+
+            let identity_refs: Vec<&dyn Identity> = loaded
+                .identities
+                .iter()
+                .map(|i| i.as_ref() as &dyn Identity)
+                .collect();
+
+            match decryptor.decrypt(identity_refs.into_iter()) {
+                Ok(mut reader) => {
+                    reader.read_to_end(&mut decrypted)?;
+                }
+                Err(e) => {
+                    return Err(eyre!(
+                        "[experimental] Failed to decrypt: {e}{}",
+                        unusable_identity_hint(&loaded.unusable)
+                    ));
+                }
+            }
+
+            String::from_utf8(decrypted)
+                .wrap_err("[experimental] Decrypted value is not valid UTF-8")
+        }
+        _ => Err(eyre!("[experimental] Not an Age directive")),
+    }
+}
+
+pub(crate) async fn load_recipients_from_defaults() -> Result<Vec<Box<dyn Recipient + Send>>> {
+    let mut parsed_recipients: Vec<Box<dyn Recipient + Send>> = Vec::new();
+    for recipient_str in default_recipient_strings().await? {
+        if let Some(recipient) = parse_recipient(&recipient_str)? {
+            parsed_recipients.push(recipient);
+        }
+    }
+
+    if parsed_recipients.is_empty() {
+        return Err(eyre!(
+            "[experimental] No age recipients found. Provide --age-recipient, --age-ssh-recipient, or configure settings.age.key_file"
+        ));
+    }
+
+    Ok(parsed_recipients)
+}
+
+pub(crate) async fn load_recipients_from_key_file(
+    path: &Path,
+) -> Result<Vec<Box<dyn Recipient + Send>>> {
+    let mut recipients: Vec<Box<dyn Recipient + Send>> = Vec::new();
+
+    if !path.exists() {
+        return Err(eyre!(
+            "[experimental] Age key file not found: {}",
+            path.display()
+        ));
+    }
+
+    let content = file::read_to_string(path)?;
+
+    // Parse age x25519 identities and convert to recipients
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with("AGE-SECRET-KEY-")
+            && let Ok(identity) = line.parse::<age::x25519::Identity>()
+        {
+            let public_key = identity.to_public();
+            recipients.push(Box::new(public_key));
+        }
+    }
+
+    if recipients.is_empty() {
+        return Err(eyre!(
+            "[experimental] No valid age identities found in {}",
+            path.display()
+        ));
+    }
+
+    Ok(recipients)
+}
+
+pub(crate) async fn load_ssh_recipient_from_path(path: &Path) -> Result<Box<dyn Recipient + Send>> {
+    let content = file::read_to_string(path)?;
+    let trimmed = content.trim();
+
+    // Check if it's a public key
+    if trimmed.starts_with("ssh-") {
+        match trimmed.parse::<age::ssh::Recipient>() {
+            Ok(r) => return Ok(Box::new(r)),
+            Err(e) => {
+                return Err(eyre!(
+                    "[experimental] Invalid SSH public key at {}: {:?}",
+                    path.display(),
+                    e
+                ));
+            }
+        }
+    }
+
+    // Try to load as private key and derive public
+    if path.extension().and_then(|s| s.to_str()) == Some("pub") {
+        Err(eyre!(
+            "[experimental] Invalid SSH public key at {}",
+            path.display()
+        ))
+    } else {
+        ssh_public_key_for_private(path).await.and_then(|s| {
+            parse_recipient(&s)?
+                .ok_or_else(|| eyre!("[experimental] Failed to parse SSH recipient"))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env;
+
+    #[tokio::test]
+    async fn test_age_x25519_round_trip_small() -> Result<()> {
+        let key = age::x25519::Identity::generate();
+        let recipient = key.to_public();
+
+        // Small value should not be compressed
+        let plaintext = "secret value";
+        let recipients: Vec<Box<dyn Recipient + Send>> = vec![Box::new(recipient)];
+        let directive =
+            create_age_directive("TEST_VAR".to_string(), plaintext, &recipients).await?;
+
+        if let EnvDirective::Age { value, format, .. } = directive {
+            // Small value should not be compressed (format should be None/Raw)
+            assert!(format.is_none() || matches!(format, Some(AgeFormat::Raw)));
+
+            use age::secrecy::ExposeSecret;
+            env::set_var("MISE_AGE_KEY", key.to_string().expose_secret());
+            let decrypted = decrypt_age_directive(&EnvDirective::Age {
+                key: "TEST_VAR".to_string(),
+                value,
+                format,
+                options: Default::default(),
+            })
+            .await?;
+            env::remove_var("MISE_AGE_KEY");
+
+            assert_eq!(decrypted, plaintext);
+        } else {
+            panic!("Expected Age directive");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_age_x25519_round_trip_large() -> Result<()> {
+        let key = age::x25519::Identity::generate();
+        let recipient = key.to_public();
+
+        // Large value should be compressed (>1KB)
+        let plaintext = "x".repeat(2000);
+        let recipients: Vec<Box<dyn Recipient + Send>> = vec![Box::new(recipient)];
+        let directive =
+            create_age_directive("TEST_VAR".to_string(), &plaintext, &recipients).await?;
+
+        if let EnvDirective::Age { value, format, .. } = directive {
+            // Large value should be compressed
+            assert_eq!(format, Some(AgeFormat::Zstd));
+
+            use age::secrecy::ExposeSecret;
+            env::set_var("MISE_AGE_KEY", key.to_string().expose_secret());
+            let decrypted = decrypt_age_directive(&EnvDirective::Age {
+                key: "TEST_VAR".to_string(),
+                value,
+                format,
+                options: Default::default(),
+            })
+            .await?;
+            env::remove_var("MISE_AGE_KEY");
+
+            assert_eq!(decrypted, plaintext);
+        } else {
+            panic!("Expected Age directive");
+        }
+        Ok(())
+    }
+}

--- a/src/agecrypt/directive.rs
+++ b/src/agecrypt/directive.rs
@@ -201,7 +201,6 @@ pub(crate) async fn load_ssh_recipient_from_path(path: &Path) -> Result<Box<dyn 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::env;
 
     #[tokio::test]
     async fn test_age_x25519_round_trip_small() -> Result<()> {
@@ -219,7 +218,8 @@ mod tests {
             assert!(format.is_none() || matches!(format, Some(AgeFormat::Raw)));
 
             use age::secrecy::ExposeSecret;
-            env::set_var("MISE_AGE_KEY", key.to_string().expose_secret());
+            let mut environment = crate::test::EnvVarGuard::new();
+            environment.set("MISE_AGE_KEY", key.to_string().expose_secret());
             let decrypted = decrypt_age_directive(&EnvDirective::Age {
                 key: "TEST_VAR".to_string(),
                 value,
@@ -227,7 +227,6 @@ mod tests {
                 options: Default::default(),
             })
             .await?;
-            env::remove_var("MISE_AGE_KEY");
 
             assert_eq!(decrypted, plaintext);
         } else {
@@ -252,7 +251,8 @@ mod tests {
             assert_eq!(format, Some(AgeFormat::Zstd));
 
             use age::secrecy::ExposeSecret;
-            env::set_var("MISE_AGE_KEY", key.to_string().expose_secret());
+            let mut environment = crate::test::EnvVarGuard::new();
+            environment.set("MISE_AGE_KEY", key.to_string().expose_secret());
             let decrypted = decrypt_age_directive(&EnvDirective::Age {
                 key: "TEST_VAR".to_string(),
                 value,
@@ -260,7 +260,6 @@ mod tests {
                 options: Default::default(),
             })
             .await?;
-            env::remove_var("MISE_AGE_KEY");
 
             assert_eq!(decrypted, plaintext);
         } else {

--- a/src/agecrypt/fixtures/age-plugin-se.py
+++ b/src/agecrypt/fixtures/age-plugin-se.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Protocol-only test double. Exposes the file key; NEVER use for real data."""
+import base64
+import os
+import sys
+
+
+def receive():
+    header = sys.stdin.readline().strip().split()
+    if not header:
+        raise EOFError("missing command")
+    body = ""
+    while True:
+        line = sys.stdin.readline().strip()
+        body += line
+        if len(line) < 64:
+            break
+    return header[1:], base64.b64decode(body + "=" * (-len(body) % 4))
+
+
+def send(command, body=b"", reply=True):
+    encoded = base64.b64encode(body).decode().rstrip("=")
+    sys.stdout.write("-> " + command + "\n")
+    for start in range(0, len(encoded), 64):
+        sys.stdout.write(encoded[start : start + 64] + "\n")
+    if len(encoded) % 64 == 0:
+        sys.stdout.write("\n")
+    sys.stdout.flush()
+    if reply:
+        return receive()
+    return None
+
+
+key = None
+while True:
+    command, body = receive()
+    if command[0] == "done":
+        break
+    if command[0] == "wrap-file-key":
+        key = body
+    if command[:3] == ["recipient-stanza", "0", "mise-test"]:
+        key = body
+
+mode = os.environ.get("MISE_TEST_PLUGIN_MODE", "ok")
+if mode == "malformed":
+    print("invalid protocol", flush=True)
+elif mode == "cancel":
+    send("request-secret", b"Test PIN")
+    send("error identity 0", b"authorization cancelled")
+    send("done", reply=False)
+elif key is not None:
+    if "recipient-v1" in sys.argv[1]:
+        send("recipient-stanza 0 mise-test", key)
+    else:
+        send("file-key 0", key)
+    send("done", reply=False)
+else:
+    send("done", reply=False)

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -92,6 +92,13 @@ struct DotfilesDiagnosis {
     sync_failing_for_secs: Option<u64>,
     /// Failed syncs in a row, since the last success.
     sync_failures: u32,
+    /// This machine's recovery refs are encrypted.
+    backups_encrypted: bool,
+    /// Uploads are being skipped (encryption on without usable recipients).
+    backups_error: Option<String>,
+    /// Whether an identity here could restore this machine's own encrypted
+    /// backups (`None` when they are not encrypted).
+    backups_restorable: Option<bool>,
 }
 
 /// How long syncs have been failing: since the current run of failures
@@ -758,6 +765,9 @@ impl Doctor {
             sync_error: None,
             sync_failing_for_secs: None,
             sync_failures: 0,
+            backups_encrypted: false,
+            backups_error: None,
+            backups_restorable: None,
         };
         if let Some(reason) = unavailable {
             self.errors.push(format!(
@@ -798,7 +808,7 @@ impl Doctor {
         }
         // the setup repository, read from what the last sync persisted:
         // nothing is fetched, applied, or asked here
-        if let Ok(Some(_)) = crate::system::history::config::origin() {
+        if let Ok(Some((_, origin))) = crate::system::history::config::origin() {
             use crate::system::history::sync::{apply, run};
             let status = match run::read_status(&state_dir) {
                 Ok(status) => status,
@@ -809,6 +819,31 @@ impl Doctor {
                     run::SyncStatus::default()
                 }
             };
+            if origin.encrypt_backups {
+                diagnosis.backups_encrypted = true;
+                if let Some(error) = &status.backup_error {
+                    diagnosis.backups_error = Some(error.clone());
+                    self.warnings.push(format!(
+                        "dotfiles: machine backups are not being uploaded ({error}).\n     Local checkpoints continue; nothing from this machine is recoverable from the repository until recipients are configured.\n     Inspect with: mise bootstrap dotfiles status"
+                    ));
+                }
+                // can this machine read what it uploads? decided from the
+                // identities here, without touching the network
+                let loaded = crate::agecrypt::load_all_identities().await;
+                let only_age = origin.recipients.iter().all(|r| r.starts_with("age1"));
+                let among = origin
+                    .recipients
+                    .iter()
+                    .any(|r| loaded.x25519_public.iter().any(|mine| mine == r));
+                let restorable = loaded.usable() > 0 && (!only_age || among);
+                diagnosis.backups_restorable = Some(restorable);
+                if !restorable && !origin.recipients.is_empty() {
+                    self.warnings.push(
+                        "dotfiles: machine backups are encrypted, but no age identity on this machine can decrypt them: this machine could not restore its own backups.\n     Put an identity among the recipients in ~/.config/mise/age.txt, settings.age.key_file, or MISE_AGE_KEY, or add this machine's key with: mise bootstrap dotfiles origin set <url> --encrypt-backups --recipient <key>"
+                            .to_string(),
+                    );
+                }
+            }
             if let Some(error) = &status.validation_error {
                 diagnosis.sync_error = Some(error.clone());
                 self.errors.push(format!("dotfiles: incoming setup is invalid: {error}. Correct the setup repository and sync again."));
@@ -909,6 +944,19 @@ impl Doctor {
                 }
                 None => {}
             }
+        }
+        if diagnosis.backups_encrypted {
+            lines.push(format!(
+                "machine backups encrypted (age){}",
+                match diagnosis.backups_restorable {
+                    Some(true) => "; an identity here can restore them",
+                    Some(false) => "; NO identity here can restore them",
+                    None => "",
+                }
+            ));
+        }
+        if let Some(error) = &diagnosis.backups_error {
+            lines.push(format!("machine backups skipped: {error}"));
         }
         info::section("dotfiles", lines.join("\n"))?;
         Ok(())

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -808,7 +808,7 @@ impl Doctor {
         }
         // the setup repository, read from what the last sync persisted:
         // nothing is fetched, applied, or asked here
-        if let Ok(Some((_, origin))) = crate::system::history::config::origin() {
+        if let Ok(origin) = crate::system::history::sync::run::origin() {
             use crate::system::history::sync::{apply, run};
             let status = match run::read_status(&state_dir) {
                 Ok(status) => status,
@@ -829,15 +829,12 @@ impl Doctor {
                 }
                 // can this machine read what it uploads? decided from the
                 // identities here, without touching the network
-                let loaded = crate::agecrypt::load_all_identities().await;
-                let only_age = origin.recipients.iter().all(|r| r.starts_with("age1"));
-                let among = origin
-                    .recipients
-                    .iter()
-                    .any(|r| loaded.x25519_public.iter().any(|mine| mine == r));
-                let restorable = loaded.usable() > 0 && (!only_age || among);
-                diagnosis.backups_restorable = Some(restorable);
-                if !restorable && !origin.recipients.is_empty() {
+                let restorable = crate::agecrypt::restorability(&origin.recipients).await;
+                diagnosis.backups_restorable = restorable;
+                if restorable.is_none() {
+                    self.warnings.push("dotfiles: hardware backup identity configured but unverified; restore interactively to unlock it".into());
+                }
+                if restorable == Some(false) && !origin.recipients.is_empty() {
                     self.warnings.push(
                         "dotfiles: machine backups are encrypted, but no age identity on this machine can decrypt them: this machine could not restore its own backups.\n     Put an identity among the recipients in ~/.config/mise/age.txt, settings.age.key_file, or MISE_AGE_KEY, or add this machine's key with: mise bootstrap dotfiles origin set <url> --encrypt-backups --recipient <key>"
                             .to_string(),

--- a/src/cli/dotfiles/history/mod.rs
+++ b/src/cli/dotfiles/history/mod.rs
@@ -84,8 +84,9 @@ pub(crate) fn resolve(spec: &str, entries: &[Entry], path: Option<&str>) -> Resu
 }
 
 /// Resolves a reference that may name another machine's checkpoint
-/// (`<machine>/<ref>`, from the recovery refs the last sync fetched).
-pub(crate) fn resolve_with_store(
+/// (`<machine>/<ref>`, from the recovery refs the last sync fetched; an
+/// encrypted one is decrypted with this machine's identities).
+pub(crate) async fn resolve_with_store(
     store: &Store,
     spec: &str,
     entries: &[Entry],
@@ -98,7 +99,8 @@ pub(crate) fn resolve_with_store(
         let repo = store
             .repo()
             .ok_or_else(|| eyre::eyre!("other machines' checkpoints require git"))?;
-        let (_, machine_entries) = crate::system::history::sync::machines::entries(repo, machine)?;
+        let (_, machine_entries) =
+            crate::system::history::sync::machines::entries(repo, machine).await?;
         return resolve(reference, &machine_entries, path);
     }
     resolve(spec, entries, path)

--- a/src/cli/dotfiles/history/mod.rs
+++ b/src/cli/dotfiles/history/mod.rs
@@ -99,9 +99,8 @@ pub(crate) async fn resolve_with_store(
         let repo = store
             .repo()
             .ok_or_else(|| eyre::eyre!("other machines' checkpoints require git"))?;
-        let (_, machine_entries) =
-            crate::system::history::sync::machines::entries(repo, machine).await?;
-        return resolve(reference, &machine_entries, path);
+        return crate::system::history::sync::machines::resolve(repo, machine, reference, path)
+            .await;
     }
     resolve(spec, entries, path)
 }

--- a/src/cli/dotfiles/history_status.rs
+++ b/src/cli/dotfiles/history_status.rs
@@ -61,7 +61,10 @@ pub(crate) fn sync_report(
     entries: &[crate::system::history::store::Entry],
 ) -> Result<Option<SyncReport>> {
     use crate::system::history::sync::{SyncMode, apply, backup, run};
-    let Some((_, origin)) = crate::system::history::config::origin()? else {
+    let Some(origin) = crate::system::history::config::origin()?
+        .map(|(_, origin)| origin)
+        .or_else(|| run::origin().ok())
+    else {
         return Ok(None);
     };
     let status = run::read_status(store.state_dir())?;

--- a/src/cli/dotfiles/history_status.rs
+++ b/src/cli/dotfiles/history_status.rs
@@ -43,6 +43,17 @@ pub(crate) struct SyncReport {
     pub consecutive_failures: u32,
     pub application_failure: Option<String>,
     pub validation_error: Option<String>,
+    pub backups: BackupsReport,
+}
+
+/// How this machine's recovery refs are written.
+#[derive(Serialize)]
+pub(crate) struct BackupsReport {
+    pub encrypted: bool,
+    pub recipients: usize,
+    /// Why uploads are skipped, when they are.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 pub(crate) fn sync_report(
@@ -71,6 +82,11 @@ pub(crate) fn sync_report(
         0
     };
     Ok(Some(SyncReport {
+        backups: BackupsReport {
+            encrypted: origin.encrypt_backups,
+            recipients: origin.recipients.len(),
+            error: status.backup_error.clone(),
+        },
         origin: origin.url,
         branch: origin.branch,
         mode: SyncMode::current()?.as_str().to_string(),
@@ -216,6 +232,17 @@ pub(crate) fn print(report: &HistoryReport) -> Result<()> {
                 when(&sync.last_apply),
                 sync.pending_upload
             );
+            if sync.backups.encrypted {
+                miseprintln!(
+                    "  machine backups: encrypted (age) for {} recipient(s).",
+                    sync.backups.recipients
+                );
+            } else {
+                miseprintln!("  machine backups: plaintext.");
+            }
+            if let Some(error) = &sync.backups.error {
+                miseprintln!("  backups skipped: {error}");
+            }
             if !sync.pending_applications.is_empty() {
                 miseprintln!(
                     "  {} incoming change(s) pending: `mise bootstrap dotfiles pull` ({})",

--- a/src/cli/dotfiles/machines.rs
+++ b/src/cli/dotfiles/machines.rs
@@ -11,6 +11,8 @@ use crate::ui::table::MiseTable;
 /// `mise bootstrap dotfiles sync` fetched. Their checkpoints are addressed as
 /// `<machine>/<ref>`: `mise bootstrap dotfiles rollback --to laptop/latest --all`
 /// recovers a machine's backed-up files; their journals are data only.
+/// Encrypted backups are listed without a key; restoring one needs an
+/// identity among its recipients.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 pub(crate) struct DotfilesMachines {
@@ -26,12 +28,18 @@ impl DotfilesMachines {
         let Some(repo) = store.repo() else {
             eyre::bail!("listing machines requires git");
         };
-        let machines = machines::list(repo, store.machine(), &entries)?;
+        let this_encrypts = crate::system::history::sync::run::origin()
+            .map(|origin| origin.encrypt_backups)
+            .unwrap_or(false);
+        let machines = machines::list(repo, store.machine(), &entries, this_encrypts)?;
         if self.json {
             miseprintln!("{}", serde_json::to_string_pretty(&machines)?);
             return Ok(());
         }
-        let mut table = MiseTable::new(false, &["Machine", "Id", "Checkpoints", "Latest"]);
+        let mut table = MiseTable::new(
+            false,
+            &["Machine", "Id", "Checkpoints", "Encrypted", "Latest"],
+        );
         for machine in machines {
             table.add_row(vec![
                 if machine.this {
@@ -41,6 +49,11 @@ impl DotfilesMachines {
                 },
                 machine.id,
                 machine.checkpoints.to_string(),
+                match machine.encrypted {
+                    0 => "no".to_string(),
+                    n if n == machine.checkpoints => "yes".to_string(),
+                    n => format!("{n} of {}", machine.checkpoints),
+                },
                 machine
                     .latest
                     .as_deref()

--- a/src/cli/dotfiles/origin.rs
+++ b/src/cli/dotfiles/origin.rs
@@ -69,7 +69,7 @@ pub(crate) struct DotfilesOriginSet {
     ///
     /// Every backed-up checkpoint becomes one age payload: file names,
     /// descriptions, and content are readable only with a recipient's
-    /// identity. The setup branch itself is always plaintext.
+    /// identity. Setup configuration stays plaintext; dotfiles can use `encrypt = true`.
     #[usage(long)]
     encrypt_backups: bool,
 

--- a/src/cli/dotfiles/origin.rs
+++ b/src/cli/dotfiles/origin.rs
@@ -10,11 +10,11 @@ use crate::system::history::sync::origin;
 /// `set <url>` connects one repository that holds the shared setup branch
 /// and this machine's recovery refs. Before anything leaves the machine it
 /// prints exactly what will happen: the sync mode, what is shared per
-/// stream, what is not and why, what is backed up (in plain form), names
-/// that look like secrets, private content already committed upstream,
-/// and how an existing repository would be adopted. The declaration goes
-/// to `[history.origin]` in the global config; the mode to
-/// `settings.history.sync`.
+/// stream, what is not and why, what is backed up (in plain form, or
+/// encrypted with `--encrypt-backups`), names that look like secrets,
+/// private content already committed upstream, and how an existing
+/// repository would be adopted. The declaration goes to `[history.origin]`
+/// in the global config; the mode to `settings.history.sync`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub(crate) struct DotfilesOrigin {
@@ -65,9 +65,21 @@ pub(crate) struct DotfilesOriginSet {
     #[usage(long)]
     allow_committed_private: bool,
 
-    /// Encrypt machine recovery refs (not supported yet)
+    /// Encrypt this machine's recovery refs with age for its recipients (see --recipient)
+    ///
+    /// Every backed-up checkpoint becomes one age payload: file names,
+    /// descriptions, and content are readable only with a recipient's
+    /// identity. The setup branch itself is always plaintext.
     #[usage(long)]
     encrypt_backups: bool,
+
+    /// A backup recipient (repeatable): an age public key (`age1…`), an SSH public key (`ssh-ed25519 …`), or a path to a `.pub` file or an age identity file
+    ///
+    /// Default: this machine's own age key (`~/.config/mise/age.txt` or
+    /// `settings.age.key_file`) and `~/.ssh/id_ed25519.pub` / `id_rsa.pub`.
+    /// When none exists, an age identity is generated at the key file path.
+    #[usage(long, value_name = "RECIPIENT", requires = "encrypt_backups")]
+    recipient: Vec<String>,
 
     /// Skip the confirmation prompt
     #[usage(long, short)]
@@ -90,11 +102,19 @@ impl DotfilesOrigin {
                 match crate::system::history::config::origin()? {
                     Some((path, origin)) => {
                         miseprintln!(
-                            "{} (branch {}) declared in {}; mode {}",
+                            "{} (branch {}) declared in {}; mode {}; machine backups {}",
                             origin.url,
                             origin.branch,
                             crate::file::display_path(&path),
-                            SyncMode::current()?.as_str()
+                            SyncMode::current()?.as_str(),
+                            if origin.encrypt_backups {
+                                format!(
+                                    "encrypted (age) for {} recipient(s)",
+                                    origin.recipients.len()
+                                )
+                            } else {
+                                "plaintext".to_string()
+                            }
                         );
                     }
                     None => miseprintln!(
@@ -128,6 +148,7 @@ impl DotfilesOriginSet {
                 include_existing: self.include_existing,
                 allow_committed_private: self.allow_committed_private,
                 encrypt_backups: self.encrypt_backups,
+                recipients: self.recipient.clone(),
                 yes: self.yes,
             },
         )
@@ -140,6 +161,8 @@ static AFTER_LONG_HELP: &str = color_print::cstr!(
 
     $ <bold>mise bootstrap dotfiles origin set https://github.com/you/setup.git</bold>
     $ <bold>mise bootstrap dotfiles origin set git@github.com:you/setup.git --name laptop --sync manual</bold>
+    $ <bold>mise bootstrap dotfiles origin set git@github.com:you/setup.git --encrypt-backups</bold>
+    $ <bold>mise bootstrap dotfiles origin set git@github.com:you/setup.git --encrypt-backups --recipient age1… --recipient ~/.ssh/id_ed25519.pub</bold>
     $ <bold>mise bootstrap dotfiles origin</bold>              # what is connected
     $ <bold>mise bootstrap dotfiles origin --remove</bold>
 "#

--- a/src/git.rs
+++ b/src/git.rs
@@ -799,12 +799,14 @@ impl GitPlumbing {
             .stderr(Stdio::inherit())
             .spawn()?;
         let mut bytes = Vec::new();
-        let read = child
+        // Keep the pipe open until Git has exited: dropping it before kill
+        // can make a large blob emit a spurious broken-pipe error on stderr.
+        let mut output = child
             .stdout
             .take()
             .expect("stdout was piped")
-            .take(prefix.len() as u64)
-            .read_to_end(&mut bytes);
+            .take(prefix.len() as u64);
+        let read = output.read_to_end(&mut bytes);
         let complete = bytes.len() == prefix.len();
         if complete || read.is_err() {
             let _ = child.kill();

--- a/src/git.rs
+++ b/src/git.rs
@@ -794,7 +794,7 @@ impl GitPlumbing {
         use std::io::Read;
         use std::process::Stdio;
         let mut child = self
-            .command(&PlumbingCall::new(["cat-file", "blob", oid]))
+            .command(&PlumbingCall::new(["cat-file", "blob", oid]))?
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .spawn()?;

--- a/src/git.rs
+++ b/src/git.rs
@@ -788,6 +788,35 @@ impl GitPlumbing {
         run_plumbing(cmd, call.stdin)
     }
 
+    /// Inspect a blob without buffering its full contents. Reap the reader
+    /// after the prefix so large ordinary files need no encryption-size cap.
+    pub(crate) fn blob_starts_with(&self, oid: &str, prefix: &[u8]) -> Result<bool> {
+        use std::io::Read;
+        use std::process::Stdio;
+        let mut child = self
+            .command(&PlumbingCall::new(["cat-file", "blob", oid]))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+        let mut bytes = Vec::new();
+        let read = child
+            .stdout
+            .take()
+            .expect("stdout was piped")
+            .take(prefix.len() as u64)
+            .read_to_end(&mut bytes);
+        let complete = bytes.len() == prefix.len();
+        if complete || read.is_err() {
+            let _ = child.kill();
+        }
+        let status = child.wait()?;
+        read?;
+        if !complete && !status.success() {
+            eyre::bail!("failed to inspect Git blob {oid}");
+        }
+        Ok(bytes == prefix)
+    }
+
     /// Runs the call and returns its full output without treating a non-zero
     /// exit as an error, for commands whose status carries meaning.
     pub(crate) fn output_unchecked(&self, call: PlumbingCall<'_>) -> Result<std::process::Output> {

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -104,6 +104,7 @@ pub(crate) struct FilePolicy {
     pub autosave: bool,
     pub share: bool,
     pub backup: bool,
+    pub encrypt: bool,
     /// `share` or `backup` was written in the declaration itself: the
     /// privacy defaults (`*.local.toml`, credential stores) yield to it.
     pub overridden: bool,
@@ -118,6 +119,7 @@ pub(crate) struct ExplicitFields {
     pub autosave: bool,
     pub share: bool,
     pub backup: bool,
+    pub encrypt: bool,
     pub variants: bool,
     pub enabled: bool,
 }
@@ -129,6 +131,7 @@ impl FilePolicy {
         Self {
             autosave: true,
             share: true,
+            encrypt: false,
             backup: !matches!(mode, FileMode::Template | FileMode::Content),
             overridden: false,
             explicit: ExplicitFields::default(),
@@ -213,6 +216,8 @@ pub(crate) enum FileTomlEntry {
         /// history: include the file in remote backups
         #[serde(default)]
         backup: Option<bool>,
+        #[serde(default)]
+        encrypt: Option<bool>,
         /// history: platform / profile streams for a tracked file
         #[serde(default)]
         variants: Option<Vec<crate::system::history::select::Variant>>,
@@ -242,6 +247,9 @@ impl FileRequest {
             self.policy.backup = later.policy.backup;
             self.policy.overridden = true;
         }
+        if explicit.encrypt {
+            self.policy.encrypt = later.policy.encrypt;
+        }
         if explicit.variants {
             self.variants = later.variants;
         }
@@ -252,6 +260,7 @@ impl FileRequest {
             autosave: mine.autosave || explicit.autosave,
             share: mine.share || explicit.share,
             backup: mine.backup || explicit.backup,
+            encrypt: mine.encrypt || explicit.encrypt,
             variants: mine.variants || explicit.variants,
             enabled: mine.enabled || explicit.enabled,
         };
@@ -547,6 +556,22 @@ pub(crate) fn validate_incoming_files(config_files: &ConfigMap) -> Result<()> {
             continue;
         };
         for (target, value) in dotfiles.0 {
+            if value.as_table().is_some_and(|t| {
+                t.contains_key("encrypt")
+                    && t.get("encrypt").and_then(toml::Value::as_bool).is_none()
+            }) {
+                bail!("dotfile {target}: encrypt must be a boolean");
+            }
+            if value.as_table().is_some_and(|t| {
+                t.get("encrypt").and_then(toml::Value::as_bool) == Some(true)
+                    && ["content", "block", "line", "template"]
+                        .iter()
+                        .any(|key| t.contains_key(*key))
+            }) {
+                bail!(
+                    "encrypted dotfile {target} requires an external source, not inline content or edits"
+                );
+            }
             let Some(entry) = file_entry_from_toml(&target, value.clone()) else {
                 // Managed line/block edits are handled by the edit engine,
                 // not by this whole-file declaration parser.
@@ -656,7 +681,30 @@ pub(crate) fn files_from_config_files(config_files: &ConfigMap) -> Vec<FileReque
             continue;
         };
         for (target_raw, value) in dotfiles.0 {
+            if value.as_table().is_some_and(|t| {
+                t.get("encrypt").and_then(toml::Value::as_bool) == Some(true)
+                    && ["content", "block", "line", "template"]
+                        .iter()
+                        .any(|key| t.contains_key(*key))
+            }) {
+                record_invalid(
+                    &target_raw,
+                    &origin.config,
+                    "encrypted dotfiles require an external source, not inline content or edits",
+                );
+                continue;
+            }
+            let encryption_declared = value
+                .as_table()
+                .is_some_and(|table| table.contains_key("encrypt"));
             let Some(entry) = file_entry_from_toml(&target_raw, value) else {
+                if encryption_declared {
+                    record_invalid(
+                        &target_raw,
+                        &origin.config,
+                        "invalid encryption declaration; encrypt must be a boolean on a whole-file entry",
+                    );
+                }
                 continue;
             };
             merge_file_entry(target_raw, entry, &base, &origin, &mut merged);
@@ -676,6 +724,7 @@ fn file_entry_from_toml(target_raw: &str, value: toml::Value) -> Option<FileToml
                 || table.contains_key("autosave")
                 || table.contains_key("share")
                 || table.contains_key("backup")
+                || table.contains_key("encrypt")
                 || table.contains_key("variants")
                 || table.contains_key("enabled")
                 || ((table.contains_key("source") || table.contains_key("content"))
@@ -705,40 +754,62 @@ fn merge_file_entry(
     origin: &ResourceOrigin,
     merged: &mut IndexMap<PathBuf, FileRequest>,
 ) {
-    let (source, content, mode, exclude, manifest, autosave, share, backup, variants, enabled) =
-        match entry {
-            FileTomlEntry::Source(source) => (
-                Some(source),
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            ),
-            FileTomlEntry::Table {
-                source,
-                content,
-                mode,
-                exclude,
-                manifest,
-                autosave,
-                share,
-                backup,
-                variants,
-                enabled,
-            } => (
-                source, content, mode, exclude, manifest, autosave, share, backup, variants,
-                enabled,
-            ),
-        };
+    let (
+        source,
+        content,
+        mode,
+        exclude,
+        manifest,
+        autosave,
+        share,
+        backup,
+        encrypt,
+        variants,
+        enabled,
+    ) = match entry {
+        FileTomlEntry::Source(source) => (
+            Some(source),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        FileTomlEntry::Table {
+            source,
+            content,
+            mode,
+            exclude,
+            manifest,
+            autosave,
+            share,
+            backup,
+            encrypt,
+            variants,
+            enabled,
+        } => (
+            source, content, mode, exclude, manifest, autosave, share, backup, encrypt, variants,
+            enabled,
+        ),
+    };
+    if encrypt == Some(true) && content.is_some() {
+        record_invalid(
+            &target_raw,
+            &origin.config,
+            "encrypted dotfiles require an external source; inline content is shared in configuration",
+        );
+        return;
+    }
     let explicit = ExplicitFields {
         autosave: autosave.is_some(),
         share: share.is_some(),
         backup: backup.is_some(),
+        encrypt: encrypt.is_some(),
         variants: variants.is_some(),
         enabled: enabled.is_some(),
     };
@@ -750,6 +821,7 @@ fn merge_file_entry(
             autosave: autosave.unwrap_or(defaults.autosave),
             share: share.unwrap_or(defaults.share),
             backup: backup.unwrap_or(defaults.backup),
+            encrypt: encrypt.unwrap_or(false),
             overridden: share.is_some() || backup.is_some(),
             explicit,
         }

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -596,6 +596,7 @@ pub(crate) fn validate_incoming_files(config_files: &ConfigMap) -> Result<()> {
                             | "autosave"
                             | "share"
                             | "backup"
+                            | "encrypt"
                             | "variants"
                             | "enabled"
                     ) {

--- a/src/system/history/config.rs
+++ b/src/system/history/config.rs
@@ -32,10 +32,26 @@ pub(crate) struct OriginTomlConfig {
     pub url: String,
     #[serde(default = "default_branch")]
     pub branch: String,
-    /// Encrypt machine recovery refs (a later milestone; parsed and refused
-    /// until then so an early declaration is never silently plaintext).
+    /// Encrypt this machine's recovery refs with age for `recipients`. On
+    /// with no recipients, nothing is uploaded (never plaintext instead).
     #[serde(default)]
     pub encrypt_backups: bool,
+    /// age public keys (`age1…`) and SSH public keys the backups are
+    /// encrypted for; `origin set --encrypt-backups` fills it in.
+    #[serde(default)]
+    pub recipients: Vec<String>,
+}
+
+impl OriginTomlConfig {
+    /// A plaintext connection, as recorded before any declaration.
+    pub(crate) fn plain(url: String, branch: String) -> Self {
+        Self {
+            url,
+            branch,
+            encrypt_backups: false,
+            recipients: vec![],
+        }
+    }
 }
 
 fn default_branch() -> String {

--- a/src/system/history/config.rs
+++ b/src/system/history/config.rs
@@ -24,6 +24,31 @@ pub(crate) struct HistoryTomlConfig {
     /// The setup repository this machine publishes to and fetches from.
     #[serde(default)]
     pub origin: Option<OriginTomlConfig>,
+    #[serde(default)]
+    pub encryption: Option<FileEncryptionConfig>,
+}
+
+/// Public recipients shared by every encrypted dotfile.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub(crate) struct FileEncryptionConfig {
+    #[serde(default)]
+    pub recipients: Vec<String>,
+}
+
+pub(crate) fn file_recipients() -> Result<Vec<String>> {
+    let mut recipients = Vec::new();
+    for (path, layer) in layers()? {
+        if let Some(encryption) = layer.encryption {
+            if !crate::config::config_file::is_trusted(&path) {
+                eyre::bail!(
+                    "trust the configuration before using its encryption recipients: {}",
+                    display_path(&path)
+                );
+            }
+            recipients = encryption.recipients;
+        }
+    }
+    Ok(recipients)
 }
 
 /// `[history.origin]`.

--- a/src/system/history/replay.rs
+++ b/src/system/history/replay.rs
@@ -143,7 +143,8 @@ pub(crate) async fn rollback(req: RollbackRequest) -> Result<()> {
                 (paths.len() == 1)
                     .then(|| display_path(&paths[0]))
                     .as_deref(),
-            )?;
+            )
+            .await?;
             refuse_unusable(&entry)?;
             let paths = if req.all {
                 covered_paths(&entry.checkpoint)

--- a/src/system/history/shadow.rs
+++ b/src/system/history/shadow.rs
@@ -388,6 +388,17 @@ impl HistoryRepo {
             .wrap_err_with(|| format!("reading {oid}"))
     }
 
+    pub(crate) fn cat_object_bounded(&self, oid: &str, limit: u64) -> Result<Vec<u8>> {
+        let size: u64 = self
+            .output_str(PlumbingCall::new(["cat-file", "-s", oid]))?
+            .trim()
+            .parse()?;
+        if size > limit {
+            eyre::bail!("object exceeds the encrypted content size limit");
+        }
+        self.cat_object(oid)
+    }
+
     pub(crate) fn hash_blob(&self, bytes: &[u8]) -> Result<String> {
         self.output_str(PlumbingCall::new(["hash-object", "-w", "--stdin"]).stdin(bytes))
     }

--- a/src/system/history/shadow.rs
+++ b/src/system/history/shadow.rs
@@ -51,6 +51,7 @@ pub(crate) struct CaptureResult {
 #[derive(Debug)]
 pub(crate) struct TreeEntry {
     pub mode: String,
+    pub oid: String,
     pub size: Option<u64>,
     pub path: String,
 }
@@ -194,8 +195,40 @@ impl HistoryRepo {
         tree
     }
 
+    /// One level of tree from an `ls-tree`-style listing.
     pub(crate) fn mktree(&self, listing: &str) -> Result<String> {
         self.output_str(PlumbingCall::new(["mktree"]).stdin(listing.as_bytes()))
+    }
+
+    /// A tree holding exactly `entries` (`(mode, oid, path)`, paths nested
+    /// as deep as they like), built in a scratch index so the repository's
+    /// own index is never touched. Objects need not exist for gitlinks
+    /// (`160000`), as in any tree git writes.
+    pub(crate) fn write_tree(&self, entries: &[(String, String, String)]) -> Result<String> {
+        if entries.is_empty() {
+            return self.empty_object("tree");
+        }
+        let index = self
+            .dir()
+            .join(format!("mise-index-{}-write-tree", std::process::id()));
+        let _ = std::fs::remove_file(&index);
+        let mut info: Vec<u8> = vec![];
+        for (mode, oid, path) in entries {
+            info.extend_from_slice(format!("{mode} {oid}\t{path}").as_bytes());
+            info.push(0);
+        }
+        let result = (|| -> Result<String> {
+            // index-only operations; git still insists on a work tree
+            self.git.run(
+                PlumbingCall::new(["update-index", "-z", "--index-info"])
+                    .work_tree(self.dir())
+                    .index_file(&index)
+                    .stdin(&info),
+            )?;
+            self.output_str(PlumbingCall::new(["write-tree"]).index_file(&index))
+        })();
+        let _ = std::fs::remove_file(&index);
+        result
     }
 
     /// Writes the wrapper commit for a checkpoint: `snapshot/`, `meta.json`,
@@ -311,13 +344,14 @@ impl HistoryRepo {
                 continue;
             };
             let mut fields = meta.split_whitespace();
-            let (Some(mode), Some(_kind), Some(_oid), Some(size)) =
+            let (Some(mode), Some(_kind), Some(oid), Some(size)) =
                 (fields.next(), fields.next(), fields.next(), fields.next())
             else {
                 continue;
             };
             entries.push(TreeEntry {
                 mode: mode.to_string(),
+                oid: oid.to_string(),
                 size: size.parse().ok(),
                 path: path.to_string(),
             });

--- a/src/system/history/shadow.rs
+++ b/src/system/history/shadow.rs
@@ -388,6 +388,10 @@ impl HistoryRepo {
             .wrap_err_with(|| format!("reading {oid}"))
     }
 
+    pub(crate) fn blob_starts_with(&self, oid: &str, prefix: &[u8]) -> Result<bool> {
+        self.git.blob_starts_with(oid, prefix)
+    }
+
     pub(crate) fn cat_object_bounded(&self, oid: &str, limit: u64) -> Result<Vec<u8>> {
         let size: u64 = self
             .output_str(PlumbingCall::new(["cat-file", "-s", oid]))?

--- a/src/system/history/store.rs
+++ b/src/system/history/store.rs
@@ -408,6 +408,8 @@ pub(crate) struct CoverageEntry {
     pub autosave: bool,
     pub share: bool,
     pub backup: bool,
+    #[serde(default)]
+    pub encrypt: bool,
     /// `live`, `saved`, or `protective`.
     pub state: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/system/history/store.rs
+++ b/src/system/history/store.rs
@@ -166,7 +166,7 @@ pub(crate) fn create_private_dir(dir: &Path) -> Result<()> {
 }
 
 /// This machine's stable identity, created on first use.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct Machine {
     pub id: String,
     pub name: String,

--- a/src/system/history/sync/apply.rs
+++ b/src/system/history/sync/apply.rs
@@ -102,7 +102,12 @@ pub(crate) async fn apply(
             ..Default::default()
         });
     }
-    run::refresh(store, tracked, &mut status)?;
+    run::refresh_with_interaction(
+        store,
+        tracked,
+        &mut status,
+        !req.automatic && console::user_attended_stderr(),
+    )?;
     let roots = Roots::current();
     let filter: BTreeSet<PathBuf> = req
         .paths
@@ -141,7 +146,17 @@ pub(crate) async fn apply(
                 bail!("save {} before choosing --keep-local", display_path(&local));
             }
             let remote = match status.upstream_commit.as_deref() {
-                Some(head) => repo.object_at(head, &conflict.branch_path)?,
+                Some(head) => repo
+                    .object_at(head, &conflict.branch_path)?
+                    .map(|object| {
+                        super::files::decrypt(
+                            repo,
+                            &conflict.branch_path,
+                            &object,
+                            !req.automatic && console::user_attended_stderr(),
+                        )
+                    })
+                    .transpose()?,
                 None => None,
             };
             status.resolutions.insert(

--- a/src/system/history/sync/apply.rs
+++ b/src/system/history/sync/apply.rs
@@ -128,6 +128,7 @@ pub(crate) async fn apply(
     // Store choices without publishing or applying any part of the setup.
     let mut sync_state = state::load(repo)?;
     let shared = super::share::current(repo, store, tracked)?.objects();
+    let encrypted = super::files::encrypted_paths(repo, status.upstream_commit.as_deref())?;
     for conflict in &status.conflicts {
         let Some(local) = roots
             .locate(&conflict.branch_path)
@@ -149,6 +150,9 @@ pub(crate) async fn apply(
                 Some(head) => repo
                     .object_at(head, &conflict.branch_path)?
                     .map(|object| {
+                        if !encrypted.contains(&conflict.branch_path) {
+                            return Ok(object);
+                        }
                         super::files::decrypt(
                             repo,
                             &conflict.branch_path,

--- a/src/system/history/sync/backup.rs
+++ b/src/system/history/sync/backup.rs
@@ -4,16 +4,117 @@
 //! removed and the record masked. Journal blobs never travel: journals
 //! are data on another machine, never executed. Retention removes only
 //! this machine's remote refs for checkpoints it pruned.
+//!
+//! With `[history.origin] encrypt_backups = true` the wrapper is the
+//! encrypted layout (`encrypted`): one age payload per checkpoint for the
+//! declared recipients. The scheme in use (plaintext, or which recipients)
+//! is recorded in `sync.json`; when it changes, this machine's refs on the
+//! origin are deleted and the eligible checkpoints uploaded again under the
+//! new one, so a repository never holds a mix by accident.
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use eyre::Result;
+use eyre::{Result, bail};
 
+use super::encrypted::{self, BackupHeader};
 use super::network::{MACHINES_PREFIX, PushOutcome, REMOTE_MACHINES_PREFIX, Remote};
 use super::privacy::mask_checkpoint;
+use super::run::SyncStatus;
+use crate::system::history::config::OriginTomlConfig;
 use crate::system::history::shadow::{HistoryRepo, Overlay};
 use crate::system::history::store::{Entry, OperationStatus};
 use crate::system::history::tracked::display_to_tree_path;
+
+/// The recorded scheme of a plaintext connection (and of every connection
+/// recorded before schemes existed).
+pub(crate) const PLAIN_SCHEME: &str = "plain";
+
+/// The recipients this machine's backups are encrypted for.
+pub(crate) struct BackupEncryption {
+    pub recipients: Vec<Box<dyn age::Recipient + Send>>,
+    /// The same recipients as declared, for the scheme fingerprint.
+    pub strings: Vec<String>,
+}
+
+impl std::fmt::Debug for BackupEncryption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BackupEncryption")
+            .field("recipients", &self.strings)
+            .finish()
+    }
+}
+
+impl BackupEncryption {
+    /// `None` for a plaintext connection. An error when encryption is on
+    /// but cannot be done (no recipients, or one that does not parse):
+    /// the caller skips uploads rather than falling back to plaintext.
+    pub(crate) fn resolve(origin: &OriginTomlConfig) -> Result<Option<Self>> {
+        if !origin.encrypt_backups {
+            return Ok(None);
+        }
+        if origin.recipients.is_empty() {
+            bail!(
+                "encrypted backups are on but [history.origin] names no recipients; `mise bootstrap dotfiles origin set {} --encrypt-backups [--recipient …]` adds them (nothing is uploaded until then)",
+                origin.url
+            );
+        }
+        let mut recipients = vec![];
+        let mut strings = vec![];
+        for declared in &origin.recipients {
+            match crate::agecrypt::parse_recipient(declared)? {
+                Some(recipient) => {
+                    recipients.push(recipient);
+                    strings.push(declared.trim().to_string());
+                }
+                None => bail!(
+                    "[history.origin] recipient {declared:?} is neither an age public key (age1…) nor an SSH public key (ssh-…)"
+                ),
+            }
+        }
+        Ok(Some(Self {
+            recipients,
+            strings,
+        }))
+    }
+}
+
+/// A fingerprint of how backups are written: `plain`, or `age:` plus a
+/// hash of the recipient set (order and repeats do not matter).
+pub(crate) fn scheme(encryption: Option<&BackupEncryption>) -> String {
+    match encryption {
+        None => PLAIN_SCHEME.to_string(),
+        Some(encryption) => {
+            let mut recipients: Vec<&str> = encryption.strings.iter().map(String::as_str).collect();
+            recipients.sort_unstable();
+            recipients.dedup();
+            format!(
+                "age:{}",
+                crate::hash::hash_sha256_to_str(&recipients.join("\n"))
+            )
+        }
+    }
+}
+
+/// Whether `scheme` differs from the one the refs on the origin were
+/// written under (a status without one is plaintext: the only scheme
+/// there was).
+pub(crate) fn scheme_changes(status: &SyncStatus, scheme: &str) -> bool {
+    status.backup_scheme.as_deref().unwrap_or(PLAIN_SCHEME) != scheme
+}
+
+/// Records `scheme`; when it changed, forgets what was uploaded so every
+/// eligible checkpoint is uploaded again. Returns whether it changed.
+pub(crate) fn reconcile_scheme(status: &mut SyncStatus, scheme: &str) -> bool {
+    if !scheme_changes(status, scheme) {
+        status
+            .backup_scheme
+            .get_or_insert_with(|| scheme.to_string());
+        return false;
+    }
+    status.uploaded.clear();
+    status.backup_scheme = Some(scheme.to_string());
+    true
+}
 
 /// Whether a checkpoint may leave the machine at all: it has content and
 /// at least one entry with `backup = true`.
@@ -42,8 +143,13 @@ fn excluded_paths(entry: &Entry) -> BTreeSet<String> {
         .collect()
 }
 
-/// A wrapper commit holding only what may be backed up.
-pub(crate) fn filtered_commit(repo: &HistoryRepo, entry: &Entry) -> Result<String> {
+/// A wrapper commit holding only what may be backed up: the plaintext
+/// layout, or the encrypted one for `encryption`.
+pub(crate) fn wrapper_commit(
+    repo: &HistoryRepo,
+    entry: &Entry,
+    encryption: Option<&BackupEncryption>,
+) -> Result<String> {
     let excluded = excluded_paths(entry);
     let snapshot = match &entry.checkpoint.tree.snapshot {
         Some(snapshot) if excluded.is_empty() => Some(snapshot.clone()),
@@ -60,9 +166,20 @@ pub(crate) fn filtered_commit(repo: &HistoryRepo, entry: &Entry) -> Result<Strin
         None => None,
     };
     let masked = mask_checkpoint(&entry.checkpoint, &excluded);
-    // a commit of its own: the local checkpoint ref keeps naming the full
-    // wrapper, private and unbacked files included
-    repo.write_checkpoint_commit(snapshot.as_deref(), &masked, &BTreeMap::new())
+    match encryption {
+        // a commit of its own: the local checkpoint ref keeps naming the
+        // full wrapper, private and unbacked files included
+        None => repo.write_checkpoint_commit(snapshot.as_deref(), &masked, &BTreeMap::new()),
+        Some(encryption) => {
+            let ciphertext =
+                encrypted::build(repo, snapshot.as_deref(), &masked, &encryption.recipients)?;
+            encrypted::write_commit(
+                repo,
+                &BackupHeader::new(&masked, encryption.recipients.len()),
+                &ciphertext,
+            )
+        }
+    }
 }
 
 pub(crate) fn remote_ref(machine_id: &str, uuid: &str) -> String {
@@ -88,6 +205,7 @@ pub(crate) fn upload(
     entries: &[Entry],
     machine_id: &str,
     uploaded: &mut BTreeSet<String>,
+    encryption: Option<&BackupEncryption>,
 ) -> Result<usize> {
     let mut count = 0;
     for entry in entries {
@@ -99,8 +217,14 @@ pub(crate) fn upload(
             uploaded.insert(uuid.clone());
             continue;
         }
-        let commit = filtered_commit(repo, entry)?;
-        let refspec = format!("{commit}:{}", remote_ref(machine_id, uuid));
+        let commit = wrapper_commit(repo, entry, encryption)?;
+        // forced: the ref is this machine's alone, and a checkpoint
+        // uploaded again after a scheme change is a parentless rewrite of
+        // the same content, not a fast-forward
+        let refspec = format!(
+            "+{commit}:{}",
+            remote_ref(machine_id, &entry.checkpoint.uuid)
+        );
         match remote.push(&[refspec], None)? {
             PushOutcome::Done => {
                 uploaded.insert(uuid.clone());
@@ -146,7 +270,8 @@ pub(crate) fn prune_remote(
     Ok(stale.len())
 }
 
-/// Every one of this machine's remote refs, for `origin --purge`.
+/// Every one of this machine's remote refs, for `origin --purge` and for
+/// replacing them after a scheme change.
 pub(crate) fn remote_refs(remote: &Remote<'_>, machine_id: &str) -> Result<Vec<String>> {
     let prefix = format!("{REMOTE_MACHINES_PREFIX}{machine_id}/");
     Ok(remote
@@ -158,7 +283,7 @@ pub(crate) fn remote_refs(remote: &Remote<'_>, machine_id: &str) -> Result<Vec<S
 }
 
 #[cfg(test)]
-mod tests {
+mod upload_tests {
     use std::process::Command;
 
     use super::*;
@@ -238,7 +363,7 @@ mod tests {
             .unwrap();
         let mut uploaded = BTreeSet::new();
         assert_eq!(
-            upload(&remote, &repo, &[entry], "m", &mut uploaded).unwrap(),
+            upload(&remote, &repo, &[entry], "m", &mut uploaded, None).unwrap(),
             0
         );
         assert_eq!(uploaded, BTreeSet::from(["u1".to_string()]));
@@ -262,7 +387,8 @@ mod tests {
                 &repo,
                 std::slice::from_ref(&entry),
                 "m",
-                &mut uploaded
+                &mut uploaded,
+                None
             )
             .unwrap(),
             1
@@ -272,7 +398,7 @@ mod tests {
         uploaded.clear();
         remote.fetch("main").unwrap();
         assert_eq!(
-            upload(&remote, &repo, &[entry], "m", &mut uploaded).unwrap(),
+            upload(&remote, &repo, &[entry], "m", &mut uploaded, None).unwrap(),
             0
         );
         assert_eq!(uploaded, BTreeSet::from(["u1".to_string()]));
@@ -301,7 +427,8 @@ mod tests {
                 &repo,
                 std::slice::from_ref(&entry),
                 "m",
-                &mut uploaded
+                &mut uploaded,
+                None
             )
             .unwrap(),
             0
@@ -312,5 +439,83 @@ mod tests {
             .output()
             .unwrap();
         assert!(String::from_utf8_lossy(&output.stdout).starts_with(&other.commit));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encryption(recipients: &[&str]) -> BackupEncryption {
+        BackupEncryption {
+            recipients: vec![],
+            strings: recipients.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn origin(encrypt: bool, recipients: &[&str]) -> OriginTomlConfig {
+        OriginTomlConfig {
+            url: "file:///origin.git".into(),
+            branch: "main".into(),
+            encrypt_backups: encrypt,
+            recipients: recipients.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn scheme_ignores_order_and_repeats() {
+        assert_eq!(scheme(None), PLAIN_SCHEME);
+        let a = scheme(Some(&encryption(&["age1a", "age1b"])));
+        let b = scheme(Some(&encryption(&["age1b", "age1a", "age1a"])));
+        assert_eq!(a, b);
+        assert!(a.starts_with("age:"), "{a}");
+        assert_ne!(a, scheme(Some(&encryption(&["age1a"]))));
+    }
+
+    #[test]
+    fn reconcile_scheme_forgets_uploads_only_on_a_change() {
+        let mut status = SyncStatus::default();
+        status.uploaded.insert("u1".into());
+        // an old status without a scheme is plaintext: no change, no re-upload
+        assert!(!reconcile_scheme(&mut status, PLAIN_SCHEME));
+        assert_eq!(status.uploaded.len(), 1);
+        assert_eq!(status.backup_scheme.as_deref(), Some(PLAIN_SCHEME));
+
+        let age = scheme(Some(&encryption(&["age1a"])));
+        assert!(reconcile_scheme(&mut status, &age));
+        assert!(status.uploaded.is_empty());
+        assert_eq!(status.backup_scheme.as_deref(), Some(age.as_str()));
+
+        status.uploaded.insert("u1".into());
+        assert!(!reconcile_scheme(&mut status, &age));
+        assert_eq!(status.uploaded.len(), 1);
+
+        assert!(reconcile_scheme(&mut status, PLAIN_SCHEME));
+        assert!(status.uploaded.is_empty());
+    }
+
+    #[test]
+    fn resolve_refuses_encryption_without_usable_recipients() {
+        assert!(
+            BackupEncryption::resolve(&origin(false, &[]))
+                .unwrap()
+                .is_none()
+        );
+        let err = BackupEncryption::resolve(&origin(true, &[]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("names no recipients"), "{err}");
+        assert!(!err.contains("experimental"), "{err}");
+        let err = BackupEncryption::resolve(&origin(true, &["not-a-key"]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("neither an age public key"), "{err}");
+        let resolved = BackupEncryption::resolve(&origin(
+            true,
+            &["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"],
+        ))
+        .unwrap()
+        .unwrap();
+        assert_eq!(resolved.recipients.len(), 1);
     }
 }

--- a/src/system/history/sync/backup.rs
+++ b/src/system/history/sync/backup.rs
@@ -9,8 +9,8 @@
 //! encrypted layout (`encrypted`): one age payload per checkpoint for the
 //! declared recipients. The scheme in use (plaintext, or which recipients)
 //! is recorded in `sync.json`; when it changes, this machine's refs on the
-//! origin are deleted and the eligible checkpoints uploaded again under the
-//! new one, so a repository never holds a mix by accident.
+//! origin are replaced in one transaction with eligible checkpoints under
+//! the new scheme, so a repository never holds a mix by accident.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -253,13 +253,9 @@ pub(crate) fn upload(
             continue;
         }
         let commit = wrapper_commit(repo, entry, encryption, encrypted_paths)?;
-        // forced: the ref is this machine's alone, and a checkpoint
-        // uploaded again after a scheme change is a parentless rewrite of
-        // the same content, not a fast-forward
-        let refspec = format!(
-            "+{commit}:{}",
-            remote_ref(machine_id, &entry.checkpoint.uuid)
-        );
+        // Scheme changes use `replace`'s complete transaction. Ordinary
+        // uploads must not overwrite a backup published since our fetch.
+        let refspec = format!("{commit}:{}", remote_ref(machine_id, uuid));
         match remote.push(&[refspec], None)? {
             PushOutcome::Done => {
                 uploaded.insert(uuid.clone());
@@ -412,6 +408,7 @@ mod upload_tests {
             autosave: true,
             share: true,
             backup: true,
+            encrypt: false,
             state: "live".into(),
             promotion: None,
             private: None,
@@ -441,7 +438,16 @@ mod upload_tests {
             .unwrap();
         let mut uploaded = BTreeSet::new();
         assert_eq!(
-            upload(&remote, &repo, &[entry], "m", &mut uploaded, None).unwrap(),
+            upload(
+                &remote,
+                &repo,
+                &[entry],
+                "m",
+                &mut uploaded,
+                None,
+                &BTreeSet::new()
+            )
+            .unwrap(),
             0
         );
         assert_eq!(uploaded, BTreeSet::from(["u1".to_string()]));
@@ -466,7 +472,8 @@ mod upload_tests {
                 std::slice::from_ref(&entry),
                 "m",
                 &mut uploaded,
-                None
+                None,
+                &BTreeSet::new()
             )
             .unwrap(),
             1
@@ -476,7 +483,16 @@ mod upload_tests {
         uploaded.clear();
         remote.fetch("main").unwrap();
         assert_eq!(
-            upload(&remote, &repo, &[entry], "m", &mut uploaded, None).unwrap(),
+            upload(
+                &remote,
+                &repo,
+                &[entry],
+                "m",
+                &mut uploaded,
+                None,
+                &BTreeSet::new()
+            )
+            .unwrap(),
             0
         );
         assert_eq!(uploaded, BTreeSet::from(["u1".to_string()]));
@@ -506,7 +522,8 @@ mod upload_tests {
                 std::slice::from_ref(&entry),
                 "m",
                 &mut uploaded,
-                None
+                None,
+                &BTreeSet::new()
             )
             .unwrap(),
             0

--- a/src/system/history/sync/backup.rs
+++ b/src/system/history/sync/backup.rs
@@ -104,6 +104,7 @@ pub(crate) fn scheme_changes(status: &SyncStatus, scheme: &str) -> bool {
 
 /// Records `scheme`; when it changed, forgets what was uploaded so every
 /// eligible checkpoint is uploaded again. Returns whether it changed.
+#[cfg(test)]
 pub(crate) fn reconcile_scheme(status: &mut SyncStatus, scheme: &str) -> bool {
     if !scheme_changes(status, scheme) {
         status
@@ -149,8 +150,22 @@ pub(crate) fn wrapper_commit(
     repo: &HistoryRepo,
     entry: &Entry,
     encryption: Option<&BackupEncryption>,
+    encrypted_paths: &BTreeSet<String>,
 ) -> Result<String> {
-    let excluded = excluded_paths(entry);
+    let mut excluded = excluded_paths(entry);
+    if encryption.is_none() {
+        excluded.extend(encrypted_paths.iter().cloned());
+        excluded.extend(
+            entry
+                .checkpoint
+                .tree
+                .coverage
+                .entries
+                .iter()
+                .filter(|c| c.encrypt)
+                .map(|c| c.path.clone()),
+        );
+    }
     let snapshot = match &entry.checkpoint.tree.snapshot {
         Some(snapshot) if excluded.is_empty() => Some(snapshot.clone()),
         Some(snapshot) => {
@@ -165,7 +180,26 @@ pub(crate) fn wrapper_commit(
         }
         None => None,
     };
-    let masked = mask_checkpoint(&entry.checkpoint, &excluded);
+    let mut masked = mask_checkpoint(&entry.checkpoint, &excluded);
+    masked.tree.snapshot = snapshot.clone();
+    if encryption.is_none()
+        && (!encrypted_paths.is_empty()
+            || entry
+                .checkpoint
+                .tree
+                .coverage
+                .entries
+                .iter()
+                .any(|coverage| coverage.encrypt))
+    {
+        // Descriptions, labels, and operation notes can contain text derived
+        // from protected files. Plaintext backups must not disclose it.
+        masked.description = "checkpoint (encrypted files omitted)".into();
+        masked.summary = masked.description.clone();
+        masked.labels.clear();
+        masked.task = None;
+        masked.operation = None;
+    }
     match encryption {
         // a commit of its own: the local checkpoint ref keeps naming the
         // full wrapper, private and unbacked files included
@@ -206,6 +240,7 @@ pub(crate) fn upload(
     machine_id: &str,
     uploaded: &mut BTreeSet<String>,
     encryption: Option<&BackupEncryption>,
+    encrypted_paths: &BTreeSet<String>,
 ) -> Result<usize> {
     let mut count = 0;
     for entry in entries {
@@ -217,7 +252,7 @@ pub(crate) fn upload(
             uploaded.insert(uuid.clone());
             continue;
         }
-        let commit = wrapper_commit(repo, entry, encryption)?;
+        let commit = wrapper_commit(repo, entry, encryption, encrypted_paths)?;
         // forced: the ref is this machine's alone, and a checkpoint
         // uploaded again after a scheme change is a parentless rewrite of
         // the same content, not a fast-forward
@@ -238,6 +273,49 @@ pub(crate) fn upload(
         }
     }
     Ok(count)
+}
+
+/// Prepare every replacement before touching the remote. Status is committed
+/// only after the atomic push, so a crash can safely repeat the transaction.
+pub(crate) fn replace(
+    remote: &Remote<'_>,
+    repo: &HistoryRepo,
+    entries: &[Entry],
+    machine_id: &str,
+    status: &mut SyncStatus,
+    encryption: Option<&BackupEncryption>,
+    encrypted_paths: &BTreeSet<String>,
+) -> Result<(usize, usize)> {
+    let old_refs = remote_refs(remote, machine_id)?;
+    let old: BTreeSet<&str> = old_refs.iter().map(String::as_str).collect();
+    let mut refs = BTreeSet::new();
+    let mut uploaded = BTreeSet::new();
+    let mut refspecs = Vec::new();
+    for entry in entries.iter().filter(|entry| eligible(entry)) {
+        let uuid = &entry.checkpoint.uuid;
+        let name = remote_ref(machine_id, uuid);
+        let newly_eligible = status
+            .upload_since
+            .as_deref()
+            .is_none_or(|since| entry.checkpoint.created_at.as_str() >= since);
+        if !newly_eligible && !status.uploaded.contains(uuid) && !old.contains(name.as_str()) {
+            continue;
+        }
+        let commit = wrapper_commit(repo, entry, encryption, encrypted_paths)?;
+        refspecs.push(format!("+{commit}:{name}"));
+        refs.insert(name);
+        uploaded.insert(uuid.clone());
+    }
+    refspecs.extend(
+        old_refs
+            .iter()
+            .filter(|name| !refs.contains(*name))
+            .map(|name| format!(":{name}")),
+    );
+    remote.push_atomic(&refspecs)?;
+    status.backup_scheme = Some(scheme(encryption));
+    status.uploaded = uploaded;
+    Ok((status.uploaded.len(), old_refs.len()))
 }
 
 /// Removes this machine's remote refs for checkpoints no longer retained

--- a/src/system/history/sync/backup.rs
+++ b/src/system/history/sync/backup.rs
@@ -48,7 +48,7 @@ impl BackupEncryption {
     /// `None` for a plaintext connection. An error when encryption is on
     /// but cannot be done (no recipients, or one that does not parse):
     /// the caller skips uploads rather than falling back to plaintext.
-    pub(crate) fn resolve(origin: &OriginTomlConfig) -> Result<Option<Self>> {
+    pub(crate) fn resolve(origin: &OriginTomlConfig, interactive: bool) -> Result<Option<Self>> {
         if !origin.encrypt_backups {
             return Ok(None);
         }
@@ -61,7 +61,7 @@ impl BackupEncryption {
         let mut recipients = vec![];
         let mut strings = vec![];
         for declared in &origin.recipients {
-            match crate::agecrypt::parse_recipient(declared)? {
+            match crate::agecrypt::parse_recipient_mode(declared, interactive)? {
                 Some(recipient) => {
                     recipients.push(recipient);
                     strings.push(declared.trim().to_string());
@@ -592,23 +592,26 @@ mod tests {
     #[test]
     fn resolve_refuses_encryption_without_usable_recipients() {
         assert!(
-            BackupEncryption::resolve(&origin(false, &[]))
+            BackupEncryption::resolve(&origin(false, &[]), false)
                 .unwrap()
                 .is_none()
         );
-        let err = BackupEncryption::resolve(&origin(true, &[]))
+        let err = BackupEncryption::resolve(&origin(true, &[]), false)
             .unwrap_err()
             .to_string();
         assert!(err.contains("names no recipients"), "{err}");
         assert!(!err.contains("experimental"), "{err}");
-        let err = BackupEncryption::resolve(&origin(true, &["not-a-key"]))
+        let err = BackupEncryption::resolve(&origin(true, &["not-a-key"]), false)
             .unwrap_err()
             .to_string();
         assert!(err.contains("neither an age public key"), "{err}");
-        let resolved = BackupEncryption::resolve(&origin(
-            true,
-            &["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"],
-        ))
+        let resolved = BackupEncryption::resolve(
+            &origin(
+                true,
+                &["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"],
+            ),
+            false,
+        )
         .unwrap()
         .unwrap();
         assert_eq!(resolved.recipients.len(), 1);

--- a/src/system/history/sync/encrypted.rs
+++ b/src/system/history/sync/encrypted.rs
@@ -1,0 +1,424 @@
+//! The encrypted form of a machine recovery ref. A plaintext backup commit
+//! carries `meta.json` and `snapshot/`; an encrypted one carries
+//! `backup.toml` (a small plaintext header: format, machine, checkpoint id
+//! and time, recipient count) and `payload.age`: the masked record and every
+//! backed-up file, serialized together, zstd-compressed, and age-encrypted
+//! for the machine's recipients. File names, descriptions, and content are
+//! all inside the payload. A mise that predates this layout finds no
+//! `meta.json` and skips the ref.
+//!
+//! Reading one back decrypts the payload once and writes its files as
+//! ordinary git objects under a local plaintext wrapper commit (kept alive
+//! by `refs/machines-plain/…`), so rollback treats the entry like any other.
+
+use std::collections::BTreeMap;
+
+use eyre::{Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::agecrypt::{self, DecryptError};
+use crate::system::history::shadow::HistoryRepo;
+use crate::system::history::store::{Checkpoint, Machine};
+
+/// The plaintext layout is implicitly format 1.
+pub(crate) const BACKUP_FORMAT: u32 = 2;
+pub(crate) const HEADER_PATH: &str = "backup.toml";
+pub(crate) const PAYLOAD_PATH: &str = "payload.age";
+const ENCRYPTION: &str = "age";
+
+/// What an encrypted backup says about itself without a key.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct BackupHeader {
+    pub format: u32,
+    pub encryption: String,
+    pub machine: Machine,
+    /// The checkpoint uuid.
+    pub checkpoint: String,
+    /// RFC 3339, UTC.
+    pub created_at: String,
+    /// How many recipients can read the payload (not who).
+    pub recipients: usize,
+}
+
+impl BackupHeader {
+    pub(crate) fn new(checkpoint: &Checkpoint, recipients: usize) -> Self {
+        Self {
+            format: BACKUP_FORMAT,
+            encryption: ENCRYPTION.to_string(),
+            machine: checkpoint.machine.clone(),
+            checkpoint: checkpoint.uuid.clone(),
+            created_at: checkpoint.created_at.clone(),
+            recipients,
+        }
+    }
+
+    pub(crate) fn to_toml(&self) -> Result<String> {
+        Ok(format!(
+            "# An encrypted mise machine backup; the files are in payload.age.\n{}",
+            toml::to_string(self)?
+        ))
+    }
+
+    pub(crate) fn parse(bytes: &[u8]) -> Result<Self> {
+        let text = std::str::from_utf8(bytes)?;
+        let header: Self = toml::from_str(text)?;
+        if header.format != BACKUP_FORMAT {
+            bail!(
+                "backup format {} is newer than this mise understands (up to {BACKUP_FORMAT}); upgrade mise",
+                header.format
+            );
+        }
+        if header.encryption != ENCRYPTION {
+            bail!(
+                "backup encryption {:?} is not one this mise understands",
+                header.encryption
+            );
+        }
+        Ok(header)
+    }
+}
+
+/// Everything inside the payload.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Payload {
+    pub format: u32,
+    /// The masked record; `tree.snapshot` is meaningless off the machine
+    /// and left empty.
+    pub checkpoint: Checkpoint,
+    pub files: Vec<PayloadFile>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct PayloadFile {
+    /// The snapshot tree path (`home/.zshrc`, `fs/etc/hosts`).
+    pub path: String,
+    /// The git mode: `100644`, `100755`, `120000` (content is the link
+    /// target), or `160000` (content is the recorded commit id).
+    pub mode: String,
+    pub content: Bytes,
+}
+
+/// Raw bytes serialized as a MessagePack `bin`, whatever the serializer's
+/// default for `Vec<u8>` is.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct Bytes(pub Vec<u8>);
+
+impl Serialize for Bytes {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Bytes {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = Bytes;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("bytes")
+            }
+            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Bytes, E> {
+                Ok(Bytes(v.to_vec()))
+            }
+            fn visit_byte_buf<E: serde::de::Error>(self, v: Vec<u8>) -> Result<Bytes, E> {
+                Ok(Bytes(v))
+            }
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Bytes, A::Error> {
+                let mut out = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+                while let Some(byte) = seq.next_element::<u8>()? {
+                    out.push(byte);
+                }
+                Ok(Bytes(out))
+            }
+        }
+        deserializer.deserialize_byte_buf(Visitor)
+    }
+}
+
+/// Why an encrypted backup could not be read.
+#[derive(Debug)]
+pub(crate) enum ReadError {
+    /// The commit has the plaintext layout.
+    NotEncrypted,
+    /// Not an age payload, or damaged.
+    Corrupt(String),
+    /// No identity here can decrypt it.
+    Decrypt(DecryptError),
+    Other(eyre::Report),
+}
+
+impl From<eyre::Report> for ReadError {
+    fn from(err: eyre::Report) -> Self {
+        Self::Other(err)
+    }
+}
+
+impl std::fmt::Display for ReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotEncrypted => write!(f, "the backup is not encrypted"),
+            Self::Corrupt(reason) => write!(f, "the encrypted backup is damaged: {reason}"),
+            Self::Decrypt(err) => write!(f, "{err}"),
+            Self::Other(err) => write!(f, "{err:#}"),
+        }
+    }
+}
+
+/// The encrypted payload of a filtered snapshot: every file under
+/// `snapshot` (none when there is no snapshot) plus the masked record.
+pub(crate) fn build(
+    repo: &HistoryRepo,
+    snapshot: Option<&str>,
+    checkpoint: &Checkpoint,
+    recipients: &[Box<dyn age::Recipient + Send>],
+) -> Result<Vec<u8>> {
+    let mut files = vec![];
+    if let Some(snapshot) = snapshot {
+        for entry in repo.ls_tree(snapshot)? {
+            let content = if entry.mode == "160000" {
+                entry.oid.clone().into_bytes()
+            } else {
+                repo.cat_object(&entry.oid)?
+            };
+            files.push(PayloadFile {
+                path: entry.path,
+                mode: entry.mode,
+                content: Bytes(content),
+            });
+        }
+    }
+    let mut checkpoint = checkpoint.clone();
+    checkpoint.tree.snapshot = None;
+    let payload = Payload {
+        format: BACKUP_FORMAT,
+        checkpoint,
+        files,
+    };
+    let serialized = rmp_serde::to_vec_named(&payload)?;
+    agecrypt::encrypt_bytes(&serialized, recipients)
+}
+
+/// The wrapper commit for an encrypted backup: `backup.toml` and
+/// `payload.age`, parentless, with a message that names only the
+/// checkpoint (the description is inside the payload).
+pub(crate) fn write_commit(
+    repo: &HistoryRepo,
+    header: &BackupHeader,
+    ciphertext: &[u8],
+) -> Result<String> {
+    let header_oid = repo.hash_blob(header.to_toml()?.as_bytes())?;
+    let payload_oid = repo.hash_blob(ciphertext)?;
+    let listing = format!(
+        "100644 blob {header_oid}\t{HEADER_PATH}\n100644 blob {payload_oid}\t{PAYLOAD_PATH}\n"
+    );
+    let tree = repo.mktree(&listing)?;
+    repo.commit_tree(
+        &tree,
+        vec![],
+        &format!("mise encrypted backup {}", header.checkpoint),
+    )
+}
+
+/// The header when `commit` has the encrypted layout; `None` for a
+/// plaintext backup.
+pub(crate) fn header_of(repo: &HistoryRepo, commit: &str) -> Result<Option<BackupHeader>> {
+    let Some((_, oid)) = repo.object_at(commit, HEADER_PATH)? else {
+        return Ok(None);
+    };
+    let bytes = repo.cat_object(&oid)?;
+    Ok(Some(BackupHeader::parse(&bytes)?))
+}
+
+/// Decrypts the payload of `commit` with this machine's identities.
+pub(crate) async fn read_payload(repo: &HistoryRepo, commit: &str) -> Result<Payload, ReadError> {
+    let Some((_, oid)) = repo.object_at(commit, PAYLOAD_PATH)? else {
+        return Err(ReadError::NotEncrypted);
+    };
+    let ciphertext = repo.cat_object(&oid)?;
+    let serialized = agecrypt::decrypt_bytes(&ciphertext)
+        .await
+        .map_err(|err| match err {
+            DecryptError::Corrupt(reason) => ReadError::Corrupt(reason),
+            other => ReadError::Decrypt(other),
+        })?;
+    let payload: Payload = rmp_serde::from_slice(&serialized)
+        .map_err(|err| ReadError::Corrupt(format!("unreadable payload: {err}")))?;
+    if payload.format != BACKUP_FORMAT {
+        return Err(ReadError::Corrupt(format!(
+            "payload format {} is newer than this mise understands",
+            payload.format
+        )));
+    }
+    Ok(payload)
+}
+
+/// Writes a decrypted payload as a local plaintext wrapper commit
+/// (`meta.json` + `snapshot/`), indistinguishable from a plaintext backup.
+pub(crate) fn materialize_payload(repo: &HistoryRepo, payload: &Payload) -> Result<String> {
+    let mut entries = vec![];
+    for file in &payload.files {
+        let oid = if file.mode == "160000" {
+            String::from_utf8(file.content.0.clone())?
+        } else {
+            repo.hash_blob(&file.content.0)?
+        };
+        entries.push((file.mode.clone(), oid, file.path.clone()));
+    }
+    let tree = repo.write_tree(&entries)?;
+    let mut checkpoint = payload.checkpoint.clone();
+    checkpoint.tree.snapshot = Some(tree.clone());
+    repo.write_checkpoint_commit(Some(&tree), &checkpoint, &BTreeMap::new())
+}
+
+/// Decrypts `commit` and materializes it; the local plaintext wrapper.
+pub(crate) async fn materialize(repo: &HistoryRepo, commit: &str) -> Result<String, ReadError> {
+    let payload = read_payload(repo, commit).await?;
+    Ok(materialize_payload(repo, &payload)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::system::history::checkpoint::test_checkpoint;
+
+    fn recipients_for(key: &age::x25519::Identity) -> Vec<Box<dyn age::Recipient + Send>> {
+        vec![Box::new(key.to_public())]
+    }
+
+    fn sample_snapshot(repo: &HistoryRepo) -> String {
+        let zshrc = repo.hash_blob(b"export EDITOR=vim\n").unwrap();
+        let script = repo.hash_blob(b"#!/bin/sh\necho hi\n").unwrap();
+        let link = repo.hash_blob(b".zshrc").unwrap();
+        repo.write_tree(&[
+            ("100644".into(), zshrc, "home/.zshrc".into()),
+            ("100755".into(), script, "home/bin/x".into()),
+            ("120000".into(), link, "home/link".into()),
+            (
+                "160000".into(),
+                "0123456789abcdef0123456789abcdef01234567".into(),
+                "home/repo".into(),
+            ),
+        ])
+        .unwrap()
+    }
+
+    fn listing(repo: &HistoryRepo, tree: &str) -> Vec<(String, String, Option<u64>, String)> {
+        repo.ls_tree(tree)
+            .unwrap()
+            .into_iter()
+            .map(|entry| (entry.mode, entry.oid, entry.size, entry.path))
+            .collect()
+    }
+
+    #[test]
+    fn header_round_trips_and_refuses_newer_formats() {
+        let checkpoint = test_checkpoint("u1", None);
+        let header = BackupHeader::new(&checkpoint, 2);
+        let text = header.to_toml().unwrap();
+        assert!(text.contains("encryption = \"age\""), "{text}");
+        assert_eq!(BackupHeader::parse(text.as_bytes()).unwrap(), header);
+        let newer = text.replace("format = 2", "format = 3");
+        let err = BackupHeader::parse(newer.as_bytes())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("upgrade mise"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn payload_round_trips_every_mode_through_git() {
+        if crate::git::plumbing_binary().is_none() {
+            return;
+        }
+        use age::secrecy::ExposeSecret;
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = HistoryRepo::open_or_init_in(tmp.path())
+            .unwrap()
+            .expect("git available");
+        let snapshot = sample_snapshot(&repo);
+        let mut checkpoint = test_checkpoint("u1", Some(&snapshot));
+        checkpoint.description = "secret description".into();
+        let key = age::x25519::Identity::generate();
+
+        let ciphertext = build(&repo, Some(&snapshot), &checkpoint, &recipients_for(&key)).unwrap();
+        let commit = write_commit(&repo, &BackupHeader::new(&checkpoint, 1), &ciphertext).unwrap();
+
+        // the wrapper holds exactly the two files, and nothing readable
+        let names: Vec<String> = repo
+            .ls_tree(&commit)
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect();
+        assert_eq!(names, vec![HEADER_PATH, PAYLOAD_PATH]);
+        let payload_oid = repo.object_at(&commit, PAYLOAD_PATH).unwrap().unwrap().1;
+        let raw = repo.cat_object(&payload_oid).unwrap();
+        assert!(!raw.windows(6).any(|w| w == b"EDITOR"));
+        assert!(!raw.windows(6).any(|w| w == b"secret"));
+        assert!(
+            repo.read_meta(&commit).is_err(),
+            "no meta.json in the clear"
+        );
+        let header = header_of(&repo, &commit).unwrap().unwrap();
+        assert_eq!(header.checkpoint, "u1");
+        assert_eq!(header.recipients, 1);
+
+        // without a key: refused, not silently empty
+        env::remove_var("MISE_AGE_KEY");
+        let no_key = materialize(&repo, &commit).await;
+        assert!(
+            matches!(no_key, Err(ReadError::Decrypt(DecryptError::NoIdentities))),
+            "{no_key:?}"
+        );
+
+        env::set_var("MISE_AGE_KEY", key.to_string().expose_secret());
+        let plain = materialize(&repo, &commit).await;
+        env::remove_var("MISE_AGE_KEY");
+        let plain = plain.unwrap();
+        let restored = repo.read_meta(&plain).unwrap();
+        assert_eq!(restored.description, "secret description");
+        let restored_snapshot = repo.object_at(&plain, "snapshot").unwrap().unwrap().1;
+        assert_eq!(
+            listing(&repo, &restored_snapshot),
+            listing(&repo, &snapshot)
+        );
+        assert_eq!(
+            restored_snapshot, snapshot,
+            "identical content, identical tree"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_tampered_payload_is_reported_as_damaged() {
+        if crate::git::plumbing_binary().is_none() {
+            return;
+        }
+        use age::secrecy::ExposeSecret;
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = HistoryRepo::open_or_init_in(tmp.path())
+            .unwrap()
+            .expect("git available");
+        let checkpoint = test_checkpoint("u2", None);
+        let key = age::x25519::Identity::generate();
+        let header = BackupHeader::new(&checkpoint, 1);
+        let commit = write_commit(&repo, &header, b"this is not an age file").unwrap();
+        env::set_var("MISE_AGE_KEY", key.to_string().expose_secret());
+        let result = read_payload(&repo, &commit).await;
+        env::remove_var("MISE_AGE_KEY");
+        assert!(matches!(result, Err(ReadError::Corrupt(_))), "{result:?}");
+
+        // a plaintext wrapper is not encrypted
+        let plain = repo
+            .write_checkpoint_commit(None, &checkpoint, &BTreeMap::new())
+            .unwrap();
+        assert!(header_of(&repo, &plain).unwrap().is_none());
+        assert!(matches!(
+            read_payload(&repo, &plain).await,
+            Err(ReadError::NotEncrypted)
+        ));
+    }
+
+    use crate::env;
+}

--- a/src/system/history/sync/encrypted.rs
+++ b/src/system/history/sync/encrypted.rs
@@ -462,16 +462,17 @@ mod tests {
         assert_eq!(header.recipients, 1);
 
         // without a key: refused, not silently empty
-        env::remove_var("MISE_AGE_KEY");
+        let mut environment = crate::test::EnvVarGuard::new();
+        environment.remove("MISE_AGE_KEY");
         let no_key = materialize(&repo, &commit).await;
         assert!(
             matches!(no_key, Err(ReadError::Decrypt(DecryptError::NoIdentities))),
             "{no_key:?}"
         );
 
-        env::set_var("MISE_AGE_KEY", key.to_string().expose_secret());
+        environment.set("MISE_AGE_KEY", key.to_string().expose_secret());
         let plain = materialize(&repo, &commit).await;
-        env::remove_var("MISE_AGE_KEY");
+        environment.remove("MISE_AGE_KEY");
         let plain = plain.unwrap();
         let restored = repo.read_meta(&plain).unwrap();
         assert_eq!(restored.description, "secret description");
@@ -500,9 +501,10 @@ mod tests {
         let key = age::x25519::Identity::generate();
         let header = BackupHeader::new(&checkpoint, 1);
         let commit = write_commit(&repo, &header, b"this is not an age file").unwrap();
-        env::set_var("MISE_AGE_KEY", key.to_string().expose_secret());
+        let mut environment = crate::test::EnvVarGuard::new();
+        environment.set("MISE_AGE_KEY", key.to_string().expose_secret());
         let result = read_payload(&repo, &commit).await;
-        env::remove_var("MISE_AGE_KEY");
+        environment.remove("MISE_AGE_KEY");
         assert!(matches!(result, Err(ReadError::Corrupt(_))), "{result:?}");
 
         // a plaintext wrapper is not encrypted
@@ -515,8 +517,6 @@ mod tests {
             Err(ReadError::NotEncrypted)
         ));
     }
-
-    use crate::env;
 }
 
 #[cfg(test)]

--- a/src/system/history/sync/encrypted.rs
+++ b/src/system/history/sync/encrypted.rs
@@ -176,7 +176,8 @@ fn validate_files(payload: &Payload) -> Result<()> {
             bail!("invalid or duplicate backup file path/mode");
         }
         if file.mode == "160000"
-            && !(file.content.0.len() == 40 && file.content.0.iter().all(u8::is_ascii_hexdigit))
+            && !(matches!(file.content.0.len(), 40 | 64)
+                && file.content.0.iter().all(u8::is_ascii_hexdigit))
         {
             bail!("invalid gitlink object id");
         }
@@ -543,6 +544,27 @@ mod validation_tests {
         assert!(
             validate_identity(&repo, &commit, &checkpoint.machine.id, "uuid", &changed).is_err()
         );
+    }
+
+    #[test]
+    fn gitlinks_accept_both_git_hash_formats() {
+        for (oid, valid) in [
+            ("a".repeat(40), true),
+            ("b".repeat(64), true),
+            ("a".repeat(41), false),
+            ("z".repeat(40), false),
+        ] {
+            let payload = Payload {
+                format: BACKUP_FORMAT,
+                checkpoint: test_checkpoint("uuid", None),
+                files: vec![PayloadFile {
+                    path: "home/repo".into(),
+                    mode: "160000".into(),
+                    content: Bytes(oid.into_bytes()),
+                }],
+            };
+            assert_eq!(validate_files(&payload).is_ok(), valid);
+        }
     }
 
     #[test]

--- a/src/system/history/sync/encrypted.rs
+++ b/src/system/history/sync/encrypted.rs
@@ -85,6 +85,7 @@ pub(crate) struct Payload {
     /// The masked record; `tree.snapshot` is meaningless off the machine
     /// and left empty.
     pub checkpoint: Checkpoint,
+    #[serde(deserialize_with = "bounded_files")]
     pub files: Vec<PayloadFile>,
 }
 
@@ -123,19 +124,102 @@ impl<'de> Deserialize<'de> for Bytes {
             fn visit_byte_buf<E: serde::de::Error>(self, v: Vec<u8>) -> Result<Bytes, E> {
                 Ok(Bytes(v))
             }
-            fn visit_seq<A: serde::de::SeqAccess<'de>>(
-                self,
-                mut seq: A,
-            ) -> Result<Bytes, A::Error> {
-                let mut out = Vec::with_capacity(seq.size_hint().unwrap_or(0));
-                while let Some(byte) = seq.next_element::<u8>()? {
-                    out.push(byte);
-                }
-                Ok(Bytes(out))
-            }
         }
         deserializer.deserialize_byte_buf(Visitor)
     }
+}
+
+const MAX_FILES: usize = 100_000;
+
+fn bounded_files<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<PayloadFile>, D::Error> {
+    struct Visitor;
+    impl<'de> serde::de::Visitor<'de> for Visitor {
+        type Value = Vec<PayloadFile>;
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("a bounded file list")
+        }
+        fn visit_seq<A: serde::de::SeqAccess<'de>>(
+            self,
+            mut seq: A,
+        ) -> Result<Self::Value, A::Error> {
+            if seq.size_hint().is_some_and(|n| n > MAX_FILES) {
+                return Err(serde::de::Error::custom("too many backup files"));
+            }
+            let mut files = Vec::new();
+            while let Some(file) = seq.next_element()? {
+                if files.len() == MAX_FILES {
+                    return Err(serde::de::Error::custom("too many backup files"));
+                }
+                files.push(file);
+            }
+            Ok(files)
+        }
+    }
+    deserializer.deserialize_seq(Visitor)
+}
+
+fn validate_files(payload: &Payload) -> Result<()> {
+    if payload.files.len() > MAX_FILES {
+        bail!("too many backup files");
+    }
+    let mut paths = std::collections::BTreeSet::new();
+    for file in &payload.files {
+        if !super::layout::is_safe_branch_path(&file.path)
+            || !matches!(
+                file.mode.as_str(),
+                "100644" | "100755" | "120000" | "160000"
+            )
+            || !paths.insert(file.path.as_str())
+        {
+            bail!("invalid or duplicate backup file path/mode");
+        }
+        if file.mode == "160000"
+            && !(file.content.0.len() == 40 && file.content.0.iter().all(u8::is_ascii_hexdigit))
+        {
+            bail!("invalid gitlink object id");
+        }
+    }
+    for path in &paths {
+        for (index, _) in path.match_indices('/') {
+            if paths.contains(&path[..index]) {
+                bail!("overlapping backup file paths");
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_identity(
+    repo: &HistoryRepo,
+    commit: &str,
+    machine: &str,
+    uuid: &str,
+    checkpoint: &Checkpoint,
+) -> Result<()> {
+    let header =
+        header_of(repo, commit)?.ok_or_else(|| eyre::eyre!("missing encrypted backup header"))?;
+    if header.machine.id != machine
+        || header.checkpoint != uuid
+        || header.machine != checkpoint.machine
+        || header.checkpoint != checkpoint.uuid
+        || header.created_at != checkpoint.created_at
+    {
+        bail!("encrypted backup identity does not match its header and ref");
+    }
+    Ok(())
+}
+
+pub(crate) async fn materialize_checked(
+    repo: &HistoryRepo,
+    commit: &str,
+    machine: &str,
+    uuid: &str,
+) -> Result<String, ReadError> {
+    let payload = read_payload(repo, commit).await?;
+    validate_identity(repo, commit, machine, uuid, &payload.checkpoint)?;
+    Ok(materialize_payload(repo, &payload)?)
 }
 
 /// Why an encrypted backup could not be read.
@@ -176,13 +260,20 @@ pub(crate) fn build(
     recipients: &[Box<dyn age::Recipient + Send>],
 ) -> Result<Vec<u8>> {
     let mut files = vec![];
+    let mut remaining = agecrypt::MAX_PLAINTEXT_BYTES;
     if let Some(snapshot) = snapshot {
         for entry in repo.ls_tree(snapshot)? {
+            if files.len() == MAX_FILES {
+                bail!("too many backup files");
+            }
             let content = if entry.mode == "160000" {
                 entry.oid.clone().into_bytes()
             } else {
-                repo.cat_object(&entry.oid)?
+                repo.cat_object_bounded(&entry.oid, remaining)?
             };
+            remaining = remaining
+                .checked_sub(content.len() as u64)
+                .ok_or_else(|| eyre::eyre!("backup exceeds size limit"))?;
             files.push(PayloadFile {
                 path: entry.path,
                 mode: entry.mode,
@@ -197,6 +288,7 @@ pub(crate) fn build(
         checkpoint,
         files,
     };
+    validate_files(&payload)?;
     let serialized = rmp_serde::to_vec_named(&payload)?;
     agecrypt::encrypt_bytes(&serialized, recipients)
 }
@@ -228,7 +320,7 @@ pub(crate) fn header_of(repo: &HistoryRepo, commit: &str) -> Result<Option<Backu
     let Some((_, oid)) = repo.object_at(commit, HEADER_PATH)? else {
         return Ok(None);
     };
-    let bytes = repo.cat_object(&oid)?;
+    let bytes = repo.cat_object_bounded(&oid, 64 * 1024)?;
     Ok(Some(BackupHeader::parse(&bytes)?))
 }
 
@@ -237,7 +329,7 @@ pub(crate) async fn read_payload(repo: &HistoryRepo, commit: &str) -> Result<Pay
     let Some((_, oid)) = repo.object_at(commit, PAYLOAD_PATH)? else {
         return Err(ReadError::NotEncrypted);
     };
-    let ciphertext = repo.cat_object(&oid)?;
+    let ciphertext = repo.cat_object_bounded(&oid, agecrypt::MAX_ENCRYPTED_BYTES)?;
     let serialized = agecrypt::decrypt_bytes(&ciphertext)
         .await
         .map_err(|err| match err {
@@ -252,12 +344,14 @@ pub(crate) async fn read_payload(repo: &HistoryRepo, commit: &str) -> Result<Pay
             payload.format
         )));
     }
+    validate_files(&payload)?;
     Ok(payload)
 }
 
 /// Writes a decrypted payload as a local plaintext wrapper commit
 /// (`meta.json` + `snapshot/`), indistinguishable from a plaintext backup.
 pub(crate) fn materialize_payload(repo: &HistoryRepo, payload: &Payload) -> Result<String> {
+    validate_files(payload)?;
     let mut entries = vec![];
     for file in &payload.files {
         let oid = if file.mode == "160000" {
@@ -274,6 +368,7 @@ pub(crate) fn materialize_payload(repo: &HistoryRepo, payload: &Payload) -> Resu
 }
 
 /// Decrypts `commit` and materializes it; the local plaintext wrapper.
+#[cfg(test)]
 pub(crate) async fn materialize(repo: &HistoryRepo, commit: &str) -> Result<String, ReadError> {
     let payload = read_payload(repo, commit).await?;
     Ok(materialize_payload(repo, &payload)?)
@@ -421,4 +516,58 @@ mod tests {
     }
 
     use crate::env;
+}
+
+#[cfg(test)]
+mod validation_tests {
+    use super::*;
+    use crate::system::history::checkpoint::test_checkpoint;
+
+    #[test]
+    fn refuses_mismatched_header_and_ref_before_materializing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = HistoryRepo::open_or_init_in(tmp.path()).unwrap().unwrap();
+        let checkpoint = test_checkpoint("uuid", None);
+        let header = BackupHeader::new(&checkpoint, 1);
+        let commit = write_commit(&repo, &header, b"irrelevant").unwrap();
+        assert!(
+            validate_identity(&repo, &commit, &checkpoint.machine.id, "uuid", &checkpoint).is_ok()
+        );
+        assert!(validate_identity(&repo, &commit, "other", "uuid", &checkpoint).is_err());
+        assert!(
+            validate_identity(&repo, &commit, &checkpoint.machine.id, "other", &checkpoint)
+                .is_err()
+        );
+        let mut changed = checkpoint.clone();
+        changed.created_at = "2020-01-01T00:00:00Z".into();
+        assert!(
+            validate_identity(&repo, &commit, &checkpoint.machine.id, "uuid", &changed).is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_unsafe_and_overlapping_paths_before_git_writes() {
+        let mut payload = Payload {
+            format: BACKUP_FORMAT,
+            checkpoint: test_checkpoint("uuid", None),
+            files: vec![],
+        };
+        for path in ["../outside", "home/.git/config", "home//file"] {
+            payload.files = vec![PayloadFile {
+                path: path.into(),
+                mode: "100644".into(),
+                content: Bytes(vec![]),
+            }];
+            assert!(validate_files(&payload).is_err());
+        }
+        payload.files = ["home/file", "home/file/child"]
+            .into_iter()
+            .map(|path| PayloadFile {
+                path: path.into(),
+                mode: "100644".into(),
+                content: Bytes(vec![]),
+            })
+            .collect();
+        assert!(validate_files(&payload).is_err());
+    }
 }

--- a/src/system/history/sync/files.rs
+++ b/src/system/history/sync/files.rs
@@ -10,6 +10,68 @@ use crate::{agecrypt, system::history::shadow::HistoryRepo};
 
 const MAGIC: &[u8] = b"mise-encrypted-file-v1\n";
 const CACHE: &str = "refs/mise-decrypted-files/";
+const INDEX: &str = ".mise-history/encrypted-files.json";
+
+#[derive(Serialize, Deserialize)]
+struct EncryptionIndex {
+    version: u32,
+    paths: BTreeSet<String>,
+}
+
+pub(crate) fn encrypted_paths(
+    repo: &HistoryRepo,
+    commit: Option<&str>,
+) -> Result<BTreeSet<String>> {
+    let Some(commit) = commit else {
+        return Ok(BTreeSet::new());
+    };
+    let Some((mode, oid)) = repo.object_at(commit, INDEX)? else {
+        return Ok(BTreeSet::new());
+    };
+    if mode != "100644" {
+        bail!("invalid encrypted-file index mode");
+    }
+    let index: EncryptionIndex =
+        serde_json::from_slice(&repo.cat_object_bounded(&oid, 16 * 1024 * 1024)?)?;
+    if index.version != 1
+        || index
+            .paths
+            .iter()
+            .any(|path| !layout::is_safe_branch_path(path) || control_file(path))
+    {
+        bail!("invalid encrypted-file index");
+    }
+    for path in &index.paths {
+        if repo.object_at(commit, path)?.is_none() {
+            bail!("encrypted file index names a missing file: {path}");
+        }
+    }
+    Ok(index.paths)
+}
+
+fn write_index(
+    repo: &HistoryRepo,
+    upstream: Option<&str>,
+    paths: BTreeSet<String>,
+    out: &mut BTreeMap<String, Option<Object>>,
+) -> Result<()> {
+    let object = if paths.is_empty() {
+        None
+    } else {
+        Some((
+            "100644".into(),
+            repo.hash_blob(&serde_json::to_vec(&EncryptionIndex { version: 1, paths })?)?,
+        ))
+    };
+    let previous = upstream
+        .map(|head| repo.object_at(head, INDEX))
+        .transpose()?
+        .flatten();
+    if previous != object {
+        out.insert(INDEX.into(), object);
+    }
+    Ok(())
+}
 
 #[derive(Serialize, Deserialize)]
 struct Envelope {
@@ -77,9 +139,8 @@ pub(crate) fn decrypt(
     object: &Object,
     interactive: bool,
 ) -> Result<Object> {
-    let Some(outer) = envelope(repo, object, agecrypt::MAX_ENCRYPTED_BYTES)? else {
-        return Ok(object.clone());
-    };
+    let outer = envelope(repo, object, agecrypt::MAX_ENCRYPTED_BYTES)?
+        .ok_or_else(|| eyre::eyre!("missing encrypted file envelope: {path}"))?;
     if control_file(path) {
         bail!("setup configuration itself cannot be encrypted: {path}");
     }
@@ -151,15 +212,14 @@ pub(crate) fn publication(
     let mut existing = BTreeMap::new();
     let mut protected = BTreeSet::new();
     if let Some(commit) = upstream {
-        for item in repo.ls_tree(commit)? {
-            if control_file(&item.path) || item.path.starts_with(".mise-history/") {
-                continue;
-            }
-            let object = (item.mode, item.oid);
-            if let Some(envelope) = envelope(repo, &object, agecrypt::MAX_ENCRYPTED_BYTES)? {
-                protected.insert(item.path.clone());
-                existing.insert(item.path, (object, envelope));
-            }
+        for path in encrypted_paths(repo, Some(commit))? {
+            let object = repo
+                .object_at(commit, &path)?
+                .ok_or_else(|| eyre::eyre!("encrypted file index names a missing file: {path}"))?;
+            let envelope = envelope(repo, &object, agecrypt::MAX_ENCRYPTED_BYTES)?
+                .ok_or_else(|| eyre::eyre!("missing encrypted file envelope: {path}"))?;
+            protected.insert(path.clone());
+            existing.insert(path, (object, envelope));
         }
     }
     for (path, file) in &shared.files {
@@ -178,6 +238,9 @@ pub(crate) fn publication(
         }
     }
     if protected.is_empty() {
+        if !existing.is_empty() {
+            write_index(repo, upstream, BTreeSet::new(), &mut out)?;
+        }
         return Ok(out);
     }
     let strings = crate::system::history::config::file_recipients()?;
@@ -207,16 +270,16 @@ pub(crate) fn publication(
                 .ok_or_else(|| eyre::eyre!("invalid encrypted-file recipient"))
         })
         .collect::<Result<_>>()?;
-    for path in protected {
-        let previous = existing.get(&path);
-        let current = if let Some(change) = changes.get(&path) {
+    for path in &protected {
+        let previous = existing.get(path);
+        let current = if let Some(change) = changes.get(path) {
             change.clone()
         } else if let Some((object, _)) = previous {
-            Some(decrypt(repo, &path, object, interactive)?)
+            Some(decrypt(repo, path, object, interactive)?)
         } else {
             shared
                 .files
-                .get(&path)
+                .get(path)
                 .map(|file| (file.mode.clone(), file.oid.clone()))
         };
         let Some(current) = current else {
@@ -224,16 +287,29 @@ pub(crate) fn publication(
         };
         if let Some((object, envelope)) = previous
             && envelope.scheme == scheme
-            && decrypt(repo, &path, object, interactive)? == current
+            && decrypt(repo, path, object, interactive)? == current
         {
-            out.remove(&path);
+            out.remove(path);
         } else {
             out.insert(
                 path.clone(),
-                Some(encrypt(repo, &path, &current, &scheme, &recipients)?),
+                Some(encrypt(repo, path, &current, &scheme, &recipients)?),
             );
         }
     }
+    let mut indexed: BTreeSet<_> = existing
+        .keys()
+        .filter(|path| protected.contains(*path))
+        .cloned()
+        .collect();
+    for (path, object) in &out {
+        if protected.contains(path) && object.is_some() {
+            indexed.insert(path.clone());
+        } else {
+            indexed.remove(path);
+        }
+    }
+    write_index(repo, upstream, indexed, &mut out)?;
     if out
         .iter()
         .any(|(p, o)| !p.starts_with(".mise-history/") && o.is_some())
@@ -248,6 +324,18 @@ pub(crate) fn publication(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn plaintext_magic_is_not_an_encryption_declaration() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = HistoryRepo::open_or_init_in(tmp.path()).unwrap().unwrap();
+        let oid = repo.hash_blob(MAGIC).unwrap();
+        let tree = repo
+            .write_tree(&[("100644".into(), oid.clone(), "tracked/home/literal".into())])
+            .unwrap();
+        let upstream = super::super::reconcile::upstream(&repo, Some(&tree)).unwrap();
+        assert_eq!(upstream.files["tracked/home/literal"].1, oid);
+        assert!(encrypted_paths(&repo, Some(&tree)).unwrap().is_empty());
+    }
     use super::*;
 
     #[test]
@@ -272,15 +360,19 @@ mod tests {
 
     #[test]
     fn envelope_preserves_modes_and_binds_path_and_scheme() {
+        use age::secrecy::ExposeSecret;
         let tmp = tempfile::tempdir().unwrap();
         let repo = HistoryRepo::open_or_init_in(tmp.path()).unwrap().unwrap();
         let key = age::x25519::Identity::generate();
+        let mut environment = crate::test::EnvVarGuard::new();
+        environment.set("MISE_AGE_KEY", key.to_string().expose_secret());
         let recipients: Vec<Box<dyn age::Recipient + Send>> = vec![Box::new(key.to_public())];
         for mode in ["100644", "100755", "120000"] {
             let object = (mode.into(), repo.hash_blob(b"private contents").unwrap());
             let encrypted =
                 encrypt(&repo, "tracked/home/secret", &object, "scheme", &recipients).unwrap();
             assert_eq!(encrypted.0, "100644");
+            repo.delete_ref(&format!("{CACHE}{}", encrypted.1)).unwrap();
             let wire = repo.cat_object(&encrypted.1).unwrap();
             assert!(!wire.windows(16).any(|w| w == b"private contents"));
             assert_eq!(

--- a/src/system/history/sync/files.rs
+++ b/src/system/history/sync/files.rs
@@ -40,9 +40,12 @@ fn control_file(path: &str) -> bool {
             && (path.starts_with("config.") || path.starts_with("mise.")))
 }
 
-fn envelope(repo: &HistoryRepo, object: &Object) -> Result<Option<Envelope>> {
-    // Bound remote data before decoding its envelope.
-    let bytes = repo.cat_object_bounded(&object.1, agecrypt::MAX_ENCRYPTED_BYTES)?;
+fn envelope(repo: &HistoryRepo, object: &Object, limit: u64) -> Result<Option<Envelope>> {
+    if !repo.blob_starts_with(&object.1, MAGIC)? {
+        return Ok(None);
+    }
+    // Only encrypted envelopes have this limit; do not change plaintext sync.
+    let bytes = repo.cat_object_bounded(&object.1, limit)?;
     let Some(body) = bytes.strip_prefix(MAGIC) else {
         return Ok(None);
     };
@@ -70,7 +73,7 @@ pub(crate) fn decrypt(
     object: &Object,
     interactive: bool,
 ) -> Result<Object> {
-    let Some(outer) = envelope(repo, object)? else {
+    let Some(outer) = envelope(repo, object, agecrypt::MAX_ENCRYPTED_BYTES)? else {
         return Ok(object.clone());
     };
     if control_file(path) {
@@ -149,7 +152,7 @@ pub(crate) fn publication(
                 continue;
             }
             let object = (item.mode, item.oid);
-            if let Some(envelope) = envelope(repo, &object)? {
+            if let Some(envelope) = envelope(repo, &object, agecrypt::MAX_ENCRYPTED_BYTES)? {
                 protected.insert(item.path.clone());
                 existing.insert(item.path, (object, envelope));
             }
@@ -177,7 +180,14 @@ pub(crate) fn publication(
     if strings.is_empty() {
         bail!("encrypted dotfiles require [history.encryption].recipients; nothing was published");
     }
-    if existing.is_empty()
+    let mut normalized = strings.clone();
+    normalized.sort();
+    normalized.dedup();
+    let scheme = crate::hash::hash_sha256_to_str(&normalized.join("\n"));
+    if (existing.is_empty()
+        || existing
+            .values()
+            .any(|(_, envelope)| envelope.scheme != scheme))
         && strings
             .iter()
             .all(|s| s.parse::<age::plugin::Recipient>().is_ok())
@@ -186,10 +196,6 @@ pub(crate) fn publication(
             "hardware-only file recipients: device loss can make these files unrecoverable; add an independent recovery recipient"
         );
     }
-    let mut normalized = strings.clone();
-    normalized.sort();
-    normalized.dedup();
-    let scheme = crate::hash::hash_sha256_to_str(&normalized.join("\n"));
     let recipients: Vec<_> = strings
         .iter()
         .map(|s| {
@@ -241,6 +247,21 @@ mod tests {
     use super::*;
 
     #[test]
+    fn plaintext_bypasses_envelope_limit_but_ciphertext_does_not() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = HistoryRepo::open_or_init_in(tmp.path()).unwrap().unwrap();
+        for bytes in [
+            b"".as_slice(),
+            b"ordinary plaintext longer than the envelope limit".as_slice(),
+        ] {
+            let object = ("100644".into(), repo.hash_blob(bytes).unwrap());
+            assert!(envelope(&repo, &object, 4).unwrap().is_none());
+        }
+        let object = ("100644".into(), repo.hash_blob(MAGIC).unwrap());
+        assert!(envelope(&repo, &object, 4).is_err());
+    }
+
+    #[test]
     fn envelope_preserves_modes_and_binds_path_and_scheme() {
         let tmp = tempfile::tempdir().unwrap();
         let repo = HistoryRepo::open_or_init_in(tmp.path()).unwrap().unwrap();
@@ -258,7 +279,9 @@ mod tests {
                 object
             );
             assert!(decrypt(&repo, "tracked/home/other", &encrypted, false).is_err());
-            let mut outer = envelope(&repo, &encrypted).unwrap().unwrap();
+            let mut outer = envelope(&repo, &encrypted, agecrypt::MAX_ENCRYPTED_BYTES)
+                .unwrap()
+                .unwrap();
             outer.scheme = "forged".into();
             let inner = Plaintext {
                 path: outer.path.clone(),

--- a/src/system/history/sync/files.rs
+++ b/src/system/history/sync/files.rs
@@ -203,7 +203,7 @@ pub(crate) fn publication(
     let recipients: Vec<_> = strings
         .iter()
         .map(|s| {
-            agecrypt::parse_recipient(s)?
+            agecrypt::parse_recipient_mode(s, interactive)?
                 .ok_or_else(|| eyre::eyre!("invalid encrypted-file recipient"))
         })
         .collect::<Result<_>>()?;

--- a/src/system/history/sync/files.rs
+++ b/src/system/history/sync/files.rs
@@ -1,0 +1,280 @@
+//! Encryption at the publication boundary. Reconciliation only sees local
+//! plaintext objects; no plaintext comparison hashes enter the shared tree.
+use std::collections::{BTreeMap, BTreeSet};
+
+use eyre::{Result, WrapErr, bail};
+use serde::{Deserialize, Serialize};
+
+use super::{encrypted::Bytes, layout, reconcile::Object, share::ShareReport};
+use crate::{agecrypt, system::history::shadow::HistoryRepo};
+
+const MAGIC: &[u8] = b"mise-encrypted-file-v1\n";
+const CACHE: &str = "refs/mise-decrypted-files/";
+
+#[derive(Serialize, Deserialize)]
+struct Envelope {
+    path: String,
+    mode: String,
+    scheme: String,
+    ciphertext: Bytes,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Plaintext {
+    path: String,
+    mode: String,
+    scheme: String,
+    content: Bytes,
+}
+
+fn control_file(path: &str) -> bool {
+    if path.starts_with(".mise-history/") {
+        return true;
+    }
+    if path.starts_with("sources/") || path.starts_with("tracked/") {
+        return false;
+    }
+    (path.starts_with("conf.d/") && path.ends_with(".toml"))
+        || (!path.contains('/')
+            && path.ends_with(".toml")
+            && (path.starts_with("config.") || path.starts_with("mise.")))
+}
+
+fn envelope(repo: &HistoryRepo, object: &Object) -> Result<Option<Envelope>> {
+    // Bound remote data before decoding its envelope.
+    let bytes = repo.cat_object_bounded(&object.1, agecrypt::MAX_ENCRYPTED_BYTES)?;
+    let Some(body) = bytes.strip_prefix(MAGIC) else {
+        return Ok(None);
+    };
+    Ok(Some(
+        rmp_serde::from_slice(body).wrap_err("invalid encrypted file envelope")?,
+    ))
+}
+
+fn validate(path: &str, outer: &Envelope, inner: &Plaintext) -> Result<()> {
+    if outer.path != path
+        || inner.path != path
+        || inner.mode != outer.mode
+        || inner.scheme != outer.scheme
+        || !layout::is_safe_branch_path(path)
+        || !matches!(inner.mode.as_str(), "100644" | "100755" | "120000")
+    {
+        bail!("encrypted file does not match its path or mode: {path}");
+    }
+    Ok(())
+}
+
+pub(crate) fn decrypt(
+    repo: &HistoryRepo,
+    path: &str,
+    object: &Object,
+    interactive: bool,
+) -> Result<Object> {
+    let Some(outer) = envelope(repo, object)? else {
+        return Ok(object.clone());
+    };
+    if control_file(path) {
+        bail!("setup configuration itself cannot be encrypted: {path}");
+    }
+    let cache_ref = format!("{CACHE}{}", object.1);
+    let bytes = match repo.ref_oid(&cache_ref)? {
+        Some(oid) => repo.cat_object_bounded(&oid, agecrypt::MAX_PLAINTEXT_BYTES)?,
+        None => agecrypt::decrypt_sync(&outer.ciphertext.0, interactive)
+            .wrap_err_with(|| format!("cannot unlock {path}; run mise bootstrap dotfiles pull interactively with a matching age identity"))?,
+    };
+    let inner: Plaintext =
+        rmp_serde::from_slice(&bytes).wrap_err("invalid encrypted file payload")?;
+    validate(path, &outer, &inner)?;
+    let oid = repo.hash_blob(&inner.content.0)?;
+    let cached = repo.hash_blob(&bytes)?;
+    if repo.ref_oid(&cache_ref)?.is_none() {
+        repo.update_ref(&cache_ref, &cached, None)?;
+    }
+    Ok((inner.mode, oid))
+}
+
+fn encrypt(
+    repo: &HistoryRepo,
+    path: &str,
+    object: &Object,
+    scheme: &str,
+    recipients: &[Box<dyn age::Recipient + Send>],
+) -> Result<Object> {
+    if control_file(path) {
+        bail!("encrypt an external dotfile source instead of configuration: {path}");
+    }
+    if !matches!(object.0.as_str(), "100644" | "100755" | "120000") {
+        bail!("unsupported encrypted file mode: {path}");
+    }
+    let inner = Plaintext {
+        path: path.into(),
+        mode: object.0.clone(),
+        scheme: scheme.into(),
+        content: Bytes(repo.cat_object_bounded(&object.1, agecrypt::MAX_PLAINTEXT_BYTES)?),
+    };
+    let bytes = rmp_serde::to_vec_named(&inner)?;
+    let outer = Envelope {
+        path: path.into(),
+        mode: object.0.clone(),
+        scheme: scheme.into(),
+        ciphertext: Bytes(agecrypt::encrypt_bytes(&bytes, recipients)?),
+    };
+    let mut encoded = MAGIC.to_vec();
+    encoded.extend(rmp_serde::to_vec_named(&outer)?);
+    if encoded.len() as u64 > agecrypt::MAX_ENCRYPTED_BYTES {
+        bail!("encrypted file exceeds the size limit: {path}");
+    }
+    let oid = repo.hash_blob(&encoded)?;
+    // A publisher already has the plaintext, including on hardware-only
+    // setups. Keep it locally so the next sync needs no hardware operation.
+    repo.update_ref(&format!("{CACHE}{oid}"), &repo.hash_blob(&bytes)?, None)?;
+    Ok(("100644".into(), oid))
+}
+
+/// Turn reconciled plaintext changes into a publishable tree delta, including
+/// recipient rotation for unchanged files. Ciphertext is never a merge base.
+pub(crate) fn publication(
+    repo: &HistoryRepo,
+    upstream: Option<&str>,
+    shared: &ShareReport,
+    changes: &BTreeMap<String, Option<Object>>,
+    interactive: bool,
+) -> Result<BTreeMap<String, Option<Object>>> {
+    let mut out = changes.clone();
+    let mut existing = BTreeMap::new();
+    let mut protected = BTreeSet::new();
+    if let Some(commit) = upstream {
+        for item in repo.ls_tree(commit)? {
+            if control_file(&item.path) || item.path.starts_with(".mise-history/") {
+                continue;
+            }
+            let object = (item.mode, item.oid);
+            if let Some(envelope) = envelope(repo, &object)? {
+                protected.insert(item.path.clone());
+                existing.insert(item.path, (object, envelope));
+            }
+        }
+    }
+    for (path, file) in &shared.files {
+        if file.encrypt {
+            protected.insert(path.clone());
+        } else if file.encrypt_explicit {
+            protected.remove(path);
+            if !changes.contains_key(path)
+                && let Some((object, _)) = existing.get(path)
+            {
+                out.insert(
+                    path.clone(),
+                    Some(decrypt(repo, path, object, interactive)?),
+                );
+            }
+        }
+    }
+    if protected.is_empty() {
+        return Ok(out);
+    }
+    let strings = crate::system::history::config::file_recipients()?;
+    if strings.is_empty() {
+        bail!("encrypted dotfiles require [history.encryption].recipients; nothing was published");
+    }
+    if existing.is_empty()
+        && strings
+            .iter()
+            .all(|s| s.parse::<age::plugin::Recipient>().is_ok())
+    {
+        warn!(
+            "hardware-only file recipients: device loss can make these files unrecoverable; add an independent recovery recipient"
+        );
+    }
+    let mut normalized = strings.clone();
+    normalized.sort();
+    normalized.dedup();
+    let scheme = crate::hash::hash_sha256_to_str(&normalized.join("\n"));
+    let recipients: Vec<_> = strings
+        .iter()
+        .map(|s| {
+            agecrypt::parse_recipient(s)?
+                .ok_or_else(|| eyre::eyre!("invalid encrypted-file recipient"))
+        })
+        .collect::<Result<_>>()?;
+    for path in protected {
+        let previous = existing.get(&path);
+        let current = if let Some(change) = changes.get(&path) {
+            change.clone()
+        } else if let Some((object, _)) = previous {
+            Some(decrypt(repo, &path, object, interactive)?)
+        } else {
+            shared
+                .files
+                .get(&path)
+                .map(|file| (file.mode.clone(), file.oid.clone()))
+        };
+        let Some(current) = current else {
+            continue;
+        };
+        if let Some((object, envelope)) = previous
+            && envelope.scheme == scheme
+            && decrypt(repo, &path, object, interactive)? == current
+        {
+            out.remove(&path);
+        } else {
+            out.insert(
+                path.clone(),
+                Some(encrypt(repo, &path, &current, &scheme, &recipients)?),
+            );
+        }
+    }
+    if out
+        .iter()
+        .any(|(p, o)| !p.starts_with(".mise-history/") && o.is_some())
+    {
+        out.insert(
+            layout::MARKER_PATH.into(),
+            Some(("100644".into(), repo.hash_blob(b"format = 2\n")?)),
+        );
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_preserves_modes_and_binds_path_and_scheme() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = HistoryRepo::open_or_init_in(tmp.path()).unwrap().unwrap();
+        let key = age::x25519::Identity::generate();
+        let recipients: Vec<Box<dyn age::Recipient + Send>> = vec![Box::new(key.to_public())];
+        for mode in ["100644", "100755", "120000"] {
+            let object = (mode.into(), repo.hash_blob(b"private contents").unwrap());
+            let encrypted =
+                encrypt(&repo, "tracked/home/secret", &object, "scheme", &recipients).unwrap();
+            assert_eq!(encrypted.0, "100644");
+            let wire = repo.cat_object(&encrypted.1).unwrap();
+            assert!(!wire.windows(16).any(|w| w == b"private contents"));
+            assert_eq!(
+                decrypt(&repo, "tracked/home/secret", &encrypted, false).unwrap(),
+                object
+            );
+            assert!(decrypt(&repo, "tracked/home/other", &encrypted, false).is_err());
+            let mut outer = envelope(&repo, &encrypted).unwrap().unwrap();
+            outer.scheme = "forged".into();
+            let inner = Plaintext {
+                path: outer.path.clone(),
+                mode: mode.into(),
+                scheme: "scheme".into(),
+                content: Bytes(vec![]),
+            };
+            assert!(validate("tracked/home/secret", &outer, &inner).is_err());
+        }
+    }
+
+    #[test]
+    fn refuses_encryption_of_control_configuration() {
+        assert!(control_file("config.toml"));
+        assert!(control_file("conf.d/tools.toml"));
+        assert!(!control_file("templates/app.toml"));
+        assert!(!control_file("tracked/home/config.toml"));
+    }
+}

--- a/src/system/history/sync/files.rs
+++ b/src/system/history/sync/files.rs
@@ -41,6 +41,10 @@ fn control_file(path: &str) -> bool {
 }
 
 fn envelope(repo: &HistoryRepo, object: &Object, limit: u64) -> Result<Option<Envelope>> {
+    // A gitlink names a commit in another repository, not a readable blob.
+    if object.0 == "160000" {
+        return Ok(None);
+    }
     if !repo.blob_starts_with(&object.1, MAGIC)? {
         return Ok(None);
     }
@@ -261,6 +265,9 @@ mod tests {
         }
         let object = ("100644".into(), repo.hash_blob(MAGIC).unwrap());
         assert!(envelope(&repo, &object, 4).is_err());
+        // The referenced submodule commit need not exist in the setup repo.
+        let gitlink = ("160000".into(), "a".repeat(40));
+        assert!(envelope(&repo, &gitlink, 4).unwrap().is_none());
     }
 
     #[test]

--- a/src/system/history/sync/files.rs
+++ b/src/system/history/sync/files.rs
@@ -208,6 +208,24 @@ pub(crate) fn publication(
     changes: &BTreeMap<String, Option<Object>>,
     interactive: bool,
 ) -> Result<BTreeMap<String, Option<Object>>> {
+    publication_with(
+        repo,
+        upstream,
+        shared,
+        changes,
+        interactive,
+        crate::system::history::config::file_recipients,
+    )
+}
+
+fn publication_with(
+    repo: &HistoryRepo,
+    upstream: Option<&str>,
+    shared: &ShareReport,
+    changes: &BTreeMap<String, Option<Object>>,
+    interactive: bool,
+    configured_recipients: impl FnOnce() -> Result<Vec<String>>,
+) -> Result<BTreeMap<String, Option<Object>>> {
     let mut out = changes.clone();
     let mut existing = BTreeMap::new();
     let mut protected = BTreeSet::new();
@@ -243,7 +261,7 @@ pub(crate) fn publication(
         }
         return Ok(out);
     }
-    let strings = crate::system::history::config::file_recipients()?;
+    let strings = configured_recipients()?;
     if strings.is_empty() {
         bail!("encrypted dotfiles require [history.encryption].recipients; nothing was published");
     }
@@ -263,13 +281,9 @@ pub(crate) fn publication(
             "hardware-only file recipients: device loss can make these files unrecoverable; add an independent recovery recipient"
         );
     }
-    let recipients: Vec<_> = strings
-        .iter()
-        .map(|s| {
-            agecrypt::parse_recipient_mode(s, interactive)?
-                .ok_or_else(|| eyre::eyre!("invalid encrypted-file recipient"))
-        })
-        .collect::<Result<_>>()?;
+    // Reusing cached ciphertext requires no recipient plugin or hardware.
+    // Resolve recipients only if a file actually needs fresh encryption.
+    let mut recipients = None;
     for path in &protected {
         let previous = existing.get(path);
         let current = if let Some(change) = changes.get(path) {
@@ -291,9 +305,21 @@ pub(crate) fn publication(
         {
             out.remove(path);
         } else {
+            let recipients = match &recipients {
+                Some(recipients) => recipients,
+                None => recipients.insert(
+                    strings
+                        .iter()
+                        .map(|s| {
+                            agecrypt::parse_recipient_mode(s, interactive)?
+                                .ok_or_else(|| eyre::eyre!("invalid encrypted-file recipient"))
+                        })
+                        .collect::<Result<Vec<_>>>()?,
+                ),
+            };
             out.insert(
                 path.clone(),
-                Some(encrypt(repo, path, &current, &scheme, &recipients)?),
+                Some(encrypt(repo, path, &current, &scheme, recipients)?),
             );
         }
     }
@@ -324,6 +350,45 @@ pub(crate) fn publication(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn unchanged_ciphertext_does_not_initialize_recipients() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = HistoryRepo::open_or_init_in(tmp.path()).unwrap().unwrap();
+        let key = age::x25519::Identity::generate();
+        let recipients: Vec<Box<dyn age::Recipient + Send>> = vec![Box::new(key.to_public())];
+        // Parsing this recipient would fail. Cached content with the same
+        // scheme must not parse recipients at all, as with a hardware plugin.
+        let configured = "unavailable-plugin-recipient";
+        let scheme = crate::hash::hash_sha256_to_str(configured);
+        let path = "tracked/home/secret";
+        let object = ("100644".into(), repo.hash_blob(b"secret").unwrap());
+        let encrypted = encrypt(&repo, path, &object, &scheme, &recipients).unwrap();
+        let mut delta = BTreeMap::from([(path.to_string(), Some(encrypted))]);
+        write_index(&repo, None, BTreeSet::from([path.to_string()]), &mut delta).unwrap();
+        let tree = repo
+            .compose(
+                &repo.empty_object("tree").unwrap(),
+                &delta
+                    .into_iter()
+                    .map(|(path, object)| crate::system::history::shadow::Overlay { path, object })
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
+        let plain = ("100644".into(), repo.hash_blob(b"new plaintext").unwrap());
+        let changes = BTreeMap::from([("tracked/home/plain".into(), Some(plain.clone()))]);
+        let result = publication_with(
+            &repo,
+            Some(&tree),
+            &ShareReport::default(),
+            &changes,
+            false,
+            || Ok(vec![configured.into()]),
+        )
+        .unwrap();
+        assert_eq!(result.get("tracked/home/plain"), Some(&Some(plain)));
+        assert!(!result.contains_key(path));
+    }
+
     #[test]
     fn plaintext_magic_is_not_an_encryption_declaration() {
         let tmp = tempfile::tempdir().unwrap();

--- a/src/system/history/sync/files.rs
+++ b/src/system/history/sync/files.rs
@@ -250,9 +250,11 @@ mod tests {
     fn plaintext_bypasses_envelope_limit_but_ciphertext_does_not() {
         let tmp = tempfile::tempdir().unwrap();
         let repo = HistoryRepo::open_or_init_in(tmp.path()).unwrap().unwrap();
+        let larger_than_pipe = vec![b'x'; 128 * 1024];
         for bytes in [
             b"".as_slice(),
             b"ordinary plaintext longer than the envelope limit".as_slice(),
+            larger_than_pipe.as_slice(),
         ] {
             let object = ("100644".into(), repo.hash_blob(bytes).unwrap());
             assert!(envelope(&repo, &object, 4).unwrap().is_none());

--- a/src/system/history/sync/format.rs
+++ b/src/system/history/sync/format.rs
@@ -44,10 +44,10 @@ impl RepoState {
     /// Fails for a format this mise does not understand.
     pub(crate) fn check(&self) -> Result<()> {
         if let Self::Marked(format) = self
-            && *format != FORMAT
+            && !matches!(*format, 1 | 2)
         {
             bail!(
-                "this setup repository uses format {format}; upgrade mise (this version supports {FORMAT})"
+                "this setup repository uses format {format}; upgrade mise (this version supports formats 1 and 2)"
             );
         }
         Ok(())

--- a/src/system/history/sync/machines.rs
+++ b/src/system/history/sync/machines.rs
@@ -57,13 +57,19 @@ fn fetched(repo: &HistoryRepo) -> Result<BTreeMap<String, Vec<Fetched>>> {
         };
         live.insert(commit.clone());
         let item = match encrypted::header_of(repo, &commit) {
-            Ok(Some(header)) => Fetched {
-                uuid: uuid.to_string(),
-                commit,
-                machine_name: header.machine.name,
-                created_at: header.created_at,
-                plain: None,
-            },
+            Ok(Some(header)) if header.machine.id == machine_id && header.checkpoint == uuid => {
+                Fetched {
+                    uuid: uuid.to_string(),
+                    commit,
+                    machine_name: header.machine.name,
+                    created_at: header.created_at,
+                    plain: None,
+                }
+            }
+            Ok(Some(_)) => {
+                debug!("history: skipping mismatched backup {name}");
+                continue;
+            }
             Ok(None) => match repo.read_meta(&commit) {
                 Ok(mut checkpoint) => {
                     // the snapshot is the wrapper commit's own `snapshot/`
@@ -168,7 +174,12 @@ pub(crate) fn any_encrypted(repo: &HistoryRepo, except_machine: &str) -> Result<
 /// A machine's fetched checkpoints, oldest first, numbered from 1. An
 /// encrypted checkpoint is decrypted here (once; the plaintext copy is
 /// kept locally), so every entry returned can be rolled back to.
-pub(crate) async fn entries(repo: &HistoryRepo, machine: &str) -> Result<(Machine, Vec<Entry>)> {
+pub(crate) async fn resolve(
+    repo: &HistoryRepo,
+    machine: &str,
+    spec: &str,
+    path: Option<&str>,
+) -> Result<Entry> {
     let fetched = fetched(repo)?;
     let matching: Vec<(&String, &Vec<Fetched>)> = fetched
         .iter()
@@ -197,30 +208,71 @@ pub(crate) async fn entries(repo: &HistoryRepo, machine: &str) -> Result<(Machin
         .last()
         .map(|entry| entry.machine_name.clone())
         .unwrap_or_else(|| id.clone());
-    let mut entries = vec![];
-    for (index, item) in items.iter().enumerate() {
-        let (commit, checkpoint) = match &item.plain {
-            Some(checkpoint) => (item.commit.clone(), checkpoint.clone()),
-            None => {
-                let plain = materialized(repo, id, item, &name).await?;
-                let mut checkpoint = repo.read_meta(&plain)?;
-                checkpoint.tree.snapshot = repo.object_at(&plain, "snapshot")?.map(|(_, oid)| oid);
-                (plain, checkpoint)
-            }
+    let candidates: Vec<usize> = if let Some(rest) = spec.strip_prefix("latest") {
+        let back: usize = if rest.is_empty() {
+            0
+        } else {
+            rest.strip_prefix('~')
+                .and_then(|s| s.parse().ok())
+                .ok_or_else(|| eyre::eyre!("invalid checkpoint reference {spec:?}"))?
         };
-        entries.push(Entry {
-            id: index as u64 + 1,
-            commit,
-            checkpoint,
-        });
+        if path.is_some() {
+            // Path-scoped latest must inspect changes, which are encrypted.
+            let mut matched = 0;
+            for index in (0..items.len()).rev() {
+                let entry = entry(repo, id, &items[index], &name, index).await?;
+                if entry.checkpoint.changes.touches(path.unwrap_or_default()) {
+                    if matched == back {
+                        return Ok(entry);
+                    }
+                    matched += 1;
+                }
+            }
+            bail!("no history checkpoint {spec} for the requested path");
+        }
+        (0..items.len()).rev().nth(back).into_iter().collect()
+    } else if let Ok(number) = spec.parse::<usize>() {
+        number
+            .checked_sub(1)
+            .filter(|index| *index < items.len())
+            .into_iter()
+            .collect()
+    } else {
+        items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| item.uuid.starts_with(spec))
+            .map(|(index, _)| index)
+            .collect()
+    };
+    match candidates.as_slice() {
+        [index] => entry(repo, id, &items[*index], &name, *index).await,
+        [] => bail!("no history checkpoint matches {spec:?}"),
+        _ => bail!("{spec:?} matches more than one checkpoint; use a longer prefix"),
     }
-    Ok((
-        Machine {
-            id: id.clone(),
-            name,
-        },
-        entries,
-    ))
+}
+
+async fn entry(
+    repo: &HistoryRepo,
+    id: &str,
+    item: &Fetched,
+    name: &str,
+    index: usize,
+) -> Result<Entry> {
+    let (commit, checkpoint) = match &item.plain {
+        Some(checkpoint) => (item.commit.clone(), checkpoint.clone()),
+        None => {
+            let plain = materialized(repo, id, item, name).await?;
+            let mut checkpoint = repo.read_meta(&plain)?;
+            checkpoint.tree.snapshot = repo.object_at(&plain, "snapshot")?.map(|(_, oid)| oid);
+            (plain, checkpoint)
+        }
+    };
+    Ok(Entry {
+        id: index as u64 + 1,
+        commit,
+        checkpoint,
+    })
 }
 
 /// The local plaintext wrapper of an encrypted ref: the one kept from an
@@ -233,9 +285,11 @@ async fn materialized(
 ) -> Result<String> {
     let plain_ref = format!("{PLAIN_PREFIX}{machine_id}/{}", item.commit);
     if let Some(commit) = repo.ref_oid(&plain_ref)? {
+        let checkpoint = repo.read_meta(&commit)?;
+        encrypted::validate_identity(repo, &item.commit, machine_id, &item.uuid, &checkpoint)?;
         return Ok(commit);
     }
-    match encrypted::materialize(repo, &item.commit).await {
+    match encrypted::materialize_checked(repo, &item.commit, machine_id, &item.uuid).await {
         Ok(commit) => {
             if let Err(err) = repo.update_ref(&plain_ref, &commit, None) {
                 debug!("history: keeping the decrypted backup {plain_ref}: {err}");

--- a/src/system/history/sync/machines.rs
+++ b/src/system/history/sync/machines.rs
@@ -2,29 +2,52 @@
 //! listed for `mise bootstrap dotfiles machines`, and readable as checkpoint entries
 //! so `rollback --to <machine>/<ref>` recovers their files. Their operation
 //! journals are data only: never inverted, replayed, or executed.
+//!
+//! An encrypted ref is listed from its header alone (machine, time, count);
+//! its content is decrypted only when a checkpoint of that machine is
+//! resolved, once, into a local plaintext wrapper under
+//! `refs/machines-plain/<id>/<remote commit>`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use eyre::{Result, bail};
 use serde::Serialize;
 
-use super::network::MACHINES_PREFIX;
+use super::encrypted::{self, ReadError};
+use super::network::{MACHINES_PREFIX, PLAIN_PREFIX};
+use crate::agecrypt::DecryptError;
 use crate::system::history::shadow::HistoryRepo;
-use crate::system::history::store::{Entry, Machine};
+use crate::system::history::store::{Checkpoint, Entry, Machine};
 
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct MachineInfo {
     pub id: String,
     pub name: String,
     pub checkpoints: usize,
+    /// How many of the checkpoints are encrypted (for this machine: all of
+    /// them when the connection encrypts, else none).
+    pub encrypted: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub latest: Option<String>,
     /// This machine (its refs are local checkpoints, not fetched ones).
     pub this: bool,
 }
 
-fn fetched(repo: &HistoryRepo) -> Result<BTreeMap<String, Vec<(String, Entry)>>> {
-    let mut by_machine: BTreeMap<String, Vec<(String, Entry)>> = BTreeMap::new();
+/// One fetched ref, read as far as its layout allows without a key.
+#[derive(Clone, Debug)]
+struct Fetched {
+    uuid: String,
+    commit: String,
+    machine_name: String,
+    created_at: String,
+    /// The record, for a plaintext backup; an encrypted one is read when
+    /// it is needed.
+    plain: Option<Checkpoint>,
+}
+
+fn fetched(repo: &HistoryRepo) -> Result<BTreeMap<String, Vec<Fetched>>> {
+    let mut by_machine: BTreeMap<String, Vec<Fetched>> = BTreeMap::new();
+    let mut live: BTreeSet<String> = BTreeSet::new();
     for (name, commit) in repo.list_refs(MACHINES_PREFIX)? {
         let Some(rest) = name.strip_prefix(MACHINES_PREFIX) else {
             continue;
@@ -32,33 +55,68 @@ fn fetched(repo: &HistoryRepo) -> Result<BTreeMap<String, Vec<(String, Entry)>>>
         let Some((machine_id, uuid)) = rest.split_once('/') else {
             continue;
         };
-        let mut checkpoint = match repo.read_meta(&commit) {
-            Ok(checkpoint) => checkpoint,
+        live.insert(commit.clone());
+        let item = match encrypted::header_of(repo, &commit) {
+            Ok(Some(header)) => Fetched {
+                uuid: uuid.to_string(),
+                commit,
+                machine_name: header.machine.name,
+                created_at: header.created_at,
+                plain: None,
+            },
+            Ok(None) => match repo.read_meta(&commit) {
+                Ok(mut checkpoint) => {
+                    // the snapshot is the wrapper commit's own `snapshot/`
+                    // tree: a pushed wrapper may have been rebuilt with
+                    // backup-excluded files removed, so the tree id its
+                    // metadata names is not the one here
+                    checkpoint.tree.snapshot =
+                        repo.object_at(&commit, "snapshot")?.map(|(_, oid)| oid);
+                    Fetched {
+                        uuid: uuid.to_string(),
+                        commit,
+                        machine_name: checkpoint.machine.name.clone(),
+                        created_at: checkpoint.created_at.clone(),
+                        plain: Some(checkpoint),
+                    }
+                }
+                Err(err) => {
+                    debug!("history: skipping {name}: {err}");
+                    continue;
+                }
+            },
             Err(err) => {
                 debug!("history: skipping {name}: {err}");
                 continue;
             }
         };
-        // the snapshot is the wrapper commit's own `snapshot/` tree: a
-        // pushed wrapper may have been rebuilt with backup-excluded files
-        // removed, so the tree id its metadata names is not the one here
-        checkpoint.tree.snapshot = repo.object_at(&commit, "snapshot")?.map(|(_, oid)| oid);
-        by_machine.entry(machine_id.to_string()).or_default().push((
-            uuid.to_string(),
-            Entry {
-                id: 0,
-                commit,
-                checkpoint,
-            },
-        ));
+        by_machine
+            .entry(machine_id.to_string())
+            .or_default()
+            .push(item);
     }
     for entries in by_machine.values_mut() {
-        entries.sort_by(|a, b| a.1.checkpoint.created_at.cmp(&b.1.checkpoint.created_at));
-        for (index, (_, entry)) in entries.iter_mut().enumerate() {
-            entry.id = index as u64 + 1;
+        entries.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    }
+    prune_plain(repo, &live)?;
+    Ok(by_machine)
+}
+
+/// Drops the decrypted copies of refs the origin no longer has (or that
+/// were uploaded again under another scheme).
+fn prune_plain(repo: &HistoryRepo, live: &BTreeSet<String>) -> Result<()> {
+    for (name, _) in repo.list_refs(PLAIN_PREFIX)? {
+        let Some(rest) = name.strip_prefix(PLAIN_PREFIX) else {
+            continue;
+        };
+        let Some((_, remote_commit)) = rest.split_once('/') else {
+            continue;
+        };
+        if !live.contains(remote_commit) {
+            repo.delete_ref(&name)?;
         }
     }
-    Ok(by_machine)
+    Ok(())
 }
 
 /// Every machine with recovery refs, this one first.
@@ -66,11 +124,13 @@ pub(crate) fn list(
     repo: &HistoryRepo,
     this: &Machine,
     local: &[Entry],
+    this_encrypts: bool,
 ) -> Result<Vec<MachineInfo>> {
     let mut out = vec![MachineInfo {
         id: this.id.clone(),
         name: this.name.clone(),
         checkpoints: local.len(),
+        encrypted: if this_encrypts { local.len() } else { 0 },
         latest: local
             .last()
             .map(|entry| entry.checkpoint.created_at.clone()),
@@ -82,50 +142,48 @@ pub(crate) fn list(
         }
         let name = entries
             .last()
-            .map(|(_, entry)| entry.checkpoint.machine.name.clone())
+            .map(|entry| entry.machine_name.clone())
             .unwrap_or_else(|| id.clone());
         out.push(MachineInfo {
             id,
             name,
             checkpoints: entries.len(),
-            latest: entries
-                .last()
-                .map(|(_, entry)| entry.checkpoint.created_at.clone()),
+            encrypted: entries.iter().filter(|entry| entry.plain.is_none()).count(),
+            latest: entries.last().map(|entry| entry.created_at.clone()),
             this: false,
         });
     }
     Ok(out)
 }
 
-/// A machine's fetched checkpoints, oldest first, numbered from 1.
-pub(crate) fn entries(repo: &HistoryRepo, machine: &str) -> Result<(Machine, Vec<Entry>)> {
+/// Whether any other machine's fetched backups are encrypted: a fresh
+/// machine set up from the repository follows suit.
+pub(crate) fn any_encrypted(repo: &HistoryRepo, except_machine: &str) -> Result<bool> {
+    Ok(fetched(repo)?
+        .iter()
+        .filter(|(id, _)| id.as_str() != except_machine)
+        .any(|(_, entries)| entries.iter().any(|entry| entry.plain.is_none())))
+}
+
+/// A machine's fetched checkpoints, oldest first, numbered from 1. An
+/// encrypted checkpoint is decrypted here (once; the plaintext copy is
+/// kept locally), so every entry returned can be rolled back to.
+pub(crate) async fn entries(repo: &HistoryRepo, machine: &str) -> Result<(Machine, Vec<Entry>)> {
     let fetched = fetched(repo)?;
-    let matching: Vec<(&String, &Vec<(String, Entry)>)> = fetched
+    let matching: Vec<(&String, &Vec<Fetched>)> = fetched
         .iter()
         .filter(|(id, entries)| {
             *id == machine
                 || entries
                     .last()
-                    .is_some_and(|(_, entry)| entry.checkpoint.machine.name == machine)
+                    .is_some_and(|entry| entry.machine_name == machine)
         })
         .collect();
-    match matching.as_slice() {
+    let (id, items) = match matching.as_slice() {
         [] => bail!(
             "no machine {machine:?} has recovery refs here; `mise bootstrap dotfiles machines` lists them (after `mise bootstrap dotfiles sync`)"
         ),
-        [(id, entries)] => {
-            let name = entries
-                .last()
-                .map(|(_, entry)| entry.checkpoint.machine.name.clone())
-                .unwrap_or_else(|| (*id).clone());
-            Ok((
-                Machine {
-                    id: (*id).clone(),
-                    name,
-                },
-                entries.iter().map(|(_, entry)| entry.clone()).collect(),
-            ))
-        }
+        [(id, items)] => (*id, *items),
         many => bail!(
             "{} machines are named {machine:?}; use an id: {}",
             many.len(),
@@ -134,5 +192,72 @@ pub(crate) fn entries(repo: &HistoryRepo, machine: &str) -> Result<(Machine, Vec
                 .collect::<Vec<_>>()
                 .join(", ")
         ),
+    };
+    let name = items
+        .last()
+        .map(|entry| entry.machine_name.clone())
+        .unwrap_or_else(|| id.clone());
+    let mut entries = vec![];
+    for (index, item) in items.iter().enumerate() {
+        let (commit, checkpoint) = match &item.plain {
+            Some(checkpoint) => (item.commit.clone(), checkpoint.clone()),
+            None => {
+                let plain = materialized(repo, id, item, &name).await?;
+                let mut checkpoint = repo.read_meta(&plain)?;
+                checkpoint.tree.snapshot = repo.object_at(&plain, "snapshot")?.map(|(_, oid)| oid);
+                (plain, checkpoint)
+            }
+        };
+        entries.push(Entry {
+            id: index as u64 + 1,
+            commit,
+            checkpoint,
+        });
+    }
+    Ok((
+        Machine {
+            id: id.clone(),
+            name,
+        },
+        entries,
+    ))
+}
+
+/// The local plaintext wrapper of an encrypted ref: the one kept from an
+/// earlier decryption, else decrypted now and kept.
+async fn materialized(
+    repo: &HistoryRepo,
+    machine_id: &str,
+    item: &Fetched,
+    machine_name: &str,
+) -> Result<String> {
+    let plain_ref = format!("{PLAIN_PREFIX}{machine_id}/{}", item.commit);
+    if let Some(commit) = repo.ref_oid(&plain_ref)? {
+        return Ok(commit);
+    }
+    match encrypted::materialize(repo, &item.commit).await {
+        Ok(commit) => {
+            if let Err(err) = repo.update_ref(&plain_ref, &commit, None) {
+                debug!("history: keeping the decrypted backup {plain_ref}: {err}");
+            }
+            Ok(commit)
+        }
+        Err(ReadError::Decrypt(DecryptError::NoIdentities)) => bail!(
+            "checkpoint {} of {machine_name} is encrypted and this machine has no age identity; put the identity in ~/.config/mise/age.txt, settings.age.key_file, or MISE_AGE_KEY",
+            item.uuid
+        ),
+        Err(ReadError::Decrypt(err)) => bail!(
+            "checkpoint {} of {machine_name} is encrypted and none of this machine's identities can decrypt it: {err}",
+            item.uuid
+        ),
+        Err(ReadError::Corrupt(reason)) => bail!(
+            "checkpoint {} of {machine_name}: the encrypted backup is damaged: {reason}",
+            item.uuid
+        ),
+        Err(ReadError::NotEncrypted) => bail!(
+            "checkpoint {} of {machine_name} is neither a plaintext nor an encrypted backup",
+            item.uuid
+        ),
+        Err(ReadError::Other(err)) => Err(err),
     }
 }

--- a/src/system/history/sync/mod.rs
+++ b/src/system/history/sync/mod.rs
@@ -3,14 +3,16 @@
 //! (`layout`), network commands with the user's git configuration
 //! (`network`), what is shareable now (`share`), the per-path transition
 //! table (`reconcile`), publication from mise's bare repository
-//! (`publish`), machine recovery refs (`backup`), explicit application
-//! (`apply`), durable sync state (`state`), privacy filtering (`privacy`),
-//! and the orchestrating `sync` run.
+//! (`publish`), machine recovery refs (`backup`) and their encrypted form
+//! (`encrypted`), explicit application (`apply`), durable sync state
+//! (`state`), privacy filtering (`privacy`), and the orchestrating `sync`
+//! run.
 
 use eyre::{Result, bail};
 
 pub(crate) mod apply;
 pub(crate) mod backup;
+pub(crate) mod encrypted;
 pub(crate) mod format;
 pub(crate) mod layout;
 pub(crate) mod machines;

--- a/src/system/history/sync/mod.rs
+++ b/src/system/history/sync/mod.rs
@@ -13,6 +13,7 @@ use eyre::{Result, bail};
 pub(crate) mod apply;
 pub(crate) mod backup;
 pub(crate) mod encrypted;
+mod files;
 pub(crate) mod format;
 pub(crate) mod layout;
 pub(crate) mod machines;

--- a/src/system/history/sync/network.rs
+++ b/src/system/history/sync/network.rs
@@ -15,6 +15,10 @@ pub(crate) const PUBLISH_REF: &str = "refs/setup/publish";
 pub(crate) const MACHINES_PREFIX: &str = "refs/machines/";
 /// Where machine recovery refs live on the remote.
 pub(crate) const REMOTE_MACHINES_PREFIX: &str = "refs/mise-history/";
+/// Local only, never pushed or fetched: the decrypted form of an encrypted
+/// recovery ref, `refs/machines-plain/<machine-id>/<remote commit>`, so a
+/// backup is decrypted once and its objects survive `gc`.
+pub(crate) const PLAIN_PREFIX: &str = "refs/machines-plain/";
 
 /// Authentication belongs in a credential helper or SSH agent, never in
 /// persisted connection URLs or the errors recorded in history health.

--- a/src/system/history/sync/network.rs
+++ b/src/system/history/sync/network.rs
@@ -169,6 +169,23 @@ impl<'a> Remote<'a> {
         bail!("pushing to {}: {stderr}", self.url)
     }
 
+    /// Replace a machine's recovery namespace as one transaction.
+    pub(crate) fn push_atomic(&self, refspecs: &[String]) -> Result<()> {
+        if refspecs.is_empty() {
+            return Ok(());
+        }
+        let mut args = vec!["push", "--quiet", "--atomic", self.url.as_str()];
+        args.extend(refspecs.iter().map(String::as_str));
+        let output = self.repo.network(args)?;
+        if !output.status.success() {
+            bail!(
+                "atomic backup replacement failed; existing refs were not partially replaced: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Ok(())
+    }
+
     /// Deletes remote refs (`:refs/...`).
     pub(crate) fn delete(&self, refs: &[String]) -> Result<()> {
         if refs.is_empty() {
@@ -222,5 +239,48 @@ impl<'a> Remote<'a> {
                 Some((oid.to_string(), name.to_string()))
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod atomic_tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_atomic_push_preserves_existing_refs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let destination = tmp.path().join("origin.git");
+        assert!(
+            std::process::Command::new("git")
+                .args(["init", "--bare", "--quiet"])
+                .arg(&destination)
+                .status()
+                .unwrap()
+                .success()
+        );
+        let repo = HistoryRepo::open_or_init_in(&tmp.path().join("local"))
+            .unwrap()
+            .unwrap();
+        let remote_url = destination.to_str().unwrap();
+        let remote = Remote::new(&repo, remote_url);
+        let tree = repo.empty_object("tree").unwrap();
+        let old = repo.commit_tree(&tree, vec![], "old").unwrap();
+        let new = repo.commit_tree(&tree, vec![], "new").unwrap();
+        let name = "refs/mise-history/machine/checkpoint";
+        assert!(matches!(
+            remote.push(&[format!("{old}:{name}")], None).unwrap(),
+            PushOutcome::Done
+        ));
+        assert!(
+            std::process::Command::new("git")
+                .arg("--git-dir")
+                .arg(&destination)
+                .args(["config", "receive.advertiseAtomic", "false"])
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(remote.push_atomic(&[format!("+{new}:{name}")]).is_err());
+        assert!(remote.ls_remote().unwrap().contains(&(old, name.into())));
     }
 }

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -86,12 +86,18 @@ fn preview_configuration(store: &Store) -> Result<tempfile::TempDir> {
     let head = repo
         .ref_oid(UPSTREAM_REF)?
         .ok_or_else(|| eyre::eyre!("setup preview has no fetched branch"))?;
+    let encrypted = super::files::encrypted_paths(repo, Some(&head))?;
     for entry in repo.ls_tree(&head)? {
         if super::layout::is_configuration(&entry.path)
             && super::layout::is_safe_branch_path(&entry.path)
         {
             let Some((mode, oid)) = repo.object_at(&head, &entry.path)? else {
                 bail!("configuration disappeared from preview commit");
+            };
+            let (mode, oid) = if encrypted.contains(&entry.path) {
+                super::files::decrypt(repo, &entry.path, &(mode, oid), true)?
+            } else {
+                (mode, oid)
             };
             crate::system::history::replay::write_path(
                 repo,

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -321,7 +321,12 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
             status.upload_since = Some(newest.unwrap_or_else(hstore::now_rfc3339));
         }
     })?;
-    super::origin::write_config(&onboarding.origin, &onboarding.branch, None, backups.as_ref())?;
+    super::origin::write_config(
+        &onboarding.origin,
+        &onboarding.branch,
+        None,
+        backups.as_ref(),
+    )?;
 
     let applied = apply::apply(store, &tracked, &ApplyRequest::automatic()).await?;
     // a conflict (a file that exists here and differs) is not pending: it

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -212,10 +212,17 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
     let mode = SyncMode::current()?;
     let config_dir = global_config_dir();
     refuse_other_connection(store, &onboarding.origin, &onboarding.branch)?;
+    let repository_format = match store.repo() {
+        Some(repo) => match format::detect(repo, repo.ref_oid(UPSTREAM_REF)?.as_deref())? {
+            RepoState::Marked(version) => version,
+            _ => format::FORMAT,
+        },
+        None => format::FORMAT,
+    };
     miseprintln!(
         "{} is a mise setup repository (format {}); branch {}.",
         onboarding.origin,
-        format::FORMAT,
+        repository_format,
         onboarding.branch
     );
     miseprintln!("Sync mode {}", mode.disclosure());

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -235,11 +235,10 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
     let (_preview_dir, planning_store) = preview_store(store)?;
     let tracked = TrackedSet::effective().await?;
     let mut request = SyncRequest::new(true);
-    request.origin = Some(OriginTomlConfig {
-        url: onboarding.fetch_from.clone(),
-        branch: onboarding.branch.clone(),
-        encrypt_backups: false,
-    });
+    request.origin = Some(OriginTomlConfig::plain(
+        onboarding.fetch_from.clone(),
+        onboarding.branch.clone(),
+    ));
     request.capture = false;
     request.dry_run = true;
     // Pending decisions belong only to this preview store.
@@ -249,6 +248,38 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
     preview.dry_run = true;
     preview.plan_only = true;
     apply::apply(&planning_store, &tracked, &preview).await?;
+    // backups follow the other machines: where they encrypt, this machine
+    // does too, for the identities found here; a declaration already in
+    // place (a re-run) keeps whatever it says
+    let declared = crate::system::history::config::origin()?
+        .is_some_and(|(_, origin)| origin.url == onboarding.origin);
+    let backups = if declared {
+        None
+    } else if let Some(repo) = planning_store.repo()
+        && super::machines::any_encrypted(repo, &store.machine().id)?
+    {
+        let recipients = crate::agecrypt::default_recipient_strings().await?;
+        if recipients.is_empty() {
+            miseprintln!(
+                "Other machines encrypt their backups, but no age identity or SSH public key was found here: nothing is backed up from this machine until `mise bootstrap dotfiles origin set {} --encrypt-backups` adds recipients (plaintext is never used as a fallback).",
+                onboarding.origin
+            );
+        } else {
+            miseprintln!(
+                "Other machines encrypt their backups; this machine's are encrypted too, for the {} recipient(s) found here.",
+                recipients.len()
+            );
+        }
+        Some(super::origin::BackupConfig {
+            encrypt: true,
+            recipients,
+        })
+    } else {
+        Some(super::origin::BackupConfig {
+            encrypt: false,
+            recipients: vec![],
+        })
+    };
     if onboarding.dry_run {
         let preview_config = Some(preview_configuration(&planning_store)?);
         miseprintln!("Dry run: nothing was changed.");
@@ -283,7 +314,7 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
             status.upload_since = Some(newest.unwrap_or_else(hstore::now_rfc3339));
         }
     })?;
-    super::origin::write_config(&onboarding.origin, &onboarding.branch, None)?;
+    super::origin::write_config(&onboarding.origin, &onboarding.branch, None, backups.as_ref())?;
 
     let applied = apply::apply(store, &tracked, &ApplyRequest::automatic()).await?;
     // a conflict (a file that exists here and differs) is not pending: it

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -297,11 +297,13 @@ async fn set_inner(
     let backed_up = walk
         .files
         .iter()
-        .filter(|(_, (_, policy))| policy.backup)
+        .filter(|(_, (_, policy))| {
+            policy.backup && (!policy.encrypt || !matches!(backups, BackupPlan::Plain))
+        })
         .count();
     match &backups {
         BackupPlan::Plain => miseprintln!(
-            "Machine backups: {backed_up} of {} captured file(s) are backed up in plain form under refs/mise-history/{}/ — anyone who can read this repository can read every file in these snapshots. The setup branch is always plaintext; use a private repository.",
+            "Machine backups: {backed_up} of {} captured file(s) are backed up in plain form under refs/mise-history/{}/ — anyone who can read this repository can read every file in these snapshots. Setup configuration stays plaintext; selected dotfiles can be encrypted. Use a private repository.",
             walk.files.len(),
             machine.id
         ),
@@ -329,15 +331,24 @@ async fn set_inner(
                 ),
             }
             miseprintln!(
-                "File names, descriptions, and content are readable only with one of these identities; the machine name, checkpoint time, and count stay visible. The setup branch is always plaintext; use a private repository."
+                "File names, descriptions, and content are readable only with one of these identities; the machine name, checkpoint time, and count stay visible. Setup configuration stays plaintext; selected dotfiles can be encrypted. Use a private repository."
             );
             if generate.is_none() {
-                let loaded = crate::agecrypt::load_all_identities().await;
-                let only_age = recipients.iter().all(|r| r.starts_with("age1"));
-                let among = recipients
+                let restorable = crate::agecrypt::restorability(recipients).await;
+                if restorable.is_none() {
+                    miseprintln!(
+                        "Hardware identity configured but unverified; restore interactively to unlock it."
+                    );
+                }
+                if recipients
                     .iter()
-                    .any(|r| loaded.x25519_public.iter().any(|mine| mine == r));
-                if loaded.identities.is_empty() || (only_age && !among) {
+                    .all(|r| r.parse::<age::plugin::Recipient>().is_ok())
+                {
+                    miseprintln!(
+                        "Hardware-only recipients: losing these devices can make backups unrecoverable. Add an independent recovery recipient."
+                    );
+                }
+                if restorable == Some(false) {
                     miseprintln!(
                         "Note: none of this machine's identities is among the recipients, so this machine could not restore its own backups."
                     );
@@ -470,6 +481,8 @@ async fn set_inner(
     // is included, not only what changes later
     status.upload_since = if opts.include_existing {
         None
+    } else if same_origin {
+        status.upload_since.clone()
     } else {
         let newest = store
             .list()?

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -14,7 +14,7 @@ use toml_edit::{Item, Value};
 use super::SyncMode;
 use super::format::{self, RepoState};
 use super::layout::{Roots, is_configuration};
-use super::network::{MACHINES_PREFIX, PUBLISH_REF, Remote, UPSTREAM_REF};
+use super::network::{MACHINES_PREFIX, PLAIN_PREFIX, PUBLISH_REF, Remote, UPSTREAM_REF};
 use super::run::{self, SyncRequest};
 use super::{backup, privacy, share};
 use crate::file::display_path;
@@ -31,7 +31,37 @@ pub(crate) struct SetOptions {
     pub include_existing: bool,
     pub allow_committed_private: bool,
     pub encrypt_backups: bool,
+    /// `--recipient` arguments: keys, or files holding them.
+    pub recipients: Vec<String>,
     pub yes: bool,
+}
+
+/// What `[history.origin]` says about backups.
+pub(crate) struct BackupConfig {
+    pub encrypt: bool,
+    pub recipients: Vec<String>,
+}
+
+/// How this connection will back up, decided before the disclosure.
+enum BackupPlan {
+    Plain,
+    Encrypted {
+        recipients: Vec<String>,
+        /// No recipient was found anywhere: generate an identity here.
+        generate: Option<PathBuf>,
+    },
+}
+
+/// A recipient as printed: an SSH key is long, so its type and the start
+/// of its material stand for it.
+fn short_recipient(recipient: &str) -> String {
+    let Some((kind, rest)) = recipient.split_once(' ') else {
+        return recipient.to_string();
+    };
+    if rest.chars().count() <= 20 {
+        return recipient.to_string();
+    }
+    format!("{kind} {}…", rest.chars().take(16).collect::<String>())
 }
 
 /// Connects the setup repository.
@@ -99,11 +129,11 @@ async fn set_inner(
     accepted: &mut bool,
     preview_lock: &mut Option<fslock::LockFile>,
 ) -> Result<()> {
-    if opts.encrypt_backups {
-        bail!("encrypted backups are not supported yet; connect without --encrypt-backups");
-    }
     if opts.url.trim().is_empty() {
         bail!("a repository url is required");
+    }
+    if !opts.recipients.is_empty() && !opts.encrypt_backups {
+        bail!("--recipient needs --encrypt-backups");
     }
     let repo = store
         .repo()
@@ -131,6 +161,32 @@ async fn set_inner(
     run::capture_now(store, tracked);
     let shared = share::current(repo, store, tracked)?;
     let walk = tracked.walk()?;
+    // the connection as it was: another repository or branch starts from a
+    // clean slate, and a scheme change on the same one replaces its refs
+    let status_before = run::read_status(state_dir);
+    let connected_before = status_before.origin_url.is_some();
+    let same_origin = status_before.origin_url.as_deref() == Some(opts.url.as_str())
+        && status_before.origin_branch.as_deref() == Some(opts.branch.as_str());
+    let backups = if opts.encrypt_backups {
+        let mut recipients: Vec<String> = vec![];
+        for arg in &opts.recipients {
+            recipients.extend(crate::agecrypt::resolve_recipient_arg(arg).await?);
+        }
+        if recipients.is_empty() {
+            recipients = crate::agecrypt::default_recipient_strings().await?;
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        recipients.retain(|recipient| seen.insert(recipient.clone()));
+        let generate = recipients
+            .is_empty()
+            .then(crate::agecrypt::default_identity_file);
+        BackupPlan::Encrypted {
+            recipients,
+            generate,
+        }
+    } else {
+        BackupPlan::Plain
+    };
 
     // committed private content in the branch's history
     if let Some(head) = &upstream {
@@ -243,11 +299,87 @@ async fn set_inner(
         .iter()
         .filter(|(_, (_, policy))| policy.backup)
         .count();
-    miseprintln!(
-        "Machine backups: {backed_up} of {} captured file(s) are backed up in plain form under refs/mise-history/{}/ — anyone who can read this repository can read every file in these snapshots. The setup branch is always plaintext; use a private repository.",
-        walk.files.len(),
-        machine.id
-    );
+    match &backups {
+        BackupPlan::Plain => miseprintln!(
+            "Machine backups: {backed_up} of {} captured file(s) are backed up in plain form under refs/mise-history/{}/ — anyone who can read this repository can read every file in these snapshots. The setup branch is always plaintext; use a private repository.",
+            walk.files.len(),
+            machine.id
+        ),
+        BackupPlan::Encrypted {
+            recipients,
+            generate,
+        } => {
+            match generate {
+                None => {
+                    miseprintln!(
+                        "Machine backups: {backed_up} of {} captured file(s) are backed up encrypted (age) under refs/mise-history/{}/ for {} recipient(s):",
+                        walk.files.len(),
+                        machine.id,
+                        recipients.len()
+                    );
+                    for recipient in recipients {
+                        miseprintln!("  {}", short_recipient(recipient));
+                    }
+                }
+                Some(path) => miseprintln!(
+                    "Machine backups: {backed_up} of {} captured file(s) are backed up encrypted (age) under refs/mise-history/{}/. No age identity or SSH public key was found here: an age identity will be generated at {} (mode 0600) and used as the only recipient. Keep it: without it these backups cannot be restored; copy it to every machine that should read them.",
+                    walk.files.len(),
+                    machine.id,
+                    display_path(path)
+                ),
+            }
+            miseprintln!(
+                "File names, descriptions, and content are readable only with one of these identities; the machine name, checkpoint time, and count stay visible. The setup branch is always plaintext; use a private repository."
+            );
+            if generate.is_none() {
+                let loaded = crate::agecrypt::load_all_identities().await;
+                let only_age = recipients.iter().all(|r| r.starts_with("age1"));
+                let among = recipients
+                    .iter()
+                    .any(|r| loaded.x25519_public.iter().any(|mine| mine == r));
+                if loaded.identities.is_empty() || (only_age && !among) {
+                    miseprintln!(
+                        "Note: none of this machine's identities is among the recipients, so this machine could not restore its own backups."
+                    );
+                }
+            }
+        }
+    }
+    if same_origin && !status_before.uploaded.is_empty() {
+        let previous_plain = status_before
+            .backup_scheme
+            .as_deref()
+            .is_none_or(|scheme| scheme == backup::PLAIN_SCHEME);
+        let changes = match &backups {
+            BackupPlan::Plain => backup::scheme_changes(&status_before, backup::PLAIN_SCHEME),
+            BackupPlan::Encrypted {
+                generate: Some(_), ..
+            } => true,
+            BackupPlan::Encrypted { recipients, .. } => {
+                let planned = backup::BackupEncryption {
+                    recipients: vec![],
+                    strings: recipients.clone(),
+                };
+                backup::scheme_changes(&status_before, &backup::scheme(Some(&planned)))
+            }
+        };
+        if changes {
+            miseprintln!(
+                "This machine's {} existing recovery ref(s) on the repository are replaced: the {} ones are deleted and eligible checkpoints are uploaded again {}.",
+                status_before.uploaded.len(),
+                if previous_plain {
+                    "plaintext"
+                } else {
+                    "previously encrypted"
+                },
+                if matches!(backups, BackupPlan::Plain) {
+                    "IN PLAIN FORM"
+                } else {
+                    "encrypted"
+                }
+            );
+        }
+    }
     miseprintln!(
         "Existing checkpoints: {}",
         if opts.include_existing {
@@ -296,13 +428,33 @@ async fn set_inner(
     // say, so `mise settings set history.sync …` keeps working afterwards
     let mode =
         (opts.mode.as_str() != crate::config::Settings::get().history.sync).then_some(opts.mode);
-    write_config(&opts.url, &opts.branch, mode)?;
+    let backup_config = match backups {
+        BackupPlan::Plain => BackupConfig {
+            encrypt: false,
+            recipients: vec![],
+        },
+        BackupPlan::Encrypted {
+            mut recipients,
+            generate,
+        } => {
+            if let Some(path) = generate {
+                let public = crate::agecrypt::generate_identity_file(&path)?;
+                miseprintln!(
+                    "Generated an age identity at {}; its public key is {public}. Copy the file to every machine that should restore these backups (mise never uploads it).",
+                    display_path(&path)
+                );
+                recipients = vec![public];
+            }
+            BackupConfig {
+                encrypt: true,
+                recipients,
+            }
+        }
+    };
+    write_config(&opts.url, &opts.branch, mode, Some(&backup_config))?;
     // another repository or branch starts from a clean slate: the previous
     // one's per-path state, pending changes, and conflicts would read its
     // absence of a file as a deletion
-    let connected_before = status.origin_url.is_some();
-    let same_origin = status.origin_url.as_deref() == Some(opts.url.as_str())
-        && status.origin_branch.as_deref() == Some(opts.branch.as_str());
     if connected_before && !same_origin {
         reset_sync_state(repo, &previous_machine_refs)?;
         status = run::SyncStatus::default();
@@ -362,6 +514,15 @@ pub(crate) fn report(outcome: &run::SyncOutcome) {
             "history: removed {} pruned checkpoint(s) from the origin",
             outcome.pruned_remote
         );
+    }
+    if outcome.replaced_remote > 0 {
+        info!(
+            "history: replaced {} recovery ref(s) on the origin (the backup scheme changed)",
+            outcome.replaced_remote
+        );
+    }
+    if let Some(error) = &outcome.backup_error {
+        warn!("history: machine backups skipped: {error}");
     }
     if outcome.pending > 0 {
         info!(
@@ -425,7 +586,14 @@ fn origin_file() -> Result<PathBuf> {
     crate::cli::dotfiles::track::declaration_file(true)
 }
 
-pub(super) fn write_config(url: &str, branch: &str, mode: Option<SyncMode>) -> Result<()> {
+/// Writes `[history.origin]`. `backups` `None` leaves any `encrypt_backups`
+/// and `recipients` keys as they are (a re-run must not undo a choice).
+pub(super) fn write_config(
+    url: &str,
+    branch: &str,
+    mode: Option<SyncMode>,
+    backups: Option<&BackupConfig>,
+) -> Result<()> {
     let global = origin_file()?;
     if let Some(parent) = global.parent() {
         crate::file::create_dir_all(parent)?;
@@ -450,6 +618,24 @@ pub(super) fn write_config(url: &str, branch: &str, mode: Option<SyncMode>) -> R
     origin.set_implicit(false);
     origin.insert("url", Item::Value(Value::from(url)));
     origin.insert("branch", Item::Value(Value::from(branch)));
+    match backups {
+        Some(BackupConfig {
+            encrypt: true,
+            recipients,
+        }) => {
+            origin.insert("encrypt_backups", Item::Value(Value::from(true)));
+            let mut array = toml_edit::Array::new();
+            for recipient in recipients {
+                array.push(recipient.as_str());
+            }
+            origin.insert("recipients", Item::Value(Value::Array(array)));
+        }
+        Some(BackupConfig { encrypt: false, .. }) => {
+            origin.remove("encrypt_backups");
+            origin.remove("recipients");
+        }
+        None => {}
+    }
     let Some(mode) = mode else {
         crate::file::write(&global, doc.to_string())?;
         return Ok(());
@@ -491,6 +677,10 @@ fn reset_sync_state(
         if repo.ref_oid(name)?.is_some() {
             repo.delete_ref(name)?;
         }
+    }
+    // and the decrypted copies of the previous repository's refs
+    for (name, _) in repo.list_refs(PLAIN_PREFIX)? {
+        repo.delete_ref(&name)?;
     }
     Ok(())
 }

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -163,7 +163,7 @@ async fn set_inner(
     let walk = tracked.walk()?;
     // the connection as it was: another repository or branch starts from a
     // clean slate, and a scheme change on the same one replaces its refs
-    let status_before = run::read_status(state_dir);
+    let status_before = run::read_status(state_dir)?;
     let connected_before = status_before.origin_url.is_some();
     let same_origin = status_before.origin_url.as_deref() == Some(opts.url.as_str())
         && status_before.origin_branch.as_deref() == Some(opts.branch.as_str());

--- a/src/system/history/sync/preflight.rs
+++ b/src/system/history/sync/preflight.rs
@@ -101,12 +101,6 @@ pub(super) fn prospective(
         let parsed = MiseToml::for_history_preflight(&body, &path)?;
         if let Some(history) = parsed.history_config() {
             excludes.extend(history.exclude);
-            if history.origin.is_some_and(|origin| origin.encrypt_backups) {
-                bail!(
-                    "encrypted backups are not supported yet ({})",
-                    path.display()
-                );
-            }
         }
         files.insert(
             path,

--- a/src/system/history/sync/reconcile.rs
+++ b/src/system/history/sync/reconcile.rs
@@ -35,11 +35,26 @@ pub(crate) struct Upstream {
 }
 
 pub(crate) fn upstream(repo: &HistoryRepo, commit: Option<&str>) -> Result<Upstream> {
+    upstream_with_interaction(repo, commit, false)
+}
+
+pub(crate) fn upstream_with_interaction(
+    repo: &HistoryRepo,
+    commit: Option<&str>,
+    interactive: bool,
+) -> Result<Upstream> {
     let mut files = BTreeMap::new();
     if let Some(commit) = commit {
         for entry in repo.ls_tree(commit)? {
             if let Some((mode, oid)) = repo.object_at(commit, &entry.path)? {
-                files.insert(entry.path, (mode, oid));
+                let object = if !entry.path.starts_with(".mise-history/")
+                    && !super::layout::is_repository_metadata(&entry.path)
+                {
+                    super::files::decrypt(repo, &entry.path, &(mode, oid), interactive)?
+                } else {
+                    (mode, oid)
+                };
+                files.insert(entry.path, object);
             }
         }
     }

--- a/src/system/history/sync/reconcile.rs
+++ b/src/system/history/sync/reconcile.rs
@@ -44,12 +44,11 @@ pub(crate) fn upstream_with_interaction(
     interactive: bool,
 ) -> Result<Upstream> {
     let mut files = BTreeMap::new();
+    let encrypted = super::files::encrypted_paths(repo, commit)?;
     if let Some(commit) = commit {
         for entry in repo.ls_tree(commit)? {
             if let Some((mode, oid)) = repo.object_at(commit, &entry.path)? {
-                let object = if !entry.path.starts_with(".mise-history/")
-                    && !super::layout::is_repository_metadata(&entry.path)
-                {
+                let object = if encrypted.contains(&entry.path) {
                     super::files::decrypt(repo, &entry.path, &(mode, oid), interactive)?
                 } else {
                     (mode, oid)

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -113,6 +113,14 @@ pub(crate) struct SyncStatus {
     /// in for a declaration.
     #[serde(default)]
     pub disconnected: bool,
+    /// How this machine's refs on the origin were written (`backup::scheme`);
+    /// absent means plaintext. A change replaces them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backup_scheme: Option<String>,
+    /// Why uploads are being skipped (encryption on without usable
+    /// recipients); publication and fetching continue.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backup_error: Option<String>,
 }
 
 fn is_zero(value: &u32) -> bool {
@@ -176,6 +184,10 @@ pub(crate) struct SyncOutcome {
     pub published: Option<String>,
     pub uploaded: usize,
     pub pruned_remote: usize,
+    /// Refs deleted from the origin because the backup scheme changed.
+    pub replaced_remote: usize,
+    /// Uploads were skipped: encryption is on without usable recipients.
+    pub backup_error: Option<String>,
     pub pending: usize,
     pub conflicts: usize,
     pub fetched_upstream: Option<String>,
@@ -222,11 +234,14 @@ pub(crate) fn origin() -> Result<OriginTomlConfig> {
     if let (Some(url), Some(branch), false) =
         (status.origin_url, status.origin_branch, status.disconnected)
     {
-        return Ok(OriginTomlConfig {
-            url,
-            branch,
-            encrypt_backups: false,
-        });
+        let mut origin = OriginTomlConfig::plain(url, branch);
+        // refs written encrypted stay that way: with the declaration (and
+        // its recipients) gone, uploads are skipped, never made plaintext
+        origin.encrypt_backups = status
+            .backup_scheme
+            .as_deref()
+            .is_some_and(|scheme| scheme != backup::PLAIN_SCHEME);
+        return Ok(origin);
     }
     bail!(
         "no setup repository is connected; `mise bootstrap dotfiles origin set <url>` connects one"
@@ -245,9 +260,10 @@ pub(crate) fn sync(
         Some(origin) => origin.clone(),
         None => origin()?,
     };
-    if origin.encrypt_backups {
-        bail!("[history.origin] encrypt_backups is not supported yet; set it to false");
-    }
+    // resolved before anything is fetched; an unusable declaration skips
+    // uploads below rather than failing the sync (publication and fetching
+    // do not depend on it)
+    let encryption = backup::BackupEncryption::resolve(&origin);
     let repo = store
         .repo()
         .ok_or_else(|| eyre::eyre!("synchronizing requires git"))?;
@@ -394,25 +410,48 @@ pub(crate) fn sync(
         status.upstream_commit = upstream_commit.clone();
         record_pending(&mut status, &plans, &Roots::current(), &shared.objects());
         if publish {
-            let since = status.upload_since.clone();
-            let uploadable: Vec<Entry> = entries
-                .iter()
-                .filter(|entry| {
-                    since
-                        .as_deref()
-                        .is_none_or(|s| entry.checkpoint.created_at.as_str() >= s)
-                })
-                .cloned()
-                .collect();
-            outcome.uploaded = backup::upload(
-                &remote,
-                repo,
-                &uploadable,
-                &machine.id,
-                &mut status.uploaded,
-            )?;
-            outcome.pruned_remote =
-                backup::prune_remote(&remote, &entries, &machine.id, &mut status.uploaded)?;
+            match &encryption {
+                Err(err) => {
+                    // recorded, not raised: the setup branch above is
+                    // published either way, and nothing is ever uploaded in
+                    // plaintext because the recipients are missing
+                    status.backup_error = Some(format!("{err:#}"));
+                    outcome.backup_error = status.backup_error.clone();
+                }
+                Ok(encryption) => {
+                    status.backup_error = None;
+                    let scheme = backup::scheme(encryption.as_ref());
+                    if backup::reconcile_scheme(&mut status, &scheme) {
+                        // durable before the deletion: a crash in between
+                        // finds an empty upload set and uploads everything
+                        // again, under the new scheme
+                        write_status(state_dir, &status)?;
+                        let refs = backup::remote_refs(&remote, &machine.id)?;
+                        remote.delete(&refs)?;
+                        outcome.replaced_remote = refs.len();
+                    }
+                    let since = status.upload_since.clone();
+                    let uploadable: Vec<Entry> = entries
+                        .iter()
+                        .filter(|entry| {
+                            since
+                                .as_deref()
+                                .is_none_or(|s| entry.checkpoint.created_at.as_str() >= s)
+                        })
+                        .cloned()
+                        .collect();
+                    outcome.uploaded = backup::upload(
+                        &remote,
+                        repo,
+                        &uploadable,
+                        &machine.id,
+                        &mut status.uploaded,
+                        encryption.as_ref(),
+                    )?;
+                    outcome.pruned_remote =
+                        backup::prune_remote(&remote, &entries, &machine.id, &mut status.uploaded)?;
+                }
+            }
         }
         outcome.pending = status.pending_applications.len();
         outcome.conflicts = status.conflicts.len();

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -265,7 +265,10 @@ pub(crate) fn sync(
     // resolved before anything is fetched; an unusable declaration skips
     // uploads below rather than failing the sync (publication and fetching
     // do not depend on it)
-    let encryption = backup::BackupEncryption::resolve(&origin);
+    let encryption = backup::BackupEncryption::resolve(
+        &origin,
+        request.capture && console::user_attended_stderr(),
+    );
     let repo = store
         .repo()
         .ok_or_else(|| eyre::eyre!("synchronizing requires git"))?;

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -117,6 +117,8 @@ pub(crate) struct SyncStatus {
     /// absent means plaintext. A change replaces them.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backup_scheme: Option<String>,
+    #[serde(default)]
+    pub backup_policy: Option<String>,
     /// Why uploads are being skipped (encryption on without usable
     /// recipients); publication and fetching continue.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -310,6 +312,13 @@ pub(crate) fn sync(
             capture_now(store, tracked);
         }
         let entries = store.list()?;
+        let encrypted_paths: BTreeSet<String> = tracked
+            .walk()?
+            .entries
+            .iter()
+            .filter(|entry| entry.policy.encrypt)
+            .map(|entry| display_path(&entry.path))
+            .collect();
         let shared = share::current(repo, store, tracked)?;
         let unsaved = unsaved_paths(repo, tracked, &shared)?;
         let publish = mode.publishes() && !request.fetch_only && !request.offline;
@@ -317,7 +326,11 @@ pub(crate) fn sync(
         let mut attempts = 0;
         loop {
             attempts += 1;
-            let upstream = reconcile::upstream(repo, upstream_commit.as_deref())?;
+            let upstream = reconcile::upstream_with_interaction(
+                repo,
+                upstream_commit.as_deref(),
+                request.capture && console::user_attended_stderr(),
+            )?;
             let sync_state = state::load(repo)?;
             plans = prepare(
                 repo,
@@ -350,6 +363,10 @@ pub(crate) fn sync(
             if !publish
                 || status.application_failure.is_some()
                 || status.validation_error.is_some()
+                // Apply incoming configuration before publishing encrypted
+                // content under a potentially superseded recipient policy.
+                || (matches!(repo_state, RepoState::Marked(2))
+                    && plans.iter().any(|plan| is_configuration(&plan.branch_path) && plan.apply.is_some()))
                 || plans.iter().any(|plan| plan.conflict.is_some())
             {
                 break;
@@ -357,7 +374,13 @@ pub(crate) fn sync(
             let add_marker = matches!(repo_state, RepoState::Empty | RepoState::Unmarked);
             let publication = publish::Publication {
                 upstream_commit: upstream_commit.as_deref(),
-                changes: changes.clone(),
+                changes: super::files::publication(
+                    repo,
+                    upstream_commit.as_deref(),
+                    &shared,
+                    &changes,
+                    request.capture && console::user_attended_stderr(),
+                )?,
                 add_marker,
                 message: publish::message(&machine.name, &changes),
             };
@@ -385,7 +408,11 @@ pub(crate) fn sync(
                     }
                     state::save(repo, &next_state, "published")?;
                     // the applications and conflicts are relative to the new head
-                    let upstream = reconcile::upstream(repo, upstream_commit.as_deref())?;
+                    let upstream = reconcile::upstream_with_interaction(
+                        repo,
+                        upstream_commit.as_deref(),
+                        request.capture && console::user_attended_stderr(),
+                    )?;
                     plans = prepare(
                         repo,
                         tracked,
@@ -421,14 +448,28 @@ pub(crate) fn sync(
                 Ok(encryption) => {
                     status.backup_error = None;
                     let scheme = backup::scheme(encryption.as_ref());
-                    if backup::reconcile_scheme(&mut status, &scheme) {
-                        // durable before the deletion: a crash in between
-                        // finds an empty upload set and uploads everything
-                        // again, under the new scheme
-                        write_status(state_dir, &status)?;
-                        let refs = backup::remote_refs(&remote, &machine.id)?;
-                        remote.delete(&refs)?;
-                        outcome.replaced_remote = refs.len();
+                    let policy = crate::hash::hash_sha256_to_str(
+                        &encrypted_paths
+                            .iter()
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join("\n"),
+                    );
+                    let policy_changed = status.backup_policy.as_deref() != Some(&policy)
+                        && (!encrypted_paths.is_empty() || status.backup_policy.is_some());
+                    if backup::scheme_changes(&status, &scheme) || policy_changed {
+                        let (uploaded, replaced) = backup::replace(
+                            &remote,
+                            repo,
+                            &entries,
+                            &machine.id,
+                            &mut status,
+                            encryption.as_ref(),
+                            &encrypted_paths,
+                        )?;
+                        status.backup_policy = Some(policy);
+                        outcome.uploaded = uploaded;
+                        outcome.replaced_remote = replaced;
                     }
                     let since = status.upload_since.clone();
                     let uploadable: Vec<Entry> = entries
@@ -440,13 +481,14 @@ pub(crate) fn sync(
                         })
                         .cloned()
                         .collect();
-                    outcome.uploaded = backup::upload(
+                    outcome.uploaded += backup::upload(
                         &remote,
                         repo,
                         &uploadable,
                         &machine.id,
                         &mut status.uploaded,
                         encryption.as_ref(),
+                        &encrypted_paths,
                     )?;
                     outcome.pruned_remote =
                         backup::prune_remote(&remote, &entries, &machine.id, &mut status.uploaded)?;
@@ -465,6 +507,7 @@ pub(crate) fn sync(
         Ok(())
     })();
     if let Err(err) = &result {
+        status.pending_applications.clear();
         status.last_error = Some(format!("{err:#}"));
         status.failing_since.get_or_insert_with(hstore::now_rfc3339);
         status.consecutive_failures = status.consecutive_failures.saturating_add(1);
@@ -632,11 +675,24 @@ fn record_pending(
 /// Rebuild the incoming plan against current saved files and the latest
 /// fetched branch. Pull never trusts an old pending plan after a save.
 pub(crate) fn refresh(store: &Store, tracked: &TrackedSet, status: &mut SyncStatus) -> Result<()> {
+    refresh_with_interaction(store, tracked, status, false)
+}
+
+pub(crate) fn refresh_with_interaction(
+    store: &Store,
+    tracked: &TrackedSet,
+    status: &mut SyncStatus,
+    interactive: bool,
+) -> Result<()> {
     let repo = store
         .repo()
         .ok_or_else(|| eyre::eyre!("planning requires git"))?;
     let shared = share::current(repo, store, tracked)?;
-    let upstream = reconcile::upstream(repo, repo.ref_oid(UPSTREAM_REF)?.as_deref())?;
+    let upstream = reconcile::upstream_with_interaction(
+        repo,
+        repo.ref_oid(UPSTREAM_REF)?.as_deref(),
+        interactive,
+    )?;
     let plans = prepare(
         repo,
         tracked,

--- a/src/system/history/sync/share.rs
+++ b/src/system/history/sync/share.rs
@@ -20,6 +20,8 @@ pub(crate) struct SharedFile {
     pub local: PathBuf,
     pub mode: String,
     pub oid: String,
+    pub encrypt: bool,
+    pub encrypt_explicit: bool,
 }
 
 /// Why a captured file is not shared.
@@ -58,6 +60,15 @@ pub(crate) fn current(
     store: &Store,
     tracked: &TrackedSet,
 ) -> Result<ShareReport> {
+    // Project-only tracking declarations are intentionally ignored. Preserve
+    // that behavior while refusing malformed encryption or mixed policies.
+    if tracked
+        .invalid
+        .iter()
+        .any(|entry| entry.reason.contains("encrypt"))
+    {
+        eyre::bail!("invalid dotfile declarations; correct them before publishing");
+    }
     let mut report = ShareReport::default();
     let Some(latest) = store.list()?.into_iter().last() else {
         return Ok(report);
@@ -67,6 +78,26 @@ pub(crate) fn current(
     };
     report.checkpoint = Some(latest.checkpoint.uuid.clone());
     let walk = tracked.walk()?;
+    for (index, entry) in walk.entries.iter().enumerate() {
+        if entry.kind == EntryKind::Implicit {
+            continue;
+        }
+        for other in walk
+            .entries
+            .iter()
+            .skip(index + 1)
+            .filter(|e| e.kind != EntryKind::Implicit)
+        {
+            if entry.policy.encrypt != other.policy.encrypt
+                && (entry.path.starts_with(&other.path) || other.path.starts_with(&entry.path))
+            {
+                eyre::bail!(
+                    "overlapping dotfile declarations disagree about encryption: {}",
+                    display_path(&entry.path)
+                );
+            }
+        }
+    }
     let roots = Roots::current();
     let private: BTreeMap<PathBuf, String> = walk
         .private
@@ -129,6 +160,8 @@ pub(crate) fn current(
                 local: path.clone(),
                 mode,
                 oid,
+                encrypt: policy.encrypt,
+                encrypt_explicit: policy.explicit.encrypt,
             },
         );
     }

--- a/src/system/history/tracked.rs
+++ b/src/system/history/tracked.rs
@@ -234,7 +234,13 @@ impl TrackedSet {
                         normalize(&request.source),
                         EntryKind::Source,
                         "source",
-                        Policy::for_mode(FileMode::Track),
+                        Policy {
+                            encrypt: request.policy.encrypt,
+                            share: request.policy.share,
+                            overridden: request.policy.overridden,
+                            explicit: request.policy.explicit,
+                            ..Policy::for_mode(FileMode::Track)
+                        },
                     );
                     source.declared_in = declared_in;
                     set.push(source);
@@ -269,7 +275,13 @@ impl TrackedSet {
                         normalize(&request.source),
                         EntryKind::Source,
                         "source",
-                        Policy::for_mode(FileMode::Track),
+                        Policy {
+                            encrypt: request.policy.encrypt,
+                            share: request.policy.share,
+                            overridden: request.policy.overridden,
+                            explicit: request.policy.explicit,
+                            ..Policy::for_mode(FileMode::Track)
+                        },
                     );
                     source.declared_in = declared_in;
                     set.push(source);
@@ -286,6 +298,15 @@ impl TrackedSet {
             .iter_mut()
             .find(|existing| existing.path == entry.path)
         {
+            if existing.kind != EntryKind::Implicit
+                && entry.kind != EntryKind::Implicit
+                && existing.policy.encrypt != entry.policy.encrypt
+            {
+                self.invalid.push(PathReason {
+                    path: display_path(&entry.path),
+                    reason: "overlapping declarations disagree about encryption".into(),
+                });
+            }
             if rank(entry.kind) > rank(existing.kind) {
                 *existing = entry;
             }
@@ -382,11 +403,14 @@ impl TrackedSet {
                 let Some(target) = resolve_link(&link) else {
                     continue;
                 };
-                if set
-                    .entries
-                    .iter()
-                    .any(|entry| target.starts_with(&entry.path))
-                {
+                if let Some(existing) = set.entry_for(&target) {
+                    if set.entries[owner].policy.encrypt && !existing.policy.encrypt {
+                        eyre::bail!(
+                            "encrypted symlink {} points to a captured plaintext target {}; mark the target encrypted too",
+                            display_path(&link),
+                            display_path(&target)
+                        );
+                    }
                     continue; // already covered
                 }
                 if !target.starts_with(&home) || target == home {
@@ -507,6 +531,7 @@ impl TrackedSet {
                 autosave: entry.policy.autosave,
                 share: entry.policy.share,
                 backup: entry.policy.backup,
+                encrypt: entry.policy.encrypt,
                 state: "live".into(),
                 promotion: None,
                 private: entry.note.clone(),
@@ -522,6 +547,7 @@ impl TrackedSet {
                 autosave: private.policy.autosave,
                 share: private.policy.share,
                 backup: private.policy.backup,
+                encrypt: private.policy.encrypt,
                 state: "live".into(),
                 promotion: None,
                 private: Some(private.reason.clone()),
@@ -847,6 +873,11 @@ pub(crate) fn hard_exclusions() -> Vec<PathBuf> {
     for reserved in ["tracked", "sources", ".mise-history"] {
         dirs.push(config_dir.join(reserved));
     }
+    dirs.extend(
+        crate::agecrypt::identity_paths()
+            .iter()
+            .map(|path| normalize(path)),
+    );
     dirs.sort();
     dirs.dedup();
     dirs

--- a/src/system/history/watch/runtime.rs
+++ b/src/system/history/watch/runtime.rs
@@ -783,8 +783,16 @@ async fn finish_sync(
             "uploaded": outcome.uploaded,
             "pending": outcome.pending,
             "conflicts": outcome.conflicts,
+            "backup_error": outcome.backup_error,
         }),
     );
+    if let Some(error) = &outcome.backup_error {
+        capture.out.emit(
+            "backups-skipped",
+            &format!("machine backups skipped: {error}"),
+            json!({ "message": error }),
+        );
+    }
     let applies = capture
         .sync
         .as_ref()

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,4 @@
 use std::env::join_paths;
-#[cfg(unix)]
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
@@ -122,12 +121,10 @@ fn init() {
 /// Unit tests run single-threaded (`RUST_TEST_THREADS=1` in `.cargo/config.toml`
 /// and in the `test:unit` task), so a guarded set/read/restore sequence is not
 /// observed by other tests.
-#[cfg(unix)]
 pub(crate) struct EnvVarGuard {
     prev: Vec<(OsString, Option<OsString>)>,
 }
 
-#[cfg(unix)]
 impl EnvVarGuard {
     pub(crate) fn new() -> Self {
         Self { prev: vec![] }
@@ -152,7 +149,6 @@ impl EnvVarGuard {
     }
 }
 
-#[cfg(unix)]
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         // restore in reverse so repeated sets of the same key unwind correctly


### PR DESCRIPTION
Stacked on #12882 (`bootstrap/10-auto-sync`). Adds age encryption for selected synced dotfiles and machine recovery backups, including user-installed hardware identity plugins.

## Behavior

```toml
[history.encryption]
recipients = ["<mac-public-recipient>", "<linux-public-recipient>", "<recovery-public-recipient>"]

[dotfiles]
"~/.config/app/credentials" = { mode = "track", encrypt = true }
```

One shared recipient list protects tracked contents and external copy, symlink, and template sources. Each consumer decrypts with its own matching identity. Publication writes versioned envelopes at existing logical paths, binds their contents to the path and original mode, and upgrades the setup marker to format 2. Existing format-1 repositories remain readable; older clients reject format 2.

Reconciliation and conflict decisions use local plaintext objects. Ciphertext is reused when content, mode, and recipients are unchanged. Recipient changes re-encrypt current protected files in one leased branch update. Missing decryption access pauses application and publication for the entire setup; fetching and local history continue. Invalid encryption declarations and overlapping plaintext/encrypted sources fail closed. Inline secrets must move to external sources.

`origin set --encrypt-backups [--recipient …]` configures separate, machine-local backup recipients. Defaults use available age/SSH public keys or generate an age identity. Encrypted files are excluded from plaintext remote backups, including rebuilt historical checkpoints. Encrypted backups can include them under that machine's backup recipients.

User-installed age plugins support Secure Enclave and TPM identities through existing identity settings. Both legacy plugin recipients and native `age1tag` TPM recipients work. Software and hardware recipients can be mixed; hardware-only configurations warn about device loss. Only locally configured identities select plugins. Background work never launches hardware identity plugins, and diagnostics report hardware restorability as configured but unverified. Interactive pull and rollback can request authorization.

Paths, configuration, and recipient public keys remain visible on the shared branch. Live files, rendered outputs, local history, and decrypted caches remain plaintext. Enabling encryption or removing recipients cannot erase earlier Git history or copies already held by other consumers.

## Backup review fixes

- Select the requested checkpoint before decrypting it; unreadable siblings cannot block an unscoped restore.
- Build all replacement wrappers before one atomic push of updates and deletions. Unsupported servers retain existing refs. Record migration success only after publication; interrupted retries remain safe.
- Preserve previously uploaded, locally retained eligible history when changing schemes or recipients without `--include-existing`.
- Validate remote namespace, header, and payload identity before materialization or cached reuse.
- Probe software restorability using actual age decryption, including SSH recipients. Preserve encrypted status when the local origin declaration is missing.
- Keep ordinary plaintext files outside the encrypted-envelope size cap and skip submodule commits during envelope detection; schema validation rejects encrypted inline declarations while preserving `encrypt = false`. Accept SHA-1 and SHA-256 gitlink IDs, and restore test environment values with scoped guards.
- Bound encrypted/compressed input to 256 MiB, decoded input to 1 GiB, and backups to 100,000 files. Validate paths, duplicates, ancestor collisions, and modes before Git writes. Non-UTF-8 paths fail explicitly rather than being silently renamed.

## Validation

Focused history, age, settings, and doctor unit tests; encrypted-file and backup e2e tests plus adjacent sync, watcher, onboarding, rollback, and age environment tests. Regression coverage includes two independent consumers, copy/template/symlink sources, executable modes, deletion, conflict resolution, recipient rotation, no-churn sync, missing keys, malformed settings, atomic-push failure/retry, damaged sibling checkpoints, and scans of published Git objects for protected plaintext.

Protocol fixtures cover hardware/software recipients, native TPM recipient encryption, missing plugins, cancelled authorization, noninteractive refusal, and software recovery. **Real Secure Enclave/TPM hardware has not been exercised.**

Schema, CLI usage/man page, and documentation are updated. The accompanying announcement is updated in jdx/blog#99. Final local checks pass: 66 history tests, 13 age tests, 74 settings tests, 3 doctor tests, the encrypted-file/backup and adjacent e2e coverage, Clippy (`--workspace --all-features --all-targets -- -D warnings`), the no-default-features check with CI's vendored-Lua feature selection and `RUSTFLAGS=-D unused`, formatting, and scoped safe hk fixes. The plain-sync regression also passes. Build/test CI was explicitly dispatched for commit `111476665`: [workflow run](https://github.com/jdx/mise/actions/runs/34059651602).

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*



## Current stack integration (7ec3e38b7)

Rebased onto the current dotfiles stack, preserving status locking, corrupt-state handling, permission-aware reconciliation, and backup deduplication. Incoming validation accepts `encrypt`. Ordinary backup uploads cannot overwrite an existing remote checkpoint; encryption-policy changes retain the dedicated replacement transaction. Local checks passed: 39 sync unit tests, 13 age tests, encrypted-file and encrypted-backup E2Es, encryption schema, permission/purge and preflight regressions, full render, and lint-fix. Real Secure Enclave/TPM hardware remains untested.

CI dispatched for this exact head: [test workflow](https://github.com/jdx/mise/actions/runs/34064079051); results pending.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication-adjacent crypto, remote backup/sync behavior, and Git push semantics (atomic replacement); misconfiguration or partial failure could block sync or leave backups unrestorable without the right identities.
> 
> **Overview**
> Adds **age-based encryption** for dotfiles sync in two independent layers: **shared setup files** (`encrypt = true` on `[dotfiles]` entries plus `[history.encryption].recipients`) and **machine recovery backups** (`mise bootstrap dotfiles origin set --encrypt-backups` with repeatable `--recipient`).
> 
> Shared encrypted content is published as versioned envelopes on the setup branch (format **2**), decrypted for apply/pull/conflict resolution, and excluded from plaintext remote backups. Missing keys or invalid declarations **pause** publication/application for the whole setup rather than falling back to plaintext. Recipient rotation re-encrypts in one branch update; unchanged ciphertext does not churn commits.
> 
> Backup encryption wraps each checkpoint as `backup.toml` + `payload.age`, records `encrypt_backups` / `recipients` in `[history.origin]`, and **atomically replaces** this machine's recovery refs when switching plaintext ↔ encrypted or changing recipients. Rollback decrypts into a local `refs/machines-plain/` cache; `machines`, `status`, and `doctor` report encryption and restorability.
> 
> **`agecrypt`** is refactored into a shared core (identities, `encrypt_bytes`/`decrypt_bytes`, plugin/tagged recipients, size limits, identity generation) with experimental `[env]` age directives moved to `agecrypt/directive`. The `age` dependency enables the **plugin** feature for user-installed hardware identities (interactive only in background paths).
> 
> Schema, CLI/docs/man pages, and CI add e2e coverage for encrypted backups and shared files, plus tombi validation for `encrypt` on dotfile entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91788dfa872f6b0007cc5deb5ced94046a213488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->