### PR TITLE
fix(task): colorize task usage help

### DIFF
--- a/e2e/tasks/test_task_help
+++ b/e2e/tasks/test_task_help
@@ -16,6 +16,15 @@ Arguments:
 Flags:
   -h, --help  Print help"
 
+# Task help follows mise's stdout color policy, including explicit overrides.
+plain_help=$(mise run atask --help)
+[[ $plain_help != *$'\e['* ]] || fail "redirected task help contains ANSI escapes"
+colored_help=$(CLICOLOR_FORCE=1 mise run atask --help)
+[[ $colored_help == *$'\e['* ]] || fail "forced task help has no ANSI styling"
+assert "NO_COLOR=1 CLICOLOR_FORCE=1 mise run atask --help" "$plain_help"
+assert "MISE_COLOR=0 CLICOLOR_FORCE=1 mise run atask --help" "$plain_help"
+assert "CLICOLOR=0 mise run atask --help" "$plain_help"
+
 cat <<'EOF' >mise.toml
 [tasks.greet]
 usage = '''

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1488,7 +1488,12 @@ fn display_task_help(task: &Task) -> Result<()> {
 
 fn render_usage_help(spec: &usage::Spec, args: &[String]) -> String {
     let cmd = usage_command_for_args(spec, args);
-    usage::docs::cli::render_help(spec, cmd, true)
+    let style = if console::colors_enabled() {
+        usage::docs::cli::Style::COLOURED
+    } else {
+        usage::docs::cli::Style::PLAIN
+    };
+    usage::docs::cli::render_help_styled(spec, cmd, true, style)
 }
 
 static AFTER_LONG_HELP: &str = color_print::cstr!(


### PR DESCRIPTION
Task help from `mise run <task> --help` always used usage-lib's plain renderer, even when colors were enabled. Switch to the styled renderer with `Style::COLOURED` when mise enables stdout colors, preserving plain redirected output and existing color overrides.

Addresses https://github.com/jdx/mise/discussions/12896. The locked usage-lib version already supports the API, so no dependency update is needed.

Validation: `mise run build`, `mise run lint-fix`, and `mise run test:e2e e2e/tasks/test_task_help` passed. The e2e run covers task help, help with `--cd`, forced color, redirected output, and `NO_COLOR`, `MISE_COLOR=0`, and `CLICOLOR=0` overrides.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help rendering only; behavior change is cosmetic output with explicit e2e checks for color policy and overrides.
> 
> **Overview**
> **Task usage help** from `mise run <task> --help` now uses the usage library’s **styled** renderer when mise considers stdout colors enabled, instead of always rendering plain text.
> 
> `render_usage_help` picks `Style::COLOURED` vs `Style::PLAIN` via `console::colors_enabled()`, so interactive terminals get colored help while piped/redirected output stays ANSI-free. Existing env overrides (`NO_COLOR`, `MISE_COLOR=0`, `CLICOLOR=0`, etc.) still win over forced color.
> 
> E2E coverage in `test_task_help` asserts plain captured help, ANSI when `CLICOLOR_FORCE=1`, and that override env vars match the plain baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a120a1fe57d64bd569ff4f6fb0e35ce243a8072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Task help output now consistently follows configured color preferences.
  - Help text remains plain when output is redirected or when color is disabled through supported environment settings.
  - Forced color output now applies styling when explicitly enabled, while explicit “no color” settings continue to take precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->