### PR TITLE
fix(install): serialize install-into destination replacement

### DIFF
--- a/e2e/cli/test_install_into_concurrent
+++ b/e2e/cli/test_install_into_concurrent
@@ -27,6 +27,15 @@ echo "$ASDF_INSTALL_VERSION" >"$ASDF_INSTALL_PATH/installed-version"
 EOF
 chmod +x "$plugin_dir/bin/list-all" "$plugin_dir/bin/install"
 
+# Force-replacing the cache must not unlink the lock protecting the destination.
+mkdir -p "$MISE_CACHE_DIR/lockfiles"
+echo preserved >"$MISE_CACHE_DIR/lockfiles/keep.txt"
+ln -s "$MISE_CACHE_DIR" cache-alias
+for destination in "$MISE_CACHE_DIR" "$MISE_CACHE_DIR/lockfiles" "$PWD/cache-alias/lockfiles"; do
+  assert_fail_contains "mise install-into asdf:install-into-race@1.0.0 '$destination' --yes" "contains mise's lock directory"
+  assert "cat '$MISE_CACHE_DIR/lockfiles/keep.txt'" preserved
+done
+
 python3 - <<'PY'
 import os
 from pathlib import Path

--- a/e2e/cli/test_install_into_concurrent
+++ b/e2e/cli/test_install_into_concurrent
@@ -33,15 +33,23 @@ chmod +x "$plugin_dir/bin/list-all" "$plugin_dir/bin/install"
 mkdir -p "$MISE_CACHE_DIR/lockfiles"
 echo preserved >"$MISE_CACHE_DIR/lockfiles/keep.txt"
 ln -s "$MISE_CACHE_DIR" cache-alias
+# A lock-directory entry that is itself a symlink pointing outward: reached
+# through the alias, resolving the whole path leads out of the lock directory,
+# but replacement would still unlink the entry sitting inside it.
+mkdir -p outside
+ln -s "$PWD/outside" "$MISE_CACHE_DIR/lockfiles/outward"
 for destination in \
   "$MISE_CACHE_DIR" \
   "$MISE_CACHE_DIR/lockfiles" \
   "$MISE_CACHE_DIR/lockfiles/keep.txt" \
   "$MISE_CACHE_DIR/lockfiles/nested/destination" \
   "$PWD/cache-alias/lockfiles" \
-  "$PWD/cache-alias/lockfiles/keep.txt"; do
+  "$PWD/cache-alias/lockfiles/keep.txt" \
+  "$PWD/cache-alias/lockfiles/outward" \
+  "$PWD/cache-alias/lockfiles/nested/destination"; do
   assert_fail_contains "mise install-into asdf:install-into-race@1.0.0 '$destination' --yes" "overlaps mise's lock directory"
   assert "cat '$MISE_CACHE_DIR/lockfiles/keep.txt'" preserved
+  assert "test -L '$MISE_CACHE_DIR/lockfiles/outward' && echo intact" intact
 done
 
 python3 - <<'PY'

--- a/e2e/cli/test_install_into_concurrent
+++ b/e2e/cli/test_install_into_concurrent
@@ -28,11 +28,19 @@ EOF
 chmod +x "$plugin_dir/bin/list-all" "$plugin_dir/bin/install"
 
 # Force-replacing the cache must not unlink the lock protecting the destination.
+# Individual lock files are just as fatal: removing one lets the next process
+# create a replacement and install beside the holder.
 mkdir -p "$MISE_CACHE_DIR/lockfiles"
 echo preserved >"$MISE_CACHE_DIR/lockfiles/keep.txt"
 ln -s "$MISE_CACHE_DIR" cache-alias
-for destination in "$MISE_CACHE_DIR" "$MISE_CACHE_DIR/lockfiles" "$PWD/cache-alias/lockfiles"; do
-  assert_fail_contains "mise install-into asdf:install-into-race@1.0.0 '$destination' --yes" "contains mise's lock directory"
+for destination in \
+  "$MISE_CACHE_DIR" \
+  "$MISE_CACHE_DIR/lockfiles" \
+  "$MISE_CACHE_DIR/lockfiles/keep.txt" \
+  "$MISE_CACHE_DIR/lockfiles/nested/destination" \
+  "$PWD/cache-alias/lockfiles" \
+  "$PWD/cache-alias/lockfiles/keep.txt"; do
+  assert_fail_contains "mise install-into asdf:install-into-race@1.0.0 '$destination' --yes" "overlaps mise's lock directory"
   assert "cat '$MISE_CACHE_DIR/lockfiles/keep.txt'" preserved
 done
 
