### PR TITLE
ci: enable local mbx caching for performance builds

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -25,13 +25,16 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MBX_DISABLE: "1"
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-mise-rust1.97.1-img5263c143
 
 jobs:
   measure:
+    env:
+      # Persistent appliance-local store; no remote backend is configured.
+      MBX_CACHE_DIR: /var/cache/mbx
+      MBX_REMOTE_URL: ""
     name: Measure
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series
@@ -41,7 +44,7 @@ jobs:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68
-      options: --cpuset-cpus 0-7
+      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx
     timeout-minutes: 30
     permissions:
       contents: read
@@ -50,8 +53,8 @@ jobs:
         with:
           persist-credentials: false
 
-      # Compile inside the pinned job container. Restoring target/ could relabel
-      # a binary built on another runner class as a jdx-perf-v1 measurement.
+      # Compile inside the pinned job container. mise's cache remains disabled:
+      # mbx uses the appliance-local content-addressed store mounted above.
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
@@ -72,6 +75,8 @@ jobs:
             uname -a
             lscpu
             mise --version
+            mbx --version
+            mbx cache dir
             rustc --version
             cargo --version
             valgrind --version


### PR DESCRIPTION
The performance workflow sets `MBX_DISABLE=1`, so `perf:record` rebuilds without caching even though it already invokes `mbx build --release`.

Enable mbx and bind-mount `/var/cache/jdx-perf/mbx` from the performance appliance at `/var/cache/mbx`. Set `MBX_CACHE_DIR` to that mount and leave `MBX_REMOTE_URL` empty for local-only caching. Include the mbx version and cache directory in runner metadata. The pinned container and disabled mise-action cache remain in place.

Validation: actionlint, formatting checks, and `git diff --check` passed. Cache reuse will be verified by subsequent main-branch performance runs; the currently running job uses its original workflow.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change on the dedicated self-hosted perf runner; no app auth or data paths, with local-only mbx storage and the same pinned image and CPU isolation.
> 
> **Overview**
> The **main-branch `perf` workflow** turns **mbx caching back on** by dropping workflow-wide `MBX_DISABLE` and configuring a **local-only** cache on the pinned perf runner.
> 
> The measure job sets `MBX_CACHE_DIR` to `/var/cache/mbx` and `MBX_REMOTE_URL` to empty, and the perf container **bind-mounts** the host path `/var/cache/jdx-perf/mbx` into that directory so `perf:record` / `mbx build --release` can reuse a **persistent content-addressed store** across runs. Comments now state that **mise-action caching stays off** while mbx supplies compile caching.
> 
> **Runner metadata** in the job summary also logs `mbx --version` and `mbx cache dir` for debugging cache behavior on the appliance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24393d1eb859fe46de1f487cb17d1aeb122d5ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Updated performance measurement workflows to use a persistent build cache.
  - Added cache configuration and visibility into the cache tool version and location.
  - Improved reuse of cached compilation data across performance runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->