### PR TITLE
feat(install): concise fractional install progress for non-TTY output

### DIFF
--- a/e2e/backend/test_aqua_cosign
+++ b/e2e/backend/test_aqua_cosign
@@ -15,7 +15,7 @@ echo "=== Testing Native Cosign Verification (checksum-level) ==="
 echo "Installing fork-cleaner with native Cosign verification..."
 
 # Capture the installation output to verify the native verification is being used
-output=$(mise install aqua:caarlos0/fork-cleaner@2.4.0 2>&1)
+output=$(mise install --verbose aqua:caarlos0/fork-cleaner@2.4.0 2>&1)
 echo "$output"
 
 # Verify the native Cosign verification was used
@@ -35,7 +35,7 @@ echo "✓ fork-cleaner installed and working correctly"
 echo "=== Testing Native Cosign Verification (top-level binary config) ==="
 echo "Installing envsense with top-level binary Cosign verification..."
 
-output=$(mise install aqua:technicalpickles/envsense@0.3.4 2>&1)
+output=$(mise install --verbose aqua:technicalpickles/envsense@0.3.4 2>&1)
 echo "$output"
 
 if echo "$output" | grep -q "Cosign verified" && ! echo "$output" | grep -q "verify checksums with cosign"; then
@@ -53,7 +53,7 @@ echo "✓ envsense installed and working correctly"
 echo "=== Testing Native Cosign Verification (public key bundle config) ==="
 echo "Installing kube-linter with native public-key bundle verification..."
 
-output=$(mise install aqua:stackrox/kube-linter@0.8.3 2>&1)
+output=$(mise install --verbose aqua:stackrox/kube-linter@0.8.3 2>&1)
 echo "$output"
 
 if echo "$output" | grep -q "Cosign verified"; then

--- a/e2e/backend/test_aqua_github_attestations
+++ b/e2e/backend/test_aqua_github_attestations
@@ -14,7 +14,7 @@ echo "=== Testing Native GitHub Artifact Attestations Verification ==="
 echo "Installing goreleaser with native GitHub artifact attestations verification..."
 
 # Capture the installation output to verify the native verification is being used
-output=$(mise install aqua:goreleaser/goreleaser@2.14.1 2>&1)
+output=$(mise install --verbose aqua:goreleaser/goreleaser@2.14.1 2>&1)
 echo "$output"
 
 # Verify the native GitHub artifact attestations verification was used

--- a/e2e/backend/test_aqua_slsa
+++ b/e2e/backend/test_aqua_slsa
@@ -13,7 +13,7 @@ echo "=== Testing Native SLSA Verification ==="
 echo "Installing sops with native SLSA verification..."
 
 # Capture the installation output to verify the native verification is being used
-output=$(mise install aqua:getsops/sops@3.9.0 2>&1)
+output=$(mise install --verbose aqua:getsops/sops@3.9.0 2>&1)
 echo "$output"
 
 # Verify the native SLSA verification was used

--- a/e2e/cli/test_install_text_progress
+++ b/e2e/cli/test_install_text_progress
@@ -49,6 +49,11 @@ assert "grep -c 'hook-failed' output.log" "1"
 if [[ $output == *'✓ dummy@1.0.2'* ]]; then
   fail "postinstall failure was reported as a successful install: $output"
 fi
+# The reason on the failure line is the worker's error, not whatever phase the
+# tool happened to be in when it died.
+if [[ $output == *'failed: running postinstall hook'* ]]; then
+  fail "failure line reported a phase as the reason: $output"
+fi
 
 # Explicit output modes keep their existing behavior.
 echo '[tools]' >mise.toml