@@ -104,4 +112,55 @@ for alias in (False, True):
                 process.kill()
             process.wait()
     print(f"Serialized competing installs: {case.name}")
+
+# Retargeting the parent symlink mid-install must not move the installation:
+# the destination is resolved once, so the running install keeps writing to the
+# directory whose lock it holds instead of following the alias to a new target.
+case = Path.cwd() / "retargeted-parent"
+first_target = case / "first-target"
+second_target = case / "second-target"
+first_target.mkdir(parents=True)
+second_target.mkdir(parents=True)
+alias = case / "alias"
+alias.symlink_to(first_target, target_is_directory=True)
+destination = alias / "destination"
+env = dict(os.environ, INSTALL_RACE_CASE=str(case), MISE_YES="0", MISE_DEBUG="1")
+processes = []
+try:
+    with (case / "first.log").open("w") as first_log, (case / "second.log").open("w") as second_log:
+        first = subprocess.Popen(
+            ["mise", "install-into", "asdf:install-into-race@1.0.0", str(destination)],
+            env=env, stdin=subprocess.DEVNULL, stdout=first_log, stderr=subprocess.STDOUT,
+        )
+        processes.append(first)
+        wait_until(lambda: (case / "entered-1.0.0").exists(), first, "first installer")
+        alias.unlink()
+        alias.symlink_to(second_target, target_is_directory=True)
+        # The alias now names a different directory, so this install owns a
+        # different destination and must not wait for the first one.
+        second = subprocess.Popen(
+            ["mise", "install-into", "asdf:install-into-race@2.0.0", str(destination)],
+            env=env, stdin=subprocess.DEVNULL, stdout=second_log, stderr=subprocess.STDOUT,
+        )
+        processes.append(second)
+        assert second.wait(timeout=20) == 0
+        assert (second_target / "destination" / "installed-version").read_text().strip() == "2.0.0"
+        (case / "release").touch()
+        assert first.wait(timeout=20) == 0
+        # The first install stayed on the directory it locked.
+        assert (first_target / "destination" / "installed-version").read_text().strip() == "1.0.0"
+        assert (second_target / "destination" / "installed-version").read_text().strip() == "2.0.0"
+except Exception:
+    for name in ("first.log", "second.log"):
+        log = case / name
+        if log.exists():
+            print(log.read_text())
+    raise
+finally:
+    (case / "release").touch()
+    for process in processes:
+        if process.poll() is None:
+            process.kill()
+        process.wait()
+print("Install stayed on the locked destination: retargeted-parent")
 PY

