### PR TITLE
test: improve Windows shim failure diagnostics and cleanup

### DIFF
--- a/e2e-win/lazy_shim.Tests.ps1
+++ b/e2e-win/lazy_shim.Tests.ps1
@@ -46,7 +46,7 @@ jq = { version = "1.7.1", lazy = true, lazy_bins = ["JQ.EXE"] }
         Test-Path (Join-Path $env:MISE_DATA_DIR 'installs\jq\1.7.1') | Should -BeFalse
 
         $output = & $shim --version 2>&1
-        $LASTEXITCODE | Should -Be 0
+        $LASTEXITCODE | Should -Be 0 -Because "native shim output: $($output | Out-String)"
         ($output | Out-String) | Should -Match 'jq-1\.7.1'
         Test-Path (Join-Path $env:MISE_DATA_DIR 'installs\jq\1.7.1') | Should -BeTrue
 
@@ -64,7 +64,7 @@ jq = { version = "1.7.1", lazy = true, lazy_bins = ["JQ.EXE"] }
         Test-Path (Join-Path $env:MISE_DATA_DIR 'installs\jq\1.7.1') | Should -BeFalse
 
         $output = & $shim --version 2>&1
-        $LASTEXITCODE | Should -Be 0
+        $LASTEXITCODE | Should -Be 0 -Because "hardlink shim output: $($output | Out-String)"
         ($output | Out-String) | Should -Match 'jq-1\.7\.1'
         Test-Path (Join-Path $env:MISE_DATA_DIR 'installs\jq\1.7.1') | Should -BeTrue
     }

--- a/e2e-win/shim_recursion.Tests.ps1
+++ b/e2e-win/shim_recursion.Tests.ps1
@@ -10,6 +10,7 @@ Describe 'shim_exec_recursion' {
     BeforeAll {
         $script:originalPath = Get-Location
         $script:originalEnvPath = $env:PATH
+        $script:originalTrustedConfigPaths = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
         Set-Location TestDrive:
         $env:MISE_TRUSTED_CONFIG_PATHS = $TestDrive
 
@@ -43,20 +44,27 @@ echo SHIM_NOT_REAL
         Remove-Item -Path (Join-Path $script:shimPath "mytool.cmd") -ErrorAction SilentlyContinue
         Set-Location $script:originalPath
         $env:PATH = $script:originalEnvPath
-        Remove-Item -Path Env:\MISE_TRUSTED_CONFIG_PATHS -ErrorAction SilentlyContinue
+        if ($null -eq $script:originalTrustedConfigPaths) {
+            Remove-Item -Path Env:\MISE_TRUSTED_CONFIG_PATHS -ErrorAction SilentlyContinue
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:originalTrustedConfigPaths, 'Process')
+        }
 
         # Windows can briefly retain an executable's file lock after its output
-        # stream closes. Remove our fixture directories before Pester tears down
-        # TestDrive, allowing a bounded retry for that transient lock only.
-        foreach ($directory in Get-ChildItem -LiteralPath $TestDrive -Directory) {
+        # stream closes. Wait for exclusive write access without changing files,
+        # then leave fixture removal to Pester's TestDrive teardown.
+        foreach ($executable in Get-ChildItem -LiteralPath $TestDrive -Recurse -File -Filter '*.exe') {
             for ($attempt = 0; ; $attempt++) {
                 try {
-                    Remove-Item -LiteralPath $directory.FullName -Recurse -Force -ErrorAction Stop
+                    $stream = [System.IO.File]::Open($executable.FullName, 'Open', 'ReadWrite', 'None')
+                    $stream.Dispose()
                     break
-                } catch [System.IO.IOException] {
-                    # ERROR_SHARING_VIOLATION / ERROR_LOCK_VIOLATION only.
-                    $errorCode = $_.Exception.HResult -band 0xffff
-                    if ($errorCode -notin @(32, 33) -or $attempt -ge 20) {
+                } catch [System.IO.IOException], [System.UnauthorizedAccessException] {
+                    # File.Open wraps the Windows error in MethodInvocationException.
+                    # Mapped executables can report ERROR_ACCESS_DENIED (5) as well
+                    # as ERROR_SHARING_VIOLATION (32) / ERROR_LOCK_VIOLATION (33).
+                    $errorCode = $_.Exception.GetBaseException().HResult -band 0xffff
+                    if ($errorCode -notin @(5, 32, 33) -or $attempt -ge 20) {
                         throw
                     }
                     Start-Sleep -Milliseconds 100

--- a/e2e-win/shim_recursion.Tests.ps1
+++ b/e2e-win/shim_recursion.Tests.ps1
@@ -41,10 +41,28 @@ echo SHIM_NOT_REAL
 
     AfterAll {
         Remove-Item -Path (Join-Path $script:shimPath "mytool.cmd") -ErrorAction SilentlyContinue
-        Remove-Item -Path $script:toolDir -Recurse -ErrorAction SilentlyContinue
         Set-Location $script:originalPath
         $env:PATH = $script:originalEnvPath
         Remove-Item -Path Env:\MISE_TRUSTED_CONFIG_PATHS -ErrorAction SilentlyContinue
+
+        # Windows can briefly retain an executable's file lock after its output
+        # stream closes. Remove our fixture directories before Pester tears down
+        # TestDrive, allowing a bounded retry for that transient lock only.
+        foreach ($directory in Get-ChildItem -LiteralPath $TestDrive -Directory) {
+            for ($attempt = 0; ; $attempt++) {
+                try {
+                    Remove-Item -LiteralPath $directory.FullName -Recurse -Force -ErrorAction Stop
+                    break
+                } catch [System.IO.IOException] {
+                    # ERROR_SHARING_VIOLATION / ERROR_LOCK_VIOLATION only.
+                    $errorCode = $_.Exception.HResult -band 0xffff
+                    if ($errorCode -notin @(32, 33) -or $attempt -ge 20) {
+                        throw
+                    }
+                    Start-Sleep -Milliseconds 100
+                }
+            }
+        }
     }
 
     It 'mise x resolves real tool, not shim' {


### PR DESCRIPTION
The Windows e2e job in [run 34053274263](https://github.com/jdx/mise/actions/runs/34053274263/job/101541688922) failed first during Pester cleanup because `mytool.exe` was locked, then on retry when the lazy hardlink shim returned exit code 1 without printing its captured output.

Include captured stdout/stderr in native and hardlink lazy-shim exit-code assertions. Before Pester tears down TestDrive, wait for exclusive read/write access to the fixture executables without modifying or deleting them. Retry Windows access-denied, sharing, and lock violations every 100 ms for up to two seconds per executable; persistent failures remain visible. Unwrap PowerShell's method-invocation exceptions to inspect the underlying Windows error. Preserve and restore the original `MISE_TRUSTED_CONFIG_PATHS` value so subsequent tests retain their environment.

Validation: PowerShell 7.5.4 parsing passed. A local harness exercised the actual wait loop using a substitute .NET method to simulate success, transient sharing/lock/access-denied errors, persistent sharing/access-denied errors, and unrelated I/O errors; all seven cases passed. The unmodified file probe preserved a real fixture. Environment restoration passed for unset, empty, and populated values. Scoped hk fix found no applicable rules for the PowerShell file, and `git diff --check` passed. Actual Windows e2e validation remains for CI; the underlying lazy-shim error is still unknown until the improved diagnostics capture it.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved Windows end-to-end test diagnostics by including shim output when exit-code checks fail.
  - Improved cleanup reliability by retrying temporary executable access when files are briefly locked.
  - Preserved the original trusted configuration path environment setting after recursive shim tests, including when it was initially unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->