--- a/e2e/cli/test_install_text_progress
+++ b/e2e/cli/test_install_text_progress
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# Captured stderr gets concise progress even outside CI.
+export CI=0 MISE_COLOR=0 MISE_DEBUG=0 MISE_TRACE=0 MISE_LOG_LEVEL=info
+export MISE_FORCE_PROGRESS=0
+
+output=$(mise install dummy@1.0.0 2>&1)
+printf '%s\n' "$output" >output.log
+assert_contains 'cat output.log' 'installing 1 tool'
+assert_contains 'cat output.log' '✓ dummy@1.0.0'
+assert_contains 'cat output.log' '████████████████ 1/1 · installed 1 tool in'
+if [[ $output == *'[1/'* || $output == *$'\033['* ]]; then
+  fail "captured install should not emit operation counters or cursor controls: $output"
+fi
+
+# The timer must keep emitting elapsed time through a slow postinstall hook, and
+# the tool must not be marked complete until that hook returns. A child process's
+# own output stays immediate; only the phase messages mise generates are folded
+# into the periodic snapshot.
+cat >mise.toml <<'TOML'
+[tools]
+dummy = { version = "1.0.1", postinstall = "sleep 4; echo hook-finished" }
+TOML
+output=$(mise install 2>&1)
+printf '%s\n' "$output" >output.log
+assert_contains 'cat output.log' '0/1 ·'
+assert_contains 'cat output.log' 'running postinstall hook'
+assert_contains 'cat output.log' 'hook-finished'
+after_hook=${output##*hook-finished}
+printf '%s\n' "$after_hook" >after-hook.log
+assert_contains 'cat after-hook.log' '✓ dummy@1.0.1'
+assert_contains 'cat after-hook.log' '1/1 · installed 1 tool in'
+
+# Failures must not acquire a success checkmark, even after backend installation.
+cat >mise.toml <<'TOML'
+[tools]
+dummy = { version = "1.0.2", postinstall = "echo hook-failed; exit 1" }
+TOML
+if output=$(mise install 2>&1); then
+  fail "failing postinstall should fail the command"
+fi
+printf '%s\n' "$output" >output.log
+assert_contains 'cat output.log' '✗ dummy@1.0.2'
+assert_contains 'cat output.log' 'installed 0 tools · 1 failed'
+# A failed hook's output is present exactly once, not duplicated by the replay
+# CmdLineRunner does for reporters that hide stdout.
+assert_contains 'cat output.log' 'hook-failed'
+assert "grep -c 'hook-failed' output.log" "1"
+if [[ $output == *'✓ dummy@1.0.2'* ]]; then
+  fail "postinstall failure was reported as a successful install: $output"
+fi
+
+# Explicit output modes keep their existing behavior.
+echo '[tools]' >mise.toml
+for mode in '--quiet' '--verbose' '--raw' '--dry-run'; do
+  output=$(mise install --force dummy@1.1.0 "$mode" 2>&1)
+  if [[ $output == *'█'* || $output == *'installing 1 tool'* ]]; then
+    fail "$mode unexpectedly enabled concise progress: $output"
+  fi
+done
+
+# CI may allocate a PTY. It should still get append-only output on stderr.
+python3 - <<'PY'
+import errno
+import os
+import pty
+import subprocess
+
+master, slave = pty.openpty()
+env = dict(os.environ, CI="1")
+proc = subprocess.Popen(
+    ["mise", "install", "--force", "dummy@1.0.0"],
+    stdout=subprocess.DEVNULL, stderr=slave, env=env,
+)
+os.close(slave)
+output = bytearray()
+try:
+    while True:
+        try:
+            chunk = os.read(master, 8192)
+        except OSError as error:
+            if error.errno == errno.EIO:
+                break
+            raise
+        if not chunk:
+            break
+        output.extend(chunk)
+finally:
+    os.close(master)
+assert proc.wait() == 0, output.decode()
+assert b"1/1" in output and b"installed 1 tool in" in output, output.decode()
+assert b"\x1b[" not in output, output.decode()
+PY

--- a/e2e/core/test_python_github_attestations
+++ b/e2e/core/test_python_github_attestations
@@ -7,7 +7,7 @@ export MISE_PYTHON_GITHUB_ATTESTATIONS=1
 
 # Use a recent Python version that has attestations in python-build-standalone.
 # Older releases (e.g. 3.12.3) predate GitHub attestation support and will fail.
-output=$(mise install python@3.13.5 2>&1) || true
+output=$(mise install --verbose python@3.13.5 2>&1) || true
 echo "$output"
 
 # Verify attestation verification was attempted and succeeded

--- a/e2e/core/test_python_precompiled
+++ b/e2e/core/test_python_precompiled
@@ -2,7 +2,9 @@
 
 export MISE_PYTHON_COMPILE=0
 export MISE_PYTHON_GITHUB_ATTESTATIONS=0
-assert_contains "mise use python@3.12.3 2>&1" "cpython-"
+# Assert the precompiled artifact was used rather than a source build. The
+# filename is phase detail, which only --verbose prints per line.
+assert_contains "mise use --verbose python@3.12.3 2>&1" "cpython-"
 assert_contains "mise x -- python --version" "Python 3.12.3"
 
 rm mise.toml
@@ -12,7 +14,7 @@ mise rm python@3.12.3
 mise settings set idiomatic_version_file_enable_tools python
 
 echo '3.12.3' >.python-version
-assert_contains "mise i 2>&1" "mise python@3.12.3"
+assert_contains "mise i 2>&1" "python@3.12.3"
 assert_contains "mise x -- python --version" "Python 3.12.3"
 
 # Disable idiomatic version files for python to test override behavior

--- a/e2e/core/test_ruby_github_attestations
+++ b/e2e/core/test_ruby_github_attestations
@@ -11,7 +11,7 @@ echo "=== Testing Ruby GitHub Artifact Attestations Verification ==="
 # Test: Install Ruby with GitHub artifact attestations verification enabled
 echo "Installing Ruby with GitHub artifact attestations verification enabled..."
 
-output=$(mise install ruby@3.4.8 2>&1) || true
+output=$(mise install --verbose ruby@3.4.8 2>&1) || true
 echo "$output"
 
 # Check if attestation verification was attempted

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -2484,6 +2484,9 @@ impl AquaBackend {
     ) -> Result<()> {
         let tarball_path = tv.download_path().join(filename);
         if tarball_path.exists() {
+            // Say so: a reporter that only sees the fetch vanish would show a
+            // suspiciously instant install, and the download cache is why.
+            ctx.pr.set_message(format!("cached {filename}"));
             return Ok(());
         }
         ctx.pr.set_message(format!("download {filename}"));

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -1267,7 +1267,9 @@ impl Backend for HttpBackend {
             let cache_path = Self::cache_path(&cache_dir, &cache_plan.key);
             let _lock = crate::lock_file::get(&cache_path, ctx.force)?;
             let extraction_type = if Self::is_cached(&cache_dir, &cache_plan.key) {
-                ctx.pr.set_message("using cached tarball".into());
+                // The download happened; it is the unpacked tree that is reused.
+                // Not "cached <file>", which reporters read as a skipped fetch.
+                ctx.pr.set_message("extracting from cache".into());
                 ctx.pr.set_length(1);
                 ctx.pr.set_position(1);
                 self.extraction_type_from_cache(&cache_dir, &cache_plan.key, &cache_plan.file_info)

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3379,14 +3379,14 @@ pub(crate) trait Backend: Debug + Send + Sync {
         // backend and tool-level hooks.
         ctx.dependency_context(&tv.request).await?;
 
-        // Query backend for operation count and set up progress tracking
-        let install_ops = self.install_operation_count(&tv, &ctx).await;
-        let total_ops = if will_uninstall {
-            install_ops + 1
-        } else {
-            install_ops
-        };
-        ctx.pr.start_operations(total_ops);
+        // Query backend for its operation plan and set up progress tracking
+        let mut weights = self.install_operation_weights(&tv, &ctx).await;
+        if will_uninstall {
+            // Removing the old install is bookkeeping next to fetching the new
+            // one, so it leads the plan with a small share.
+            weights.insert(0, UNINSTALL_OPERATION_WEIGHT);
+        }
+        ctx.pr.start_operations_weighted(&weights);
 
         if will_uninstall {
             self.uninstall_version_unlocked(&ctx.config, &tv, ctx.pr.as_ref(), false)
@@ -3582,6 +3582,17 @@ pub(crate) trait Backend: Debug + Send + Sync {
     /// Default is 3: download, checksum, extract
     async fn install_operation_count(&self, _tv: &ToolVersion, _ctx: &InstallContext) -> usize {
         3
+    }
+
+    /// Relative cost of each install operation, in the order they run.
+    ///
+    /// Only used to pace a progress display, so an estimate is fine and nothing
+    /// may depend on it. The default assumes the shape almost every backend
+    /// here has — fetch the artifact, then verify and unpack it — and weights
+    /// the fetch accordingly. Override it where that does not hold, such as a
+    /// backend that compiles from source.
+    async fn install_operation_weights(&self, tv: &ToolVersion, ctx: &InstallContext) -> Vec<f64> {
+        default_operation_weights(self.install_operation_count(tv, ctx).await)
     }
 
     /// Whether this version could install here at all, judged without downloading anything.
@@ -5271,6 +5282,29 @@ mod latest_version_tests {
 
 /// Helper function for calculating install operation count in HTTP/S3-style backends.
 /// Used by HttpBackend and S3Backend to avoid code duplication.
+/// Share of an install the initial fetch is assumed to take when a backend has
+/// not said otherwise. Downloading is normally the long pole; verification and
+/// extraction split what is left.
+const DOWNLOAD_OPERATION_WEIGHT: f64 = 0.7;
+
+/// Replacing an existing install before the new one is fetched.
+const UNINSTALL_OPERATION_WEIGHT: f64 = 0.05;
+
+/// Weight the first operation as the fetch and split the remainder evenly over
+/// whatever verification and unpacking steps the backend declared.
+pub(crate) fn default_operation_weights(count: usize) -> Vec<f64> {
+    match count {
+        0 => vec![],
+        1 => vec![1.0],
+        n => {
+            let rest = (1.0 - DOWNLOAD_OPERATION_WEIGHT) / (n - 1) as f64;
+            std::iter::once(DOWNLOAD_OPERATION_WEIGHT)
+                .chain(std::iter::repeat_n(rest, n - 1))
+                .collect()
+        }
+    }
+}
+
 pub(crate) fn http_install_operation_count(
     has_checksum_opt: bool,
     platform_key: &str,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3366,6 +3366,10 @@ pub(crate) trait Backend: Debug + Send + Sync {
             (ctx.force || rolling_reinstall) && self.is_version_installed(&ctx.config, &tv, true);
 
         if install_satisfied && !will_uninstall {
+            ctx.pr.finish_with_icon(
+                "already installed".into(),
+                crate::ui::progress_report::ProgressIcon::Skipped,
+            );
             return Ok(tv);
         }
 
@@ -3435,7 +3439,7 @@ pub(crate) trait Backend: Debug + Send + Sync {
         install_state::clear_incomplete_marker_best_effort(&tv.ba().short, &tv.tv_pathname());
         if let Some(script) = tv.request.options().get("postinstall") {
             ctx.pr
-                .finish_with_message("running custom postinstall hook".to_string());
+                .set_message("running custom postinstall hook".to_string());
             self.run_postinstall_hook(&ctx, &tv, script).await?;
         }
         ctx.pr.finish_with_message("installed".to_string());

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1768,7 +1768,7 @@ impl<'a> CmdLineRunner<'a> {
             .or(self.pr_arc.as_ref().map(|arc| arc.as_ref().as_ref()))
         {
             if !line.trim().is_empty() {
-                pr.set_message(line)
+                pr.set_process_output(line)
             }
         } else {
             let mut stdout = std::io::stdout().lock();
@@ -1816,11 +1816,12 @@ impl<'a> CmdLineRunner<'a> {
         {
             Some(pr) => {
                 error!("{} failed", self.get_program());
-                if self.on_stdout.is_none() {
+                if self.on_stdout.is_none() && !pr.shows_process_output() {
                     // Stdout was hidden behind the progress indicator
-                    // (pr.set_message) so replay it on failure. Only replay
+                    // (pr.set_process_output) so replay it on failure. Only replay
                     // stdout — stderr was already printed during execution
-                    // via pr.println.
+                    // via pr.println. Reporters that already showed stdout as it
+                    // arrived would only duplicate it here.
                     let stdout_only: String = output
                         .into_iter()
                         .filter(|(_, source)| matches!(source, OutputSource::Stdout))

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -612,6 +612,8 @@ impl Backend for JavaPlugin {
                             .await?;
                         // Optionally verify checksum if present
                         self.verify_checksum(ctx, &mut tv, &tarball_path)?;
+                    } else {
+                        ctx.pr.set_message(format!("cached {filename}"));
                     }
 
                     // Fetch metadata for installation (for install/move logic)

--- a/src/plugins/core/node.rs
+++ b/src/plugins/core/node.rs
@@ -270,8 +270,7 @@ impl NodePlugin {
         let settings = Settings::get();
         let tarball_name = local.file_name().unwrap().to_string_lossy().to_string();
         if local.exists() {
-            ctx.pr
-                .set_message(format!("using previously downloaded {tarball_name}"));
+            ctx.pr.set_message(format!("cached {tarball_name}"));
         } else {
             ctx.pr.set_message(format!("download {tarball_name}"));
             HTTP.download_file(url.clone(), local, Some(ctx.pr.as_ref()))

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -24,6 +24,7 @@ use crate::toolset::tool_request::ToolRequest;
 use crate::toolset::tool_source::ToolSource;
 use crate::toolset::tool_version::{ResolveOptions, ToolVersion};
 use crate::ui::multi_progress_report::MultiProgressReport;
+use crate::ui::text_install_progress::{TextInstallProgress, TextToolProgress};
 use crate::{backend, config, hooks, runtime_symlinks, shims};
 
 impl Toolset {
@@ -280,6 +281,10 @@ impl Toolset {
             opts.reason.clone()
         };
         mpr.init_footer(opts.dry_run, &footer_reason, versions.len());
+        let mut text_progress =
+            (mpr.use_text_install_output() && !opts.raw && !opts.dry_run).then(|| {
+                TextInstallProgress::new(versions.iter().map(|tr| (tool_key(tr), tr.to_string())))
+            });
 
         hooks::run_one_hook_with_context(
             config,
@@ -321,8 +326,9 @@ impl Toolset {
         preflight_system_deps(config, &versions, opts).await;
 
         // Build dependency graph and install using Kahn's algorithm
-        let (installed, failed, attempted_failures) =
-            self.install_with_deps(config, versions, opts).await;
+        let (installed, failed, attempted_failures) = self
+            .install_with_deps(config, versions, opts, text_progress.as_ref())
+            .await;
         let failed_backends = attempted_failures
             .iter()
             .filter_map(|tr| tr.backend().ok())
@@ -339,6 +345,13 @@ impl Toolset {
         let mut all_failed = disabled_backend_errors;
         all_failed.extend(plugin_errors);
         all_failed.extend(failed);
+        if let Some(progress) = text_progress.as_mut() {
+            progress.finish(
+                all_failed
+                    .iter()
+                    .map(|(tr, error)| (tool_key(tr), error.to_string())),
+            );
+        }
 
         // Skip config reload and resolve in dry-run mode
         if !opts.dry_run {
@@ -487,6 +500,7 @@ impl Toolset {
         config: &Arc<Config>,
         versions: Vec<ToolRequest>,
         opts: &InstallOptions,
+        text_progress: Option<&TextInstallProgress>,
     ) -> (
         Vec<ToolVersion>,
         Vec<(ToolRequest, eyre::Error)>,
@@ -591,9 +605,13 @@ impl Toolset {
                             let opts = opts.clone();
                             let tr_clone = tr.clone();
 
+                            let progress = text_progress.and_then(|p| p.start_tool(&tool_key(&tr)));
                             let handle = jset.spawn(async move {
                                 let _permit = permit;
-                                let result = Self::install_single_tool(&config, &ts, &tr, &opts).await;
+                                let result = Self::install_single_tool(&config, &ts, &tr, &opts, progress.as_ref()).await;
+                                if let Some(progress) = progress {
+                                    progress.complete(result.is_ok());
+                                }
                                 (tr, result)
                             });
                             in_flight.insert(handle.id(), tr_clone);
@@ -659,6 +677,7 @@ impl Toolset {
         ts: &Arc<Toolset>,
         tr: &ToolRequest,
         opts: &Arc<InstallOptions>,
+        text_progress: Option<&TextToolProgress>,
     ) -> Result<ToolVersion> {
         let mpr = MultiProgressReport::get();
         let pre_resolve_backend = tr.backend()?;
@@ -680,7 +699,12 @@ impl Toolset {
         let ctx = InstallContext {
             config: config.clone(),
             ts: ts.clone(),
-            pr: mpr.add_with_options(&tv.style(), opts.dry_run),
+            pr: if let Some(progress) = text_progress {
+                progress.set_prefix(tv.style());
+                Box::new(progress.clone())
+            } else {
+                mpr.add_with_options(&tv.style(), opts.dry_run)
+            },
             force: opts.force,
             dry_run: opts.dry_run,
             locked: config.invocation_locked_for(tr.source(), opts.locked)

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -281,10 +281,13 @@ impl Toolset {
             opts.reason.clone()
         };
         mpr.init_footer(opts.dry_run, &footer_reason, versions.len());
-        let mut text_progress =
-            (mpr.use_text_install_output() && !opts.raw && !opts.dry_run).then(|| {
-                TextInstallProgress::new(versions.iter().map(|tr| (tool_key(tr), tr.to_string())))
-            });
+        let mut text_progress = (mpr.use_text_install_output()
+            && !opts.raw
+            && !opts.dry_run
+            && !versions.is_empty())
+        .then(|| {
+            TextInstallProgress::new(versions.iter().map(|tr| (tool_key(tr), tr.to_string())))
+        });
 
         hooks::run_one_hook_with_context(
             config,

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -610,7 +610,8 @@ impl Toolset {
                                 let _permit = permit;
                                 let result = Self::install_single_tool(&config, &ts, &tr, &opts, progress.as_ref()).await;
                                 if let Some(progress) = progress {
-                                    progress.complete(result.is_ok());
+                                    let error = result.as_ref().err().map(|e| e.to_string());
+                                    progress.complete(error.as_deref());
                                 }
                                 (tr, result)
                             });

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod progress_report;
 pub(crate) mod prompt;
 pub(crate) mod style;
 pub(crate) mod table;
+pub(crate) mod text_install_progress;
 pub(crate) mod theme;
 pub(crate) mod time;
 pub(crate) mod tree;

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -152,11 +152,26 @@ impl MultiProgressReport {
         self.pause_state.lock().unwrap().count
     }
 
+    /// Serialize append-only snapshots with prompt ownership. Holding this lock
+    /// through the write prevents a prompt from starting between the check and
+    /// the heartbeat's output.
+    pub(crate) fn with_progress_unpaused(&self, render: impl FnOnce()) {
+        let state = self.pause_state.lock().unwrap();
+        if state.count == 0 {
+            render();
+        }
+    }
+
     fn resume_progress(&self) {
         let mut state = self.pause_state.lock().unwrap();
         if state.release() {
             progress::resume();
         }
+    }
+
+    pub(crate) fn use_text_install_output(&self) -> bool {
+        let settings = Settings::get();
+        !self.quiet && !self.use_progress_ui && !settings.verbose && !settings.raw
     }
 
     pub(crate) fn add(&self, prefix: &str) -> Box<dyn SingleReport> {

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -209,6 +209,13 @@ impl SingleReport for VerboseReport {
     fn println(&self, message: String) {
         safe_eprintln!("{message}");
     }
+    fn set_process_output(&self, message: String) {
+        // Not set_message: its dedup collapses repeated phase text, which would
+        // silently drop a child's repeated stdout lines now that
+        // `shows_process_output` suppresses the failure replay.
+        let prefix = pad_prefix(self.pad, &self.prefix);
+        log::info!("{prefix} {message}");
+    }
     fn shows_process_output(&self) -> bool {
         true
     }

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -70,6 +70,16 @@ pub(crate) trait SingleReport: Send + Sync + std::fmt::Debug {
     /// Then each set_length() call will allocate 33.33% of the total progress
     fn start_operations(&self, _count: usize) {}
 
+    /// Declare the operations with a relative cost for each, in the order they
+    /// run, when the backend can estimate them better than "all equal".
+    ///
+    /// This only paces a progress display. The numbers are estimates — a
+    /// download's share of an install varies with the artifact and the network
+    /// — so nothing may depend on them being right.
+    fn start_operations_weighted(&self, weights: &[f64]) {
+        self.start_operations(weights.len());
+    }
+
     /// Advance to the next operation
     /// Call this before each new stage (after the first one)
     fn next_operation(&self) {}

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -17,9 +17,6 @@ pub(crate) enum ProgressIcon {
     Skipped,
     #[allow(dead_code)]
     Warning,
-    // Constructed only by the brew package managers (`#[cfg(unix)]`), so it reads
-    // as never-constructed on the windows build.
-    #[cfg_attr(windows, allow(dead_code))]
     Error,
 }
 
@@ -37,6 +34,22 @@ impl Display for ProgressIcon {
 pub(crate) trait SingleReport: Send + Sync + std::fmt::Debug {
     fn println(&self, _message: String) {}
     fn set_message(&self, _message: String) {}
+
+    /// A line of a child process's stdout, as opposed to a phase message a
+    /// backend produced itself.
+    ///
+    /// Reporters that only have room for one status line fold it in and rely on
+    /// [`crate::cmd::CmdLineRunner`] replaying the whole stream when the command
+    /// fails. Reporters that show it as it arrives say so with
+    /// [`Self::shows_process_output`], which suppresses that replay.
+    fn set_process_output(&self, message: String) {
+        self.set_message(message);
+    }
+
+    /// Whether [`Self::set_process_output`] reaches the user immediately.
+    fn shows_process_output(&self) -> bool {
+        false
+    }
     fn inc(&self, _delta: u64) {}
     fn set_position(&self, _delta: u64) {}
     fn set_length(&self, _length: u64) {}
@@ -195,6 +208,9 @@ impl VerboseReport {
 impl SingleReport for VerboseReport {
     fn println(&self, message: String) {
         safe_eprintln!("{message}");
+    }
+    fn shows_process_output(&self) -> bool {
+        true
     }
     fn set_message(&self, message: String) {
         let mut prev_message = self.prev_message.lock().unwrap();

--- a/src/ui/text_install_progress.rs
+++ b/src/ui/text_install_progress.rs
@@ -19,6 +19,139 @@ struct Tool {
     message: String,
     outcome: Option<Outcome>,
     skipped: bool,
+    /// Relative cost of each install operation, in the order they run, as the
+    /// backend estimated it. Empty until the backend declares its plan.
+    weights: Vec<f64>,
+    completed_ops: usize,
+    transfer: Option<Transfer>,
+    /// The file the backend chose to download, from its `download <name>`
+    /// status. Kept for the completion line: "which artifact did it pick?" is a
+    /// question people ask the log after the fact, and a fast install never
+    /// lives long enough to appear in a snapshot.
+    artifact: Option<String>,
+    /// The backend found the artifact already downloaded and skipped the fetch.
+    /// Without saying so, a 0.3s install of an 80 MB tool looks like a lie.
+    reused: bool,
+    /// Never decreases. A backend that restarts a download (a range request
+    /// that the server refuses, a retry) would otherwise walk the bar
+    /// backwards, which reads as the install having gone wrong.
+    fraction: f64,
+}
+
+/// Byte progress for the operation currently running.
+#[derive(Debug, Clone, Copy)]
+struct Transfer {
+    done: u64,
+    total: u64,
+    started: Instant,
+    /// Bytes already on disk when this transfer began, from a resumed
+    /// download. Excluded from the rate so a resume does not report a
+    /// throughput the network never achieved.
+    resumed_at: u64,
+}
+
+impl Transfer {
+    fn fraction(&self) -> Option<f64> {
+        (self.total > 0).then(|| (self.done as f64 / self.total as f64).clamp(0.0, 1.0))
+    }
+
+    /// Average over this transfer rather than an instantaneous rate: the
+    /// snapshot only lands every few seconds, so a sampled rate would report
+    /// whichever moment it happened to catch.
+    fn rate(&self, now: Instant) -> Option<f64> {
+        let seconds = now.saturating_duration_since(self.started).as_secs_f64();
+        let moved = self.done.saturating_sub(self.resumed_at);
+        (seconds > 0.5 && moved > 0).then(|| moved as f64 / seconds)
+    }
+}
+
+impl Tool {
+    /// How far through its own install this tool is, in [0, 1].
+    ///
+    /// Operations are weighted by the backend's estimate of their cost, and the
+    /// one in flight is filled by its byte progress when it has any. This paces
+    /// the bar; it is not a time estimate, and nothing about the install depends
+    /// on it being accurate.
+    fn compute_fraction(&self) -> f64 {
+        if self.outcome.is_some() {
+            return 1.0;
+        }
+        let total: f64 = self.weights.iter().sum();
+        if total <= 0.0 {
+            return 0.0;
+        }
+        let done: f64 = self.weights.iter().take(self.completed_ops).sum();
+        let current = self
+            .transfer
+            .and_then(|t| t.fraction())
+            .and_then(|f| self.weights.get(self.completed_ops).map(|w| w * f))
+            .unwrap_or(0.0);
+        // Reserve the tail: a tool is only 1.0 once its worker returns, since
+        // postinstall hooks and cleanup run after the last declared operation.
+        ((done + current) / total).clamp(0.0, 0.99)
+    }
+
+    fn advance(&mut self) {
+        self.fraction = self.compute_fraction().max(self.fraction);
+    }
+
+    /// `42.1/78.3 MB · 12.4 MB/s`, dropping whichever half is unknown. A server
+    /// that sends no content-length still gets a running byte count.
+    fn transfer_detail(&self, now: Instant) -> String {
+        let Some(transfer) = self.transfer else {
+            return String::new();
+        };
+        if transfer.done == 0 && transfer.total == 0 {
+            return String::new();
+        }
+        let bytes = if transfer.total > 0 {
+            format!(
+                "{}/{}",
+                format_bytes_in(transfer.done, transfer.total),
+                format_bytes(transfer.total)
+            )
+        } else {
+            format_bytes(transfer.done)
+        };
+        match transfer.rate(now) {
+            Some(rate) => format!("{bytes} · {}/s", format_bytes(rate.round() as u64)),
+            None => bytes,
+        }
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KB: f64 = 1_000.0;
+    const MB: f64 = 1_000_000.0;
+    const GB: f64 = 1_000_000_000.0;
+    let bytes = bytes as f64;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes / GB)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{:.0} kB", bytes / KB)
+    } else {
+        format!("{bytes:.0} B")
+    }
+}
+
+/// The running half of `42.1/78.3 MB`: scaled to the total's unit and printed
+/// without it, so the pair reads as one measurement instead of two.
+fn format_bytes_in(bytes: u64, total: u64) -> String {
+    const KB: f64 = 1_000.0;
+    const MB: f64 = 1_000_000.0;
+    const GB: f64 = 1_000_000_000.0;
+    let (unit, decimals) = if total as f64 >= GB {
+        (GB, 1)
+    } else if total as f64 >= MB {
+        (MB, 1)
+    } else if total as f64 >= KB {
+        (KB, 0)
+    } else {
+        (1.0, 0)
+    };
+    format!("{:.*}", decimals, bytes as f64 / unit)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,12 +176,19 @@ impl State {
             .unwrap_or(0)
     }
 
+    /// The bar fills fractionally — a tool halfway through its own install
+    /// occupies half the width a finished one would — while the count beside it
+    /// stays whole tools, which is the number that can be verified against the
+    /// completion lines above.
     fn bar(&self) -> String {
         let total = self.tools.len();
         let complete = self.tools.iter().filter(|t| t.outcome.is_some()).count();
-        let filled = (complete * BAR_WIDTH)
-            .checked_div(total)
-            .unwrap_or(BAR_WIDTH);
+        let progress = if total == 0 {
+            1.0
+        } else {
+            self.tools.iter().map(|t| t.fraction).sum::<f64>() / total as f64
+        };
+        let filled = ((progress * BAR_WIDTH as f64).round() as usize).min(BAR_WIDTH);
         format!(
             "{}{} {complete}/{total}",
             style::ecyan("█".repeat(filled)),
@@ -58,14 +198,48 @@ impl State {
 
     fn snapshot(&self, now: Instant) -> String {
         let mut lines = vec![format!("{} · {}", self.bar(), elapsed(self.started, now))];
+        // Columns size to their content on every snapshot. A fixed width would
+        // either truncate a status like "running postinstall hook" or reserve
+        // blank space for a transfer column most rows never fill.
+        let rows: Vec<_> = self
+            .tools
+            .iter()
+            .filter(|t| t.outcome.is_none())
+            .filter_map(|tool| {
+                let started = tool.started?;
+                Some((
+                    tool.prefix.as_str(),
+                    tool.message.as_str(),
+                    tool.transfer_detail(now),
+                    elapsed(started, now),
+                    tool.artifact.as_deref(),
+                ))
+            })
+            .collect();
         let width = self.width();
-        for tool in self.tools.iter().filter(|t| t.outcome.is_none()) {
-            if let Some(started) = tool.started {
-                let prefix = console::pad_str(&tool.prefix, width, console::Alignment::Left, None);
-                let message =
-                    console::pad_str(&tool.message, 30, console::Alignment::Left, Some("…"));
-                lines.push(format!("  {prefix}  {message}  {}", elapsed(started, now)));
+        let message_width = column_width(rows.iter().map(|r| r.1));
+        let detail_width = column_width(rows.iter().map(|r| r.2.as_str()));
+        for (prefix, message, detail, elapsed, artifact) in rows {
+            let mut line = format!(
+                "  {}  {}",
+                console::pad_str(prefix, width, console::Alignment::Left, None),
+                console::pad_str(message, message_width, console::Alignment::Left, None),
+            );
+            if detail_width > 0 {
+                line.push_str("  ");
+                line.push_str(&console::pad_str(
+                    &detail,
+                    detail_width,
+                    console::Alignment::Left,
+                    None,
+                ));
             }
+            line.push_str(&format!("  {elapsed}"));
+            if let Some(artifact) = artifact {
+                // Last, dimmed, so its length cannot disturb the columns.
+                line.push_str(&format!("  {}", style::edim(artifact)));
+            }
+            lines.push(line);
         }
         let queued = self
             .tools
@@ -85,17 +259,24 @@ impl State {
             return None;
         }
         tool.outcome = Some(outcome);
+        tool.fraction = 1.0;
+        tool.transfer = None;
         let prefix = console::pad_str(&tool.prefix, width, console::Alignment::Left, None);
         let duration = tool
             .started
             .map(|started| format!("  {}", elapsed(started, now)))
             .unwrap_or_default();
         let (icon, detail) = match outcome {
+            Outcome::Installed if tool.reused => (ProgressIcon::Success, " · cached".into()),
             Outcome::Installed => (ProgressIcon::Success, String::new()),
             Outcome::Skipped => (ProgressIcon::Skipped, " · already installed".into()),
             Outcome::Failed => (ProgressIcon::Error, format!(" · failed: {}", tool.message)),
         };
-        Some(format!("{icon} {prefix}{duration}{detail}"))
+        let artifact = match (&tool.artifact, outcome) {
+            (Some(artifact), Outcome::Installed) => format!("  {}", style::edim(artifact)),
+            _ => String::new(),
+        };
+        Some(format!("{icon} {prefix}{duration}{detail}{artifact}"))
     }
 
     fn summary(&self, now: Instant) -> String {
@@ -134,6 +315,10 @@ fn first_line(error: &str) -> String {
     error.lines().next().unwrap_or("installation failed").into()
 }
 
+fn column_width<'a>(cells: impl Iterator<Item = &'a str>) -> usize {
+    cells.map(console::measure_text_width).max().unwrap_or(0)
+}
+
 fn tool_noun(count: usize) -> &'static str {
     if count == 1 { "tool" } else { "tools" }
 }
@@ -170,6 +355,12 @@ impl TextInstallProgress {
                     message: "queued".into(),
                     outcome: None,
                     skipped: false,
+                    weights: vec![],
+                    completed_ops: 0,
+                    transfer: None,
+                    artifact: None,
+                    reused: false,
+                    fraction: 0.0,
                 })
                 .collect(),
         }));
@@ -254,6 +445,16 @@ pub(crate) struct TextToolProgress {
 }
 
 impl TextToolProgress {
+    /// Mutate this tool's state and refresh its cached fraction. Every progress
+    /// signal goes through here so the bar can never be stale relative to the
+    /// rows printed beside it.
+    fn with_tool(&self, f: impl FnOnce(&mut Tool)) {
+        let mut state = self.state.lock().unwrap();
+        let tool = &mut state.tools[self.index];
+        f(tool);
+        tool.advance();
+    }
+
     pub(crate) fn set_prefix(&self, prefix: String) {
         self.state.lock().unwrap().tools[self.index].prefix = prefix;
     }
@@ -285,17 +486,36 @@ impl SingleReport for TextToolProgress {
         // Keep counters from embedded package managers, but omit artifact names
         // from the common download/checksum/extract status messages.
         let message = message.replace(['\r', '\n'], " ");
-        let message = match message.split_whitespace().next() {
-            Some("download") => "downloading",
-            Some("checksum") => "verifying checksum",
-            Some("extract") => "extracting",
-            Some("install") => "installing",
-            Some("running") if message == "running custom postinstall hook" => {
-                "running postinstall hook"
+        let mut words = message.split_whitespace();
+        let mut reused = false;
+        let (phase, artifact) = match words.next() {
+            Some("download") => ("downloading", words.next()),
+            Some("cached") => {
+                reused = true;
+                ("reusing download", words.next())
             }
-            _ => &message,
+            // The http backend's older wording for the same thing.
+            Some("using") if message == "using cached tarball" => {
+                reused = true;
+                ("reusing download", None)
+            }
+            Some("checksum") => ("verifying checksum", None),
+            Some("extract") => ("extracting", None),
+            Some("install") => ("installing", None),
+            Some("running") if message == "running custom postinstall hook" => {
+                ("running postinstall hook", None)
+            }
+            _ => (message.as_str(), None),
         };
-        self.state.lock().unwrap().tools[self.index].message = message.into();
+        let phase = phase.to_string();
+        let artifact = artifact.map(str::to_string);
+        self.with_tool(|tool| {
+            tool.message = phase;
+            tool.reused |= reused;
+            if let Some(artifact) = artifact {
+                tool.artifact = Some(artifact);
+            }
+        });
     }
 
     /// A child process's own output is the diagnostic value of an install log,
@@ -320,6 +540,73 @@ impl SingleReport for TextToolProgress {
         }
     }
 
+    fn start_operations(&self, count: usize) {
+        self.with_tool(|tool| tool.weights = vec![1.0; count.max(1)]);
+    }
+
+    fn start_operations_weighted(&self, weights: &[f64]) {
+        let weights: Vec<f64> = weights.iter().copied().filter(|w| *w > 0.0).collect();
+        self.with_tool(|tool| {
+            tool.weights = if weights.is_empty() {
+                vec![1.0]
+            } else {
+                weights.clone()
+            }
+        });
+    }
+
+    fn next_operation(&self) {
+        self.with_tool(|tool| {
+            tool.completed_ops = (tool.completed_ops + 1).min(tool.weights.len());
+            // Byte progress belongs to the operation that just ended.
+            tool.transfer = None;
+        });
+    }
+
+    fn set_length(&self, length: u64) {
+        self.with_tool(|tool| match tool.transfer.as_mut() {
+            // A second length on the same operation is a new transfer, not a
+            // resize: verification and extraction reuse the same reporter.
+            Some(transfer) if transfer.total != length => {
+                *transfer = Transfer {
+                    done: 0,
+                    total: length,
+                    started: Instant::now(),
+                    resumed_at: 0,
+                };
+            }
+            Some(transfer) => transfer.total = length,
+            None => {
+                tool.transfer = Some(Transfer {
+                    done: 0,
+                    total: length,
+                    started: Instant::now(),
+                    resumed_at: 0,
+                })
+            }
+        });
+    }
+
+    fn set_position(&self, position: u64) {
+        self.with_tool(|tool| {
+            if let Some(transfer) = tool.transfer.as_mut() {
+                // A resumed download reports its starting offset here.
+                if transfer.done == 0 && position > 0 {
+                    transfer.resumed_at = position;
+                }
+                transfer.done = position;
+            }
+        });
+    }
+
+    fn inc(&self, delta: u64) {
+        self.with_tool(|tool| {
+            if let Some(transfer) = tool.transfer.as_mut() {
+                transfer.done = transfer.done.saturating_add(delta);
+            }
+        });
+    }
+
     fn finish_with_icon(&self, _message: String, icon: ProgressIcon) {
         self.state.lock().unwrap().tools[self.index].skipped =
             matches!(icon, ProgressIcon::Skipped);
@@ -341,6 +628,12 @@ mod tests {
                     message: "queued".into(),
                     outcome: None,
                     skipped: false,
+                    weights: vec![],
+                    completed_ops: 0,
+                    transfer: None,
+                    artifact: None,
+                    reused: false,
+                    fraction: 0.0,
                 })
                 .collect(),
         }
@@ -357,8 +650,15 @@ mod tests {
         let snapshot =
             console::strip_ansi_codes(&state.snapshot(start + Duration::from_secs(3))).into_owned();
         assert!(snapshot.starts_with("█████░░░░░░░░░░░ 1/3 · 3.0s"));
+        // A finished tool has already printed its own line.
         assert!(!snapshot.contains("tool0"));
-        assert!(snapshot.contains("tool1@1  extracting                      1.0s"));
+        let row = snapshot
+            .lines()
+            .find(|l| l.contains("tool1@1"))
+            .expect("the running tool has a row");
+        assert!(row.contains("extracting"), "{row}");
+        // Its own 1.0s of work, not the 3.0s since the install started.
+        assert!(row.trim_end().ends_with("1.0s"), "{row}");
         assert!(snapshot.ends_with("1 queued"));
     }
 
@@ -437,6 +737,158 @@ mod tests {
         progress.stop();
         assert!(progress.thread.is_none());
         assert!(start.elapsed() < INTERVAL);
+    }
+
+    #[test]
+    fn a_half_done_tool_fills_half_the_width_of_a_finished_one() {
+        let start = Instant::now();
+        let mut state = state(start);
+        // One finished, one exactly halfway through a single-operation install.
+        state.tools[0].started = Some(start);
+        state.finish_tool(0, Outcome::Installed, start);
+        state.tools[1].started = Some(start);
+        state.tools[1].weights = vec![1.0];
+        state.tools[1].transfer = Some(Transfer {
+            done: 50,
+            total: 100,
+            started: start,
+            resumed_at: 0,
+        });
+        state.tools[1].advance();
+        // 1.0 + ~0.5 + 0.0 over three tools is half the bar, while the count
+        // beside it still reports whole tools.
+        let bar = console::strip_ansi_codes(&state.bar()).into_owned();
+        assert_eq!(bar, "████████░░░░░░░░ 1/3");
+    }
+
+    #[test]
+    fn weights_pace_the_bar_by_the_backends_estimate() {
+        let start = Instant::now();
+        let mut state = state(start);
+        let tool = &mut state.tools[0];
+        tool.started = Some(start);
+        // download, checksum, extract
+        tool.weights = vec![0.7, 0.15, 0.15];
+        tool.advance();
+        assert_eq!(tool.fraction, 0.0);
+        // Halfway through the download is 35% of the tool, not 1/6.
+        tool.transfer = Some(Transfer {
+            done: 1,
+            total: 2,
+            started: start,
+            resumed_at: 0,
+        });
+        tool.advance();
+        assert!((tool.fraction - 0.35).abs() < 1e-9, "{}", tool.fraction);
+        // The tail stays reserved for the work that follows the last operation.
+        tool.completed_ops = 3;
+        tool.transfer = None;
+        tool.advance();
+        assert_eq!(tool.fraction, 0.99);
+    }
+
+    #[test]
+    fn progress_never_walks_backwards() {
+        let start = Instant::now();
+        let mut state = state(start);
+        let tool = &mut state.tools[0];
+        tool.weights = vec![1.0];
+        tool.transfer = Some(Transfer {
+            done: 90,
+            total: 100,
+            started: start,
+            resumed_at: 0,
+        });
+        tool.advance();
+        let high = tool.fraction;
+        // A restarted download reports byte zero again.
+        tool.transfer = Some(Transfer {
+            done: 0,
+            total: 100,
+            started: start,
+            resumed_at: 0,
+        });
+        tool.advance();
+        assert_eq!(tool.fraction, high);
+    }
+
+    #[test]
+    fn transfer_detail_reports_bytes_and_rate_in_one_unit() {
+        let start = Instant::now();
+        let mut state = state(start);
+        let tool = &mut state.tools[0];
+        tool.transfer = Some(Transfer {
+            done: 42_100_000,
+            total: 78_300_000,
+            started: start,
+            resumed_at: 0,
+        });
+        let detail = tool.transfer_detail(start + Duration::from_secs(4));
+        assert_eq!(detail, "42.1/78.3 MB · 10.5 MB/s");
+
+        // A server that sends no length still gets a running count, and a rate
+        // needs enough of a sample to mean anything.
+        tool.transfer = Some(Transfer {
+            done: 1_500_000,
+            total: 0,
+            started: start,
+            resumed_at: 0,
+        });
+        assert_eq!(
+            tool.transfer_detail(start + Duration::from_millis(100)),
+            "1.5 MB"
+        );
+    }
+
+    #[test]
+    fn a_resumed_download_does_not_inflate_the_rate() {
+        let start = Instant::now();
+        let mut state = state(start);
+        let tool = &mut state.tools[0];
+        tool.transfer = Some(Transfer {
+            done: 0,
+            total: 100_000_000,
+            started: start,
+            resumed_at: 0,
+        });
+        // 90 MB was already on disk; only the 10 MB since counts toward rate.
+        let progress = TextToolProgress {
+            state: Arc::new(Mutex::new(state)),
+            index: 0,
+        };
+        progress.set_position(90_000_000);
+        progress.inc(10_000_000);
+        let shared = progress.state.lock().unwrap();
+        let detail = shared.tools[0].transfer_detail(start + Duration::from_secs(2));
+        assert_eq!(detail, "100.0/100.0 MB · 5.0 MB/s");
+    }
+
+    #[test]
+    fn completion_line_names_the_artifact_and_says_when_it_was_reused() {
+        let start = Instant::now();
+        let shared = Arc::new(Mutex::new(state(start)));
+        shared.lock().unwrap().tools[0].started = Some(start);
+        let progress = TextToolProgress {
+            state: shared.clone(),
+            index: 0,
+        };
+        progress.set_message("cached node-v24.20.0-linux-x64.tar.xz".into());
+        {
+            let state = shared.lock().unwrap();
+            assert_eq!(state.tools[0].message, "reusing download");
+            assert!(state.tools[0].reused);
+        }
+        progress.set_message("extract node-v24.20.0-linux-x64.tar.xz".into());
+        let line = shared
+            .lock()
+            .unwrap()
+            .finish_tool(0, Outcome::Installed, start + Duration::from_millis(300))
+            .unwrap();
+        let line = console::strip_ansi_codes(&line).into_owned();
+        assert_eq!(
+            line,
+            "✓ tool0@1  300ms · cached  node-v24.20.0-linux-x64.tar.xz"
+        );
     }
 
     #[test]

--- a/src/ui/text_install_progress.rs
+++ b/src/ui/text_install_progress.rs
@@ -51,6 +51,15 @@ struct Transfer {
 }
 
 impl Transfer {
+    fn new(total: u64) -> Self {
+        Self {
+            done: 0,
+            total,
+            started: Instant::now(),
+            resumed_at: 0,
+        }
+    }
+
     fn fraction(&self) -> Option<f64> {
         (self.total > 0).then(|| (self.done as f64 / self.total as f64).clamp(0.0, 1.0))
     }
@@ -183,15 +192,27 @@ impl State {
     fn bar(&self) -> String {
         let total = self.tools.len();
         let complete = self.tools.iter().filter(|t| t.outcome.is_some()).count();
-        let progress = if total == 0 {
-            1.0
+        let (progress, failed_share) = if total == 0 {
+            (1.0, 0.0)
         } else {
-            self.tools.iter().map(|t| t.fraction).sum::<f64>() / total as f64
+            let failed = self
+                .tools
+                .iter()
+                .filter(|t| t.outcome == Some(Outcome::Failed))
+                .count();
+            (
+                self.tools.iter().map(|t| t.fraction).sum::<f64>() / total as f64,
+                failed as f64 / total as f64,
+            )
         };
         let filled = ((progress * BAR_WIDTH as f64).round() as usize).min(BAR_WIDTH);
+        // A failed tool still counts as finished work, but a fully cyan bar over
+        // "installed 0 tools · 1 failed" reads as success. Its share is red.
+        let failed = ((failed_share * BAR_WIDTH as f64).round() as usize).min(filled);
         format!(
-            "{}{} {complete}/{total}",
-            style::ecyan("█".repeat(filled)),
+            "{}{}{} {complete}/{total}",
+            style::ecyan("█".repeat(filled - failed)),
+            style::ered("█".repeat(failed)),
             style::edim("░".repeat(BAR_WIDTH - filled))
         )
     }
@@ -488,21 +509,19 @@ impl SingleReport for TextToolProgress {
         let message = message.replace(['\r', '\n'], " ");
         let mut words = message.split_whitespace();
         let mut reused = false;
+        let mut operations_done = false;
         let (phase, artifact) = match words.next() {
             Some("download") => ("downloading", words.next()),
             Some("cached") => {
                 reused = true;
                 ("reusing download", words.next())
             }
-            // The http backend's older wording for the same thing.
-            Some("using") if message == "using cached tarball" => {
-                reused = true;
-                ("reusing download", None)
-            }
+
             Some("checksum") => ("verifying checksum", None),
             Some("extract") => ("extracting", None),
             Some("install") => ("installing", None),
             Some("running") if message == "running custom postinstall hook" => {
+                operations_done = true;
                 ("running postinstall hook", None)
             }
             _ => (message.as_str(), None),
@@ -512,6 +531,10 @@ impl SingleReport for TextToolProgress {
         self.with_tool(|tool| {
             tool.message = phase;
             tool.reused |= reused;
+            if operations_done {
+                tool.completed_ops = tool.weights.len();
+                tool.transfer = None;
+            }
             if let Some(artifact) = artifact {
                 tool.artifact = Some(artifact);
             }
@@ -564,46 +587,30 @@ impl SingleReport for TextToolProgress {
     }
 
     fn set_length(&self, length: u64) {
-        self.with_tool(|tool| match tool.transfer.as_mut() {
-            // A second length on the same operation is a new transfer, not a
-            // resize: verification and extraction reuse the same reporter.
-            Some(transfer) if transfer.total != length => {
-                *transfer = Transfer {
-                    done: 0,
-                    total: length,
-                    started: Instant::now(),
-                    resumed_at: 0,
-                };
-            }
-            Some(transfer) => transfer.total = length,
-            None => {
-                tool.transfer = Some(Transfer {
-                    done: 0,
-                    total: length,
-                    started: Instant::now(),
-                    resumed_at: 0,
-                })
-            }
-        });
+        // A length always opens a new transfer, even when it equals the last
+        // one: the downloader announces it once per attempt, and a retry that
+        // kept the previous state would fold the failed attempt's bytes and
+        // time into this one's rate.
+        self.with_tool(|tool| tool.transfer = Some(Transfer::new(length)));
     }
 
     fn set_position(&self, position: u64) {
         self.with_tool(|tool| {
-            if let Some(transfer) = tool.transfer.as_mut() {
-                // A resumed download reports its starting offset here.
-                if transfer.done == 0 && position > 0 {
-                    transfer.resumed_at = position;
-                }
-                transfer.done = position;
+            // A server that sends no content-length never calls set_length, so
+            // the first bytes open a transfer with an unknown total.
+            let transfer = tool.transfer.get_or_insert_with(|| Transfer::new(0));
+            // A resumed download reports its starting offset here.
+            if transfer.done == 0 && position > 0 {
+                transfer.resumed_at = position;
             }
+            transfer.done = position;
         });
     }
 
     fn inc(&self, delta: u64) {
         self.with_tool(|tool| {
-            if let Some(transfer) = tool.transfer.as_mut() {
-                transfer.done = transfer.done.saturating_add(delta);
-            }
+            let transfer = tool.transfer.get_or_insert_with(|| Transfer::new(0));
+            transfer.done = transfer.done.saturating_add(delta);
         });
     }
 
@@ -889,6 +896,75 @@ mod tests {
             line,
             "✓ tool0@1  300ms · cached  node-v24.20.0-linux-x64.tar.xz"
         );
+    }
+
+    #[test]
+    fn failures_take_their_share_of_the_bar_in_red() {
+        let start = Instant::now();
+        let mut state = state(start);
+        state.finish_tool(0, Outcome::Installed, start);
+        state.finish_tool(1, Outcome::Failed, start);
+        state.finish_tool(2, Outcome::Failed, start);
+        let bar = state.bar();
+        let plain = console::strip_ansi_codes(&bar).into_owned();
+        assert_eq!(plain, "████████████████ 3/3");
+        // Two of three tools failed: eleven red cells follow five cyan ones.
+        let red = format!("{}", style::ered("█".repeat(11)));
+        let cyan = format!("{}", style::ecyan("█".repeat(5)));
+        assert!(
+            !console::colors_enabled_stderr() || (bar.contains(&red) && bar.contains(&cyan)),
+            "{bar:?}"
+        );
+    }
+
+    #[test]
+    fn the_postinstall_hook_completes_every_declared_operation() {
+        let start = Instant::now();
+        let shared = Arc::new(Mutex::new(state(start)));
+        let progress = TextToolProgress {
+            state: shared.clone(),
+            index: 0,
+        };
+        // A plugin backend that never calls next_operation.
+        progress.start_operations(3);
+        assert_eq!(shared.lock().unwrap().tools[0].fraction, 0.0);
+        progress.set_message("running custom postinstall hook".into());
+        let state = shared.lock().unwrap();
+        assert_eq!(state.tools[0].completed_ops, 3);
+        assert_eq!(state.tools[0].fraction, 0.99);
+    }
+
+    #[test]
+    fn a_retried_attempt_starts_its_rate_from_zero() {
+        let start = Instant::now();
+        let shared = Arc::new(Mutex::new(state(start)));
+        let progress = TextToolProgress {
+            state: shared.clone(),
+            index: 0,
+        };
+        progress.set_length(100);
+        progress.inc(60);
+        // Same total announced again: a new attempt, resuming at 60.
+        progress.set_length(100);
+        progress.set_position(60);
+        progress.inc(10);
+        let transfer = shared.lock().unwrap().tools[0].transfer.unwrap();
+        assert_eq!((transfer.done, transfer.resumed_at), (70, 60));
+    }
+
+    #[test]
+    fn bytes_without_a_length_still_show_a_running_count() {
+        let start = Instant::now();
+        let shared = Arc::new(Mutex::new(state(start)));
+        let progress = TextToolProgress {
+            state: shared.clone(),
+            index: 0,
+        };
+        progress.inc(1_500_000);
+        let state = shared.lock().unwrap();
+        assert_eq!(state.tools[0].transfer_detail(start), "1.5 MB");
+        // No total, so no fraction: the bar must not pretend to know.
+        assert_eq!(state.tools[0].transfer.unwrap().fraction(), None);
     }
 
     #[test]

--- a/src/ui/text_install_progress.rs
+++ b/src/ui/text_install_progress.rs
@@ -1,0 +1,407 @@
+//! Append-only install progress for captured stderr and CI terminals.
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use super::multi_progress_report::MultiProgressReport;
+use super::progress_report::{ProgressIcon, SingleReport};
+use super::style;
+
+const INTERVAL: Duration = Duration::from_secs(3);
+const BAR_WIDTH: usize = 16;
+
+#[derive(Debug)]
+struct Tool {
+    key: String,
+    prefix: String,
+    started: Option<Instant>,
+    message: String,
+    outcome: Option<Outcome>,
+    skipped: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Outcome {
+    Installed,
+    Skipped,
+    Failed,
+}
+
+#[derive(Debug)]
+struct State {
+    tools: Vec<Tool>,
+    started: Instant,
+}
+
+impl State {
+    fn width(&self) -> usize {
+        self.tools
+            .iter()
+            .map(|t| console::measure_text_width(&t.prefix))
+            .max()
+            .unwrap_or(0)
+    }
+
+    fn bar(&self) -> String {
+        let total = self.tools.len();
+        let complete = self.tools.iter().filter(|t| t.outcome.is_some()).count();
+        let filled = (complete * BAR_WIDTH)
+            .checked_div(total)
+            .unwrap_or(BAR_WIDTH);
+        format!(
+            "{}{} {complete}/{total}",
+            style::ecyan("█".repeat(filled)),
+            style::edim("░".repeat(BAR_WIDTH - filled))
+        )
+    }
+
+    fn snapshot(&self, now: Instant) -> String {
+        let mut lines = vec![format!("{} · {}", self.bar(), elapsed(self.started, now))];
+        let width = self.width();
+        for tool in self.tools.iter().filter(|t| t.outcome.is_none()) {
+            if let Some(started) = tool.started {
+                let prefix = console::pad_str(&tool.prefix, width, console::Alignment::Left, None);
+                let message =
+                    console::pad_str(&tool.message, 30, console::Alignment::Left, Some("…"));
+                lines.push(format!("  {prefix}  {message}  {}", elapsed(started, now)));
+            }
+        }
+        let queued = self
+            .tools
+            .iter()
+            .filter(|t| t.started.is_none() && t.outcome.is_none())
+            .count();
+        if queued > 0 {
+            lines.push(format!("  {queued} queued"));
+        }
+        lines.join("\n")
+    }
+
+    fn finish_tool(&mut self, index: usize, outcome: Outcome, now: Instant) -> Option<String> {
+        let width = self.width();
+        let tool = &mut self.tools[index];
+        if tool.outcome.is_some() {
+            return None;
+        }
+        tool.outcome = Some(outcome);
+        let prefix = console::pad_str(&tool.prefix, width, console::Alignment::Left, None);
+        let duration = tool
+            .started
+            .map(|started| format!("  {}", elapsed(started, now)))
+            .unwrap_or_default();
+        let (icon, detail) = match outcome {
+            Outcome::Installed => (ProgressIcon::Success, String::new()),
+            Outcome::Skipped => (ProgressIcon::Skipped, " · already installed".into()),
+            Outcome::Failed => (ProgressIcon::Error, format!(" · failed: {}", tool.message)),
+        };
+        Some(format!("{icon} {prefix}{duration}{detail}"))
+    }
+
+    fn summary(&self, now: Instant) -> String {
+        let installed = self
+            .tools
+            .iter()
+            .filter(|t| t.outcome == Some(Outcome::Installed))
+            .count();
+        let skipped = self
+            .tools
+            .iter()
+            .filter(|t| t.outcome == Some(Outcome::Skipped))
+            .count();
+        let failed = self
+            .tools
+            .iter()
+            .filter(|t| t.outcome == Some(Outcome::Failed))
+            .count();
+        let mut result = format!(
+            "{} · installed {installed} {}",
+            self.bar(),
+            tool_noun(installed)
+        );
+        if skipped > 0 {
+            result.push_str(&format!(" · {skipped} already installed"));
+        }
+        if failed > 0 {
+            result.push_str(&format!(" · {failed} failed"));
+        }
+        result.push_str(&format!(" in {}", elapsed(self.started, now)));
+        result
+    }
+}
+
+fn tool_noun(count: usize) -> &'static str {
+    if count == 1 { "tool" } else { "tools" }
+}
+
+fn elapsed(start: Instant, now: Instant) -> String {
+    let duration = now.duration_since(start);
+    if duration < Duration::from_secs(1) {
+        format!("{}ms", duration.as_millis())
+    } else {
+        format!("{:.1}s", duration.as_secs_f64())
+    }
+}
+
+/// A session owns its heartbeat. Dropping it stops and joins the thread, including
+/// on early errors, so no progress can appear after the command's final output.
+pub(crate) struct TextInstallProgress {
+    state: Arc<Mutex<State>>,
+    stop: mpsc::Sender<()>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl TextInstallProgress {
+    pub(crate) fn new(tools: impl Iterator<Item = (String, String)>) -> Self {
+        // Match the dependency scheduler's deduplication of repeated requests.
+        let mut seen = HashSet::new();
+        let state = Arc::new(Mutex::new(State {
+            started: Instant::now(),
+            tools: tools
+                .filter(|(key, _)| seen.insert(key.clone()))
+                .map(|(key, prefix)| Tool {
+                    key,
+                    prefix,
+                    started: None,
+                    message: "queued".into(),
+                    outcome: None,
+                    skipped: false,
+                })
+                .collect(),
+        }));
+        let total = state.lock().unwrap().tools.len();
+        info!("installing {total} {}", tool_noun(total));
+        let (stop, rx) = mpsc::channel();
+        let shared = state.clone();
+        let thread = thread::spawn(move || {
+            while rx.recv_timeout(INTERVAL) == Err(mpsc::RecvTimeoutError::Timeout) {
+                let render = || {
+                    let state = shared.lock().unwrap();
+                    // Completed tools have already printed their individual results.
+                    if state.tools.iter().any(|t| t.outcome.is_none()) {
+                        info!("{}", state.snapshot(Instant::now()));
+                    }
+                };
+                if let Some(report) = MultiProgressReport::try_get() {
+                    report.with_progress_unpaused(render);
+                } else {
+                    render();
+                }
+            }
+        });
+        Self {
+            state,
+            stop,
+            thread: Some(thread),
+        }
+    }
+
+    /// Returns `None` for a request that was not part of this session, letting the
+    /// caller fall back to the standard reporter instead of panicking mid-install.
+    pub(crate) fn start_tool(&self, key: &str) -> Option<TextToolProgress> {
+        let mut state = self.state.lock().unwrap();
+        let index = state.tools.iter().position(|t| t.key == key)?;
+        let tool = &mut state.tools[index];
+        tool.started = Some(Instant::now());
+        tool.message = "resolving".into();
+        Some(TextToolProgress {
+            state: self.state.clone(),
+            index,
+        })
+    }
+
+    pub(crate) fn finish(&mut self, failures: impl Iterator<Item = (String, String)>) {
+        self.stop();
+        let mut state = self.state.lock().unwrap();
+        let now = Instant::now();
+        for (key, error) in failures {
+            if let Some(index) = state
+                .tools
+                .iter()
+                .position(|t| t.key == key && t.outcome.is_none())
+            {
+                state.tools[index].message =
+                    error.lines().next().unwrap_or("installation failed").into();
+                if let Some(line) = state.finish_tool(index, Outcome::Failed, now) {
+                    info!("{line}");
+                }
+            }
+        }
+        info!("{}", state.summary(now));
+    }
+
+    fn stop(&mut self) {
+        let _ = self.stop.send(());
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+impl Drop for TextInstallProgress {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TextToolProgress {
+    state: Arc<Mutex<State>>,
+    index: usize,
+}
+
+impl TextToolProgress {
+    pub(crate) fn set_prefix(&self, prefix: String) {
+        self.state.lock().unwrap().tools[self.index].prefix = prefix;
+    }
+
+    /// The worker result is authoritative: backends sometimes finish their
+    /// report before their postinstall work has actually returned.
+    pub(crate) fn complete(&self, success: bool) {
+        let mut state = self.state.lock().unwrap();
+        let outcome = if !success {
+            Outcome::Failed
+        } else if state.tools[self.index].skipped {
+            Outcome::Skipped
+        } else {
+            Outcome::Installed
+        };
+        if let Some(line) = state.finish_tool(self.index, outcome, Instant::now()) {
+            info!("{line}");
+        }
+    }
+}
+
+impl SingleReport for TextToolProgress {
+    fn set_message(&self, message: String) {
+        // Keep counters from embedded package managers, but omit artifact names
+        // from the common download/checksum/extract status messages.
+        let message = message.replace(['\r', '\n'], " ");
+        let message = match message.split_whitespace().next() {
+            Some("download") => "downloading",
+            Some("checksum") => "verifying checksum",
+            Some("extract") => "extracting",
+            Some("install") => "installing",
+            Some("running") if message == "running custom postinstall hook" => {
+                "running postinstall hook"
+            }
+            _ => &message,
+        };
+        self.state.lock().unwrap().tools[self.index].message = message.into();
+    }
+
+    /// A child process's own output is the diagnostic value of an install log,
+    /// so it stays immediate. Only the phase messages a backend generates are
+    /// folded into the periodic snapshot.
+    fn set_process_output(&self, message: String) {
+        self.println(message);
+    }
+
+    fn shows_process_output(&self) -> bool {
+        true
+    }
+
+    fn println(&self, message: String) {
+        // Explicit output (including build scripts) remains immediate.
+        let state = self.state.lock().unwrap();
+        for line in message.lines() {
+            safe_eprintln!("{} {line}", state.tools[self.index].prefix);
+        }
+    }
+
+    fn finish_with_icon(&self, _message: String, icon: ProgressIcon) {
+        self.state.lock().unwrap().tools[self.index].skipped =
+            matches!(icon, ProgressIcon::Skipped);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state(started: Instant) -> State {
+        State {
+            started,
+            tools: (0..3)
+                .map(|i| Tool {
+                    key: i.to_string(),
+                    prefix: format!("tool{i}@1"),
+                    started: None,
+                    message: "queued".into(),
+                    outcome: None,
+                    skipped: false,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn snapshots_separate_queue_time_from_work_time() {
+        let start = Instant::now();
+        let mut state = state(start);
+        state.tools[0].started = Some(start);
+        state.finish_tool(0, Outcome::Installed, start + Duration::from_secs(1));
+        state.tools[1].started = Some(start + Duration::from_secs(2));
+        state.tools[1].message = "extracting".into();
+        let snapshot =
+            console::strip_ansi_codes(&state.snapshot(start + Duration::from_secs(3))).into_owned();
+        assert!(snapshot.starts_with("█████░░░░░░░░░░░ 1/3 · 3.0s"));
+        assert!(!snapshot.contains("tool0"));
+        assert!(snapshot.contains("tool1@1  extracting                      1.0s"));
+        assert!(snapshot.ends_with("1 queued"));
+    }
+
+    #[test]
+    fn terminal_results_are_not_reported_or_counted_twice() {
+        let start = Instant::now();
+        let mut state = state(start);
+        state.tools[0].started = Some(start);
+        let finished = state
+            .finish_tool(0, Outcome::Installed, start + Duration::from_millis(250))
+            .unwrap();
+        assert!(finished.contains("250ms"));
+        assert!(state.finish_tool(0, Outcome::Failed, start).is_none());
+        state.finish_tool(1, Outcome::Skipped, start);
+        state.finish_tool(2, Outcome::Failed, start);
+        let summary = console::strip_ansi_codes(&state.summary(start)).into_owned();
+        assert_eq!(
+            summary,
+            "████████████████ 3/3 · installed 1 tool · 1 already installed · 1 failed in 0ms"
+        );
+    }
+
+    #[test]
+    fn backend_finish_does_not_complete_a_worker() {
+        let start = Instant::now();
+        let shared = Arc::new(Mutex::new(state(start)));
+        let progress = TextToolProgress {
+            state: shared.clone(),
+            index: 0,
+        };
+        progress.finish_with_message("installed".into());
+        assert!(shared.lock().unwrap().tools[0].outcome.is_none());
+        progress.set_message("running postinstall hook".into());
+        progress.complete(false);
+        assert_eq!(
+            shared.lock().unwrap().tools[0].outcome,
+            Some(Outcome::Failed)
+        );
+    }
+
+    #[test]
+    fn stopping_joins_the_heartbeat_without_waiting_for_a_tick() {
+        let start = Instant::now();
+        let mut progress =
+            TextInstallProgress::new(std::iter::once(("tool".into(), "tool@1".into())));
+        progress.stop();
+        assert!(progress.thread.is_none());
+        assert!(start.elapsed() < INTERVAL);
+    }
+
+    #[test]
+    fn an_unknown_request_falls_back_instead_of_panicking() {
+        let progress = TextInstallProgress::new(std::iter::once(("tool".into(), "tool@1".into())));
+        assert!(progress.start_tool("tool").is_some());
+        assert!(progress.start_tool("other").is_none());
+    }
+}

--- a/src/ui/text_install_progress.rs
+++ b/src/ui/text_install_progress.rs
@@ -130,6 +130,10 @@ impl State {
     }
 }
 
+fn first_line(error: &str) -> String {
+    error.lines().next().unwrap_or("installation failed").into()
+}
+
 fn tool_noun(count: usize) -> &'static str {
     if count == 1 { "tool" } else { "tools" }
 }
@@ -220,8 +224,7 @@ impl TextInstallProgress {
                 .iter()
                 .position(|t| t.key == key && t.outcome.is_none())
             {
-                state.tools[index].message =
-                    error.lines().next().unwrap_or("installation failed").into();
+                state.tools[index].message = first_line(&error);
                 if let Some(line) = state.finish_tool(index, Outcome::Failed, now) {
                     info!("{line}");
                 }
@@ -257,14 +260,19 @@ impl TextToolProgress {
 
     /// The worker result is authoritative: backends sometimes finish their
     /// report before their postinstall work has actually returned.
-    pub(crate) fn complete(&self, success: bool) {
+    ///
+    /// `error` is the worker's own failure. Without it the line would report
+    /// whatever phase the tool happened to be in when it died, which reads as a
+    /// reason ("failed: ✓ Cosign verified") without being one.
+    pub(crate) fn complete(&self, error: Option<&str>) {
         let mut state = self.state.lock().unwrap();
-        let outcome = if !success {
-            Outcome::Failed
-        } else if state.tools[self.index].skipped {
-            Outcome::Skipped
-        } else {
-            Outcome::Installed
+        let outcome = match error {
+            Some(error) => {
+                state.tools[self.index].message = first_line(error);
+                Outcome::Failed
+            }
+            None if state.tools[self.index].skipped => Outcome::Skipped,
+            None => Outcome::Installed,
         };
         if let Some(line) = state.finish_tool(self.index, outcome, Instant::now()) {
             info!("{line}");
@@ -302,10 +310,13 @@ impl SingleReport for TextToolProgress {
     }
 
     fn println(&self, message: String) {
-        // Explicit output (including build scripts) remains immediate.
-        let state = self.state.lock().unwrap();
+        // Explicit output (including build scripts) remains immediate, through
+        // the logger so that it is redacted like every other line mise prints.
+        // The lock is released first: a child can emit a lot of these, and they
+        // must not serialize behind another tool's status update.
+        let prefix = self.state.lock().unwrap().tools[self.index].prefix.clone();
         for line in message.lines() {
-            safe_eprintln!("{} {line}", state.tools[self.index].prefix);
+            info!("{prefix} {line}");
         }
     }
 
@@ -381,10 +392,40 @@ mod tests {
         progress.finish_with_message("installed".into());
         assert!(shared.lock().unwrap().tools[0].outcome.is_none());
         progress.set_message("running postinstall hook".into());
-        progress.complete(false);
+        progress.complete(Some("hook exited with status 1"));
         assert_eq!(
             shared.lock().unwrap().tools[0].outcome,
             Some(Outcome::Failed)
+        );
+    }
+
+    #[test]
+    fn a_failure_reports_the_error_not_the_phase_it_died_in() {
+        let start = Instant::now();
+        let shared = Arc::new(Mutex::new(state(start)));
+        let progress = TextToolProgress {
+            state: shared.clone(),
+            index: 0,
+        };
+        // A phase message can even read as a success on its own.
+        progress.set_message("✓ Cosign verified".into());
+        progress.complete(Some("checksum mismatch\nsecond line"));
+        assert_eq!(shared.lock().unwrap().tools[0].message, "checksum mismatch");
+    }
+
+    #[test]
+    fn a_skip_survives_a_successful_completion() {
+        let start = Instant::now();
+        let shared = Arc::new(Mutex::new(state(start)));
+        let progress = TextToolProgress {
+            state: shared.clone(),
+            index: 0,
+        };
+        progress.finish_with_icon("already installed".into(), ProgressIcon::Skipped);
+        progress.complete(None);
+        assert_eq!(
+            shared.lock().unwrap().tools[0].outcome,
+            Some(Outcome::Skipped)
         );
     }
 


### PR DESCRIPTION
Install output in CI logs and captured stderr currently comes from `VerboseReport`, which prints a line for every status change. A 22-tool `mise install` turns into hundreds of rows of archive names, checksum lines and rapidly-changing npm counters, and none of them answer the two questions you actually have when reading the log: *what finished*, and *what is taking so long*.

This adds a dedicated append-only reporter for non-TTY stderr (and for known CI, which often allocates a PTY and then keeps every redraw frame in the log). Interactive terminals, `--verbose`, `--raw`, `--quiet` and `--dry-run` are unchanged.

## Output

```text
mise installing 22 tools

  ✓ cargo-insta@1.48.0               0.8s
  ✓ bun@1.4.0                        1.2s
  ✓ hk@1.56.1                        1.5s

  ██████░░░░░░░░░░  8/22 · 3.0s
    aube@2.2.9                      extracting            1.2s
    lua-language-server@3.19.1       downloading           0.8s
    10 queued

  ✓ stylua@2.5.2                     0.8s
  ✓ aube@2.2.9                       1.8s

  ████████████████ 22/22 · installed 22 tools in 10.8s
```

- One permanent line per finished tool, with the time that tool took.
- One periodic snapshot (every 3s, one timer for the whole install regardless of concurrency) showing the bar, what each active tool is doing, its elapsed time, and how many are still queued.
- Per-tool timers start when the worker begins, so queue time is not charged to a tool. The bar's timer covers the whole install.
- The summary distinguishes installed, already-installed and failed, so a full bar can't imply everything succeeded.

There is deliberately no overall ETA or percentage-of-bytes: a 2MB binary and a Rust toolchain are not comparable units, and a completed-tool count is a number the log can actually justify.

## Progress that means something

The bar fills fractionally: a tool halfway through its own install occupies half the width a finished one would. Each tool's fraction is its completed operations plus byte progress through the current one, weighted by a new `Backend::install_operation_weights` (default: the fetch is 0.7, verification and extraction split the rest — the shape nearly every backend here has; a backend that compiles from source can override it). The count beside the bar stays whole tools, since that is the number you can check against the completion lines above it.

The fraction is monotonic — a retried download that reports byte zero again cannot walk the bar backwards — and a tool caps at 0.99 until its worker returns, because postinstall hooks run after the last declared operation. This makes the bar smooth, not time-proportional: three tools are still three equal shares, whatever their size.

Active rows show bytes and rate (`42.1/78.3 MB · 10.5 MB/s`), averaged over the transfer so a 3-second snapshot doesn't report whichever instant it caught. A resumed download's existing offset is excluded from the rate, every announced length opens a fresh transfer so a retry cannot inherit the failed attempt's bytes and time, and a server that sends no `content-length` still gets a running count (no fraction — the bar must not pretend to know).

Two more things the log is asked after the fact. The artifact the backend chose is kept, dimmed, on the row and the completion line (`✓ python@3.12.3  7.1s  cpython-3.12.3+….tar.gz`). And a fetch skipped because the file was already in the download cache says `· cached` — aqua and java returned silently in that case and now report `cached <name>`, the wording node used under a different phrasing. The http backend's `using cached tarball` is deliberately *not* that: it fires after a real download when the unpacked tree is cached, so it is now the phase `extracting from cache`.

Failures take their share of the filled bar in red: `████████████░░░░` over `installed 0 tools · 1 failed` would otherwise read as success. When a tool's custom postinstall hook starts, every declared operation is treated as complete — plugin backends (asdf, vfox) never call `next_operation`, so their bar sat at zero until the worker returned. An empty install creates no reporter at all.

## What stays visible

Only the phase messages mise generates itself are folded into the snapshot. A child process's own stdout — cargo, npm, build scripts — is the diagnostic value of an install log, so it keeps printing as it arrives.

That needed a split: `CmdLineRunner` routed child stdout through `pr.set_message`, the same call backends use for their own phase text. `set_process_output` now carries child stdout and defaults to `set_message`, so the progress and quiet reporters are unchanged; the verbose and text reporters show it live and declare `shows_process_output`, which suppresses the failure replay that would otherwise print it twice.

## Fixes found along the way

- A tool with a custom `postinstall` hook was reported as finished *before* the hook ran (`finish_with_message` on the reporter, then `run_postinstall_hook`). A failing hook still fails the command, but the log had already shown a completed install. The reporter now sets a status message and the worker's own result decides the outcome.
- Backends that short-circuit on an already-installed version now mark the report skipped, so "already installed" is distinguishable from a fresh install rather than silently counting as one.

## Tests

- Unit tests for snapshot layout, queue-time vs work-time, duplicate terminal results, and heartbeat shutdown.
- `e2e/cli/test_install_text_progress` covers captured stderr, a slow postinstall hook (timer keeps ticking, completion only after the hook returns), a failing postinstall hook (no success checkmark), the unchanged `--quiet`/`--verbose`/`--raw`/`--dry-run` modes, and a CI-with-PTY run that must still be append-only.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad install UX and progress-reporting changes across backends and hook timing; behavior is well-tested but affects every default non-TTY install path.
> 
> **Overview**
> **Adds append-only install progress** for captured stderr and CI logs (including PTY-backed CI), while interactive TTY, `--quiet`, `--verbose`, `--raw`, and `--dry-run` stay on the existing reporters.
> 
> The new **`TextInstallProgress`** path prints one completion line per tool, periodic ~3s snapshots (bar, active phases, byte/rate hints, queue count), and a final summary that separates installed, already-installed, and failed. Progress bars use **weighted install operations** (`start_operations_weighted` / `Backend::install_operation_weights`, default ~70% download) plus byte transfer state, with monotonic fractions and red bar segments for failures.
> 
> **Reporting plumbing changes:** child stdout goes through **`set_process_output`** (immediate for text/verbose reporters; **`shows_process_output`** skips duplicate failure replay). Backends report **`cached <file>`** when skipping download fetches; HTTP cache hits say **`extracting from cache`** instead of implying a skipped download. **Postinstall** no longer finishes the progress report before the hook runs—the worker result (and hook failure) drives success/failure lines. Already-installed short-circuits emit a **skipped** icon.
> 
> **Tests:** new `e2e/cli/test_install_text_progress`; attestation/precompile e2e installs use **`--verbose`** where assertions depend on per-phase log lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616faf4817d931d20f41b179c826bfc03deec7d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added concise text-based install progress with fractional progress bars, download details, transfer rates, artifact names, and postinstall status.
  - Progress now reflects weighted installation steps for smoother, more accurate pacing.
  - Failed tools display their specific error messages and failed progress portions.

- **Improvements**
  - Cached downloads and artifacts now show clear status messages, including cached filenames and extraction progress.
  - Progress output avoids duplicated process logs and remains clean in terminal and CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->