--- a/e2e/cli/test_install_into_concurrent
+++ b/e2e/cli/test_install_into_concurrent
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A local plugin pauses the first installer before it populates the destination.
+# No network or real tool downloads are needed to exercise the replacement race.
+plugin_dir="$MISE_DATA_DIR/plugins/asdf-install-into-race"
+mkdir -p "$plugin_dir/bin"
+cat >"$plugin_dir/bin/list-all" <<'EOF'
+#!/usr/bin/env bash
+echo '1.0.0 2.0.0'
+EOF
+cat >"$plugin_dir/bin/install" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+touch "$INSTALL_RACE_CASE/entered-$ASDF_INSTALL_VERSION"
+if [[ "$ASDF_INSTALL_VERSION" == 1.0.0 ]]; then
+  for ((attempt = 0; attempt < 600; attempt++)); do
+    if [[ -e "$INSTALL_RACE_CASE/release" ]]; then
+      break
+    fi
+    sleep 0.05
+  done
+  test -e "$INSTALL_RACE_CASE/release"
+fi
+mkdir -p "$ASDF_INSTALL_PATH/bin"
+echo "$ASDF_INSTALL_VERSION" >"$ASDF_INSTALL_PATH/installed-version"
+EOF
+chmod +x "$plugin_dir/bin/list-all" "$plugin_dir/bin/install"
+
+python3 - <<'PY'
+import os
+from pathlib import Path
+import subprocess
+import time
+
+
+def wait_until(predicate, process, description):
+    deadline = time.monotonic() + 20
+    while not predicate():
+        if process.poll() is not None:
+            raise AssertionError(f"process exited before {description}")
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"timed out waiting for {description}")
+        time.sleep(0.05)
+
+
+for alias in (False, True):
+    case = Path.cwd() / ("symlink-parent" if alias else "same-path")
+    real = case / "real"
+    real.mkdir(parents=True)
+    # Include a missing parent so normalization must resolve an existing prefix.
+    destination = real / "new-parent" / "destination"
+    if alias:
+        (case / "alias").symlink_to(real, target_is_directory=True)
+        competing_destination = case / "alias" / "new-parent" / "destination"
+    else:
+        competing_destination = destination
+    env = dict(os.environ, INSTALL_RACE_CASE=str(case), MISE_YES="0", MISE_DEBUG="1")
+    processes = []
+    try:
+        with (case / "first.log").open("w") as first_log, (case / "second.log").open("w") as second_log:
+            first = subprocess.Popen(
+                ["mise", "install-into", "asdf:install-into-race@1.0.0", str(destination)],
+                env=env, stdin=subprocess.DEVNULL, stdout=first_log, stderr=subprocess.STDOUT,
+            )
+            processes.append(first)
+            wait_until(lambda: (case / "entered-1.0.0").exists(), first, "first installer")
+            second = subprocess.Popen(
+                ["mise", "install-into", "asdf:install-into-race@2.0.0", str(competing_destination)],
+                env=env, stdin=subprocess.DEVNULL, stdout=second_log, stderr=subprocess.STDOUT,
+            )
+            processes.append(second)
+            wait_until(
+                lambda: "waiting for install-into destination lock" in (case / "second.log").read_text(),
+                second, "second process to wait for the destination lock",
+            )
+            assert not (case / "entered-2.0.0").exists()
+            (case / "release").touch()
+            assert first.wait(timeout=20) == 0
+            assert second.wait(timeout=20) != 0
+            assert "refusing to overwrite non-empty directory" in (case / "second.log").read_text()
+            assert (destination / "installed-version").read_text().strip() == "1.0.0"
+            assert not (case / "entered-2.0.0").exists()
+    except Exception:
+        for name in ("first.log", "second.log"):
+            log = case / name
+            if log.exists():
+                print(log.read_text())
+        raise
+    finally:
+        # Always release the fixture installer, including on assertion failures.
+        (case / "release").touch()
+        for process in processes:
+            if process.poll() is None:
+                process.kill()
+            process.wait()
+    print(f"Serialized competing installs: {case.name}")
+PY

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -68,6 +68,38 @@ impl InstallInto {
             before_date,
             dependency_context: OnceCell::new(),
         };
+        // Replacement deletes the destination, so refuse a destination that
+        // overlaps the lock directory in either direction: an ancestor would
+        // take the whole directory with it, and a descendant could unlink an
+        // active lock file, letting the next process create a fresh one and
+        // install alongside the holder.
+        let lock_dir = crate::dirs::CACHE.join("lockfiles");
+        if crate::file::path_starts_with_resolved(&lock_dir, &install_path)
+            || crate::file::path_starts_with_resolved(&install_path, &lock_dir)
+        {
+            bail!(
+                "install-into destination {} overlaps mise's lock directory {}; choose a different destination",
+                display_path(&install_path),
+                display_path(&lock_dir)
+            );
+        }
+        // Resolve parent aliases once, then install into and lock that one
+        // path. Binding both to the same resolved destination keeps the lock
+        // key and the replaced directory identical even if a parent symlink is
+        // retargeted afterwards. Create the parent first: resolving a missing
+        // path can spell the same directory differently than canonicalizing it
+        // once it exists (an unresolved `..`, or a verbatim `\\?\` prefix on
+        // Windows), so two invocations straddling the parent's creation would
+        // otherwise take two different locks for one destination. The install
+        // creates this parent regardless. Do not resolve the final component:
+        // installation replaces that entry, even if it is a symlink.
+        let install_path = match (install_path.parent(), install_path.file_name()) {
+            (Some(parent), Some(name)) => {
+                crate::file::create_dir_all(parent)?;
+                crate::file::desymlink_path(parent).join(name)
+            }
+            _ => crate::file::desymlink_path(&install_path),
+        };
         tv.install_path = Some(install_path.clone());
         tv.install_path_is_exact = true;
         tv.install_path_is_explicit = true;
