### PR TITLE
registry: add muse code

### DIFF
--- a/e2e/backend/test_http_redirect_format
+++ b/e2e/backend/test_http_redirect_format
@@ -44,6 +44,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             # Deliberately misleading suffix: explicit format must win.
             "/artifact.zip": "artifact.tar.gz",
             "/raw-tool": "raw-tool",
+            "/download/": "raw-tool",
         }
         filename = files.get(path)
         if filename is None:
@@ -98,6 +99,15 @@ assert_contains "mise x -- redirect-tool" "redirected archive"
 cat >mise.toml <<EOF
 [tools]
 "http:redirect-raw" = { version = "1.0.0", url = "http://127.0.0.1:$PORT/raw", bin = "redirect-raw" }
+EOF
+
+mise install
+assert_contains "mise x -- redirect-raw" "redirected raw file"
+
+# Query-selected downloads may have no filename in the URL path.
+cat >mise.toml <<EOF
+[tools]
+"http:query-raw" = { version = "1.0.0", url = "http://127.0.0.1:$PORT/download/?file=raw-tool", bin = "redirect-raw" }
 EOF
 
 mise install

--- a/registry/muse.toml
+++ b/registry/muse.toml
@@ -1,0 +1,25 @@
+description = "Meta's Muse Code AI coding agent"
+os = ["linux", "macos", "windows"]
+test = { cmd = "muse --version", expected = "{{version}}" }
+version_order = "source"
+
+bins = ["muse"]
+[[backends]]
+full = "http:muse"
+
+[backends.options]
+bin = "muse"
+checksum_expr = '"sha256:" + fromJSON(body).artifacts[(arch == "x64" ? "x86" : "aarch64") + "_" + os].checksum'
+checksum_url = "https://lookaside.facebook.com/lookaside/muse/download/?channel=muse&version={{ version }}&file=manifest.json"
+url = 'https://lookaside.facebook.com/lookaside/muse/download/?channel=muse&version={{ version }}&file=muse-{{ arch(x64="x86", arm64="aarch64") }}-{{ os() }}'
+# The stable channel publishes the current release rather than a version history.
+version_json_path = ".version"
+version_list_url = "https://api.meta.ai/muse-code/channels/muse-stable"
+
+[backends.options.platforms.windows-arm64]
+bin = "muse.exe"
+url = "https://lookaside.facebook.com/lookaside/muse/download/?channel=muse&version={{ version }}&file=muse-aarch64-windows.exe"
+
+[backends.options.platforms.windows-x64]
+bin = "muse.exe"
+url = "https://lookaside.facebook.com/lookaside/muse/download/?channel=muse&version={{ version }}&file=muse-x86-windows.exe"

--- a/src/backend/static_helpers.rs
+++ b/src/backend/static_helpers.rs
@@ -598,8 +598,9 @@ pub(crate) fn get_filename_from_url(url_str: &str) -> String {
         // Use proper URL parsing to get the path and extract filename
         url.path_segments()
             .and_then(|mut segments| segments.next_back())
+            .filter(|segment| !segment.is_empty())
             .map(|s| s.to_string())
-            .unwrap_or_else(|| url_str.to_string())
+            .unwrap_or_else(|| "download".to_string())
     } else {
         // Fallback to simple parsing for non-URL strings or malformed URLs
         url_str
@@ -1568,6 +1569,20 @@ mod tests {
     use super::*;
     use crate::toolset::ToolVersionOptions;
     use indexmap::IndexMap;
+
+    #[test]
+    fn test_get_filename_from_url() {
+        for (url, expected) in [
+            ("https://example.com/download/?file=muse", "download"),
+            ("https://example.com/?file=muse", "download"),
+            ("https://example.com", "download"),
+            ("https://example.com/muse.tar.gz?token=value", "muse.tar.gz"),
+            ("https://example.com/my%20tool.zip", "my tool.zip"),
+            ("tool.tar.gz", "tool.tar.gz"),
+        ] {
+            assert_eq!(get_filename_from_url(url), expected, "{url}");
+        }
+    }
 
     const SHA256_LOWER: &str = "7fdd1f42e6b0855421ecf27bb406e2492ade1087c85e30ebf0deab6280ea743c";
     const SHA256_UPPER: &str = "7FDD1F42E6B0855421ECF27BB406E2492ADE1087C85E30EBF0DEAB6280EA743C";


### PR DESCRIPTION
Add `muse` for Meta’s Muse Code CLI using its official HTTP downloads, stable-channel version discovery, and per-platform SHA-256 manifest. Support macOS, Linux, and Windows on x64 and arm64. The channel exposes the current stable release, not historical version listings.

Meta’s artifact endpoint ends in `/` and selects the binary through query parameters. Fix the shared download-filename helper to use `download` when the URL path has no filename; previously installation failed with `Is a directory`. Include unit coverage and an HTTP installation regression.

## Popularity
- Maintainer-authorized exception: @jdx explicitly requested this addition despite the usual popularity requirement.
- The CLI’s public adoption/download counts could not be verified.
- Related SDK only: [meta-models/muse-code-sdk](https://github.com/meta-models/muse-code-sdk) has 17 stars and 2 forks, last pushed 2026-09-02; these are not CLI adoption figures.
- Official [stable channel](https://api.meta.ai/muse-code/channels/muse-stable) currently publishes `1.0.3-R2198.1`.

## Validation
- `mise run lint-fix`
- `mise run build`
- `mise x -- cargo test --all-features --bin mise test_get_filename_from_url`
- `mise run test:e2e e2e/backend/test_http_redirect_format`
- Rebuilt `mise ls-remote muse` and `mise test-tool muse` on macOS arm64; output: `Muse Code 1.0.3 (1.0.3-R2198.1)`.
- Generated lock entries for all six platforms from the entry’s HTTP options and compared every URL and checksum with Meta’s manifest; installed with `--locked` on macOS arm64.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The shared filename helper affects all backends that derive local names from URLs (not only Muse); behavior changes for pathless URLs but is covered by tests and a targeted e2e.
> 
> **Overview**
> Adds a **`muse`** registry entry for Meta’s Muse Code CLI: HTTP downloads from lookaside, stable-channel version discovery, manifest-driven **SHA-256** checksums, and Windows-specific binary URLs.
> 
> Fixes **`get_filename_from_url`** when the URL path has no real filename (e.g. `/download/?file=…` or a trailing slash). Empty final path segments are ignored and the inferred name is **`download`** instead of the full URL or a directory path, which previously broke HTTP installs with **“Is a directory”**. Unit tests cover the new cases; the HTTP redirect e2e adds a **query-only** download scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b90af0ab6ffeff83b34491b0e1166954c25129a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for installing Meta’s Muse Code AI coding agent across supported Linux, macOS, and Windows architectures.
  - Muse versions and platform-specific downloads are resolved automatically.

- **Bug Fixes**
  - Improved download naming for URLs without a usable path by assigning the filename `download`.
  - Preserved correct filename handling for URLs with paths and percent-encoded characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->