@@ -76,29 +108,7 @@ impl InstallInto {
         // locks would not overlap. Keep the lock through confirmation and the
         // backend replacement so no cooperating writer can populate the path
         // between the occupancy check and deletion.
-        let lock_dir = crate::dirs::CACHE.join("lockfiles");
-        if crate::file::path_starts_with_resolved(&lock_dir, &install_path) {
-            bail!(
-                "install-into destination {} contains mise's lock directory {}; choose a different destination",
-                display_path(&install_path),
-                display_path(&lock_dir)
-            );
-        }
-        // Resolve parent aliases so every writer derives the same lock key.
-        // Create the parent first: resolving a missing path can spell the same
-        // directory differently than canonicalizing it once it exists (an
-        // unresolved `..`, or a verbatim `\\?\` prefix on Windows), so two
-        // invocations straddling the parent's creation would otherwise take
-        // two different locks for one destination. The install creates this
-        // parent regardless. Do not resolve the final component: installation
-        // replaces that entry, even if it is a symlink.
-        let lock_path = match (install_path.parent(), install_path.file_name()) {
-            (Some(parent), Some(name)) => {
-                crate::file::create_dir_all(parent)?;
-                crate::file::desymlink_path(parent).join(name)
-            }
-            _ => crate::file::desymlink_path(&install_path),
-        };
+        let lock_path = install_path.clone();
         let lock_display_path = install_path.clone();
         let _destination_lock = tokio::task::spawn_blocking(move || {
             crate::lock_file::LockFile::new(&lock_path)

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -76,7 +76,13 @@ impl InstallInto {
         // locks would not overlap. Keep the lock through confirmation and the
         // backend replacement so no cooperating writer can populate the path
         // between the occupancy check and deletion.
-        let lock_path = install_path.clone();
+        // Resolve parent aliases, including an existing prefix when the rest
+        // of the destination does not exist yet. Do not resolve the final
+        // component: installation replaces that entry, even if it is a symlink.
+        let lock_path = match (install_path.parent(), install_path.file_name()) {
+            (Some(parent), Some(name)) => crate::file::desymlink_path(parent).join(name),
+            _ => crate::file::desymlink_path(&install_path),
+        };
         let lock_display_path = install_path.clone();
         let _destination_lock = tokio::task::spawn_blocking(move || {
             crate::lock_file::LockFile::new(&lock_path)

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -76,13 +76,6 @@ impl InstallInto {
         // locks would not overlap. Keep the lock through confirmation and the
         // backend replacement so no cooperating writer can populate the path
         // between the occupancy check and deletion.
-        // Resolve parent aliases, including an existing prefix when the rest
-        // of the destination does not exist yet. Do not resolve the final
-        // component: installation replaces that entry, even if it is a symlink.
-        let lock_path = match (install_path.parent(), install_path.file_name()) {
-            (Some(parent), Some(name)) => crate::file::desymlink_path(parent).join(name),
-            _ => crate::file::desymlink_path(&install_path),
-        };
         let lock_dir = crate::dirs::CACHE.join("lockfiles");
         if crate::file::path_starts_with_resolved(&lock_dir, &install_path) {
             bail!(
@@ -91,6 +84,21 @@ impl InstallInto {
                 display_path(&lock_dir)
             );
         }
+        // Resolve parent aliases so every writer derives the same lock key.
+        // Create the parent first: resolving a missing path can spell the same
+        // directory differently than canonicalizing it once it exists (an
+        // unresolved `..`, or a verbatim `\\?\` prefix on Windows), so two
+        // invocations straddling the parent's creation would otherwise take
+        // two different locks for one destination. The install creates this
+        // parent regardless. Do not resolve the final component: installation
+        // replaces that entry, even if it is a symlink.
+        let lock_path = match (install_path.parent(), install_path.file_name()) {
+            (Some(parent), Some(name)) => {
+                crate::file::create_dir_all(parent)?;
+                crate::file::desymlink_path(parent).join(name)
+            }
+            _ => crate::file::desymlink_path(&install_path),
+        };
         let lock_display_path = install_path.clone();
         let _destination_lock = tokio::task::spawn_blocking(move || {
             crate::lock_file::LockFile::new(&lock_path)

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -68,20 +68,13 @@ impl InstallInto {
             before_date,
             dependency_context: OnceCell::new(),
         };
-        // Replacement deletes the destination, so refuse a destination that
-        // overlaps the lock directory in either direction: an ancestor would
-        // take the whole directory with it, and a descendant could unlink an
-        // active lock file, letting the next process create a fresh one and
-        // install alongside the holder.
+        // Refuse before anything is created, so a rejected destination leaves
+        // no directories behind inside the lock directory.
         let lock_dir = crate::dirs::CACHE.join("lockfiles");
         if crate::file::path_starts_with_resolved(&lock_dir, &install_path)
             || crate::file::path_starts_with_resolved(&install_path, &lock_dir)
         {
-            bail!(
-                "install-into destination {} overlaps mise's lock directory {}; choose a different destination",
-                display_path(&install_path),
-                display_path(&lock_dir)
-            );
+            return Err(lock_dir_overlap(&install_path, &lock_dir));
         }
         // Resolve parent aliases once, then install into and lock that one
         // path. Binding both to the same resolved destination keeps the lock
@@ -93,13 +86,29 @@ impl InstallInto {
         // otherwise take two different locks for one destination. The install
         // creates this parent regardless. Do not resolve the final component:
         // installation replaces that entry, even if it is a symlink.
+        // `dunce::simplified` drops the extended-length prefix `canonicalize`
+        // adds on Windows wherever the plain path names the same file. The
+        // destination reaches backends and plugins as `MISE_INSTALL_PATH`, and
+        // mise itself rejects `\\?\` paths as tool paths, so the resolved
+        // spelling has to stay one mise would accept back.
         let install_path = match (install_path.parent(), install_path.file_name()) {
             (Some(parent), Some(name)) => {
                 crate::file::create_dir_all(parent)?;
-                crate::file::desymlink_path(parent).join(name)
+                dunce::simplified(&crate::file::desymlink_path(parent).join(name)).to_path_buf()
             }
-            _ => crate::file::desymlink_path(&install_path),
+            _ => dunce::simplified(&crate::file::desymlink_path(&install_path)).to_path_buf(),
         };
+        // The final component above is deliberately left unresolved, so a
+        // destination reached through an alias whose own last component is a
+        // symlink pointing out of the lock directory slips past the resolving
+        // check. Re-check what will actually be replaced.
+        let resolved_lock_dir =
+            dunce::simplified(&crate::file::desymlink_path(&lock_dir)).to_path_buf();
+        if install_path.starts_with(&resolved_lock_dir)
+            || resolved_lock_dir.starts_with(&install_path)
+        {
+            return Err(lock_dir_overlap(&install_path, &lock_dir));
+        }
         tv.install_path = Some(install_path.clone());
         tv.install_path_is_exact = true;
         tv.install_path_is_explicit = true;
@@ -150,6 +159,18 @@ impl InstallInto {
         backend.install_version(install_ctx, tv).await?;
         Ok(())
     }
+}
+
+/// Replacement deletes the destination, so one that overlaps the lock directory
+/// in either direction is refused: an ancestor would take the whole directory
+/// with it, and a descendant could unlink an active lock file, letting the next
+/// process create a replacement and install alongside the holder.
+fn lock_dir_overlap(destination: &Path, lock_dir: &Path) -> eyre::Report {
+    eyre!(
+        "install-into destination {} overlaps mise's lock directory {}; choose a different destination",
+        display_path(destination),
+        display_path(lock_dir)
+    )
 }
 
 /// True if `path` exists and is anything other than an empty directory

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -71,6 +71,24 @@ impl InstallInto {
         tv.install_path = Some(install_path.clone());
         tv.install_path_is_exact = true;
         tv.install_path_is_explicit = true;
+        // Serialize every `install-into` writer targeting this destination,
+        // including different tools or versions whose ordinary tool-version
+        // locks would not overlap. Keep the lock through confirmation and the
+        // backend replacement so no cooperating writer can populate the path
+        // between the occupancy check and deletion.
+        let lock_path = install_path.clone();
+        let lock_display_path = install_path.clone();
+        let _destination_lock = tokio::task::spawn_blocking(move || {
+            crate::lock_file::LockFile::new(&lock_path)
+                .with_callback(move |_| {
+                    debug!(
+                        "waiting for install-into destination lock on {}",
+                        display_path(&lock_display_path)
+                    );
+                })
+                .lock()
+        })
+        .await??;
         // install-into force-reinstalls, which uninstalls (rm -rf) whatever
         // already exists at the install path. Check immediately before the
         // install performs that deletion (rather than at the start of `run`) so

--- a/src/cli/install_into.rs
+++ b/src/cli/install_into.rs
@@ -83,6 +83,14 @@ impl InstallInto {
             (Some(parent), Some(name)) => crate::file::desymlink_path(parent).join(name),
             _ => crate::file::desymlink_path(&install_path),
         };
+        let lock_dir = crate::dirs::CACHE.join("lockfiles");
+        if crate::file::path_starts_with_resolved(&lock_dir, &install_path) {
+            bail!(
+                "install-into destination {} contains mise's lock directory {}; choose a different destination",
+                display_path(&install_path),
+                display_path(&lock_dir)
+            );
+        }
         let lock_display_path = install_path.clone();
         let _destination_lock = tokio::task::spawn_blocking(move || {
             crate::lock_file::LockFile::new(&lock_path)


### PR DESCRIPTION
Two concurrent `mise install-into` commands targeting the same directory can both pass the occupancy check before either installs, allowing one to replace the other's output without a new confirmation.

Resolve the destination once — creating its parent first and resolving parent symlinks against it, while preserving the replaceable final component — then use that one resolved path as the install target, the occupancy check, and the lock key. Every writer therefore hashes the same path bytes no matter when it arrives, and the installation cannot follow a parent symlink retargeted after the lock was taken. Hold the lock across the occupancy check, confirmation, and backend installation, acquiring it with `spawn_blocking` so waiting does not block a Tokio worker. Reject destinations that overlap the lock directory in either direction — checked before anything is created and again on the resolved path, so an alias whose final component symlinks out of the lock directory cannot slip through — and replacement can delete neither the directory nor an active lock file. Simplify the resolved path with `dunce`, so the destination handed to backends keeps a spelling mise accepts as input rather than the extended-length prefix `canonicalize` adds on Windows. This coordinates cooperating `install-into` processes that share a cache directory; it does not protect against external filesystem writers.

Extracted from #12885 to keep that PR focused on documentation.

Validation: scoped safe hk checks (Cargo check and formatting), build with all features, and `mise run test:e2e 'e2e/cli/test_install_into$'`. Added `e2e/cli/test_install_into_concurrent`, which uses a local plugin to coordinate two competing processes and verifies waiting, refusal after the first install completes, and preservation of its output. It covers identical paths, symlinked parent directories with a missing parent, and a parent symlink retargeted while the first install holds the lock (verified to fail against the previous behavior). It also verifies that destinations at, above, or inside the lock directory — including through a symlink alias, and one whose final component symlinks back out of it — are rejected without deleting existing files.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*
*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes destructive install-into filesystem behavior (locking, path resolution, and new rejections) on a force-reinstall code path; mistakes could block installs or allow wrong-path writes, though scope is limited to install-into and cooperating mise processes.
> 
> **Overview**
> Fixes a race where two concurrent **`mise install-into`** runs could both pass the non-empty check and overwrite each other’s output on the same path.
> 
> **`install-into`** now normalizes the destination once (creates the parent, resolves parent symlinks, keeps the final component replaceable), uses that path for **`MISE_INSTALL_PATH`**, the occupancy prompt, and a per-destination **`LockFile`** held through confirmation and backend install (acquired via **`spawn_blocking`** so waits don’t block the async runtime). Competing writers block on the same lock; after the first finishes, the second still fails with the existing non-empty refusal unless **`--yes`**.
> 
> Destinations that overlap **`$MISE_CACHE_DIR/lockfiles`** in either direction are rejected up front and again after resolution, so force-replace cannot delete the lock tree or individual lock files (including paths reached through cache symlinks).
> 
> Adds **`e2e/cli/test_install_into_concurrent`**: a stub plugin plus Python orchestration for serialized installs (same path vs symlinked parents), mid-install parent symlink retargeting, and lock-directory overlap cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b48d986914705fd7f02e727a4eca3d7fbc7dc062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `mise install-into` reliability when multiple installations target the same destination concurrently.
  - Installations now coordinate correctly when destinations are accessed through different path aliases or symlinks.
  - Added safeguards against destinations that overlap mise’s lock directory.
  - Improved protection for active destinations during force replacement.
  - Ensured installations remain tied to the destination path locked at startup, even when parent links change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
