### PR TITLE
feat(dotfiles): clarify sharing choices and private tracking

### DIFF
--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -153,6 +153,7 @@ jobs:
       # Line Tools guard exercised on a real macOS runner.
       - run: mise run test:e2e e2e/cli/test_dotfiles_history_bootstrap
       - run: mise run test:e2e e2e/cli/test_dotfiles_history
+      - run: mise run test:e2e e2e/cli/test_dotfiles_onboarding
       - run: mise run test:e2e e2e/cli/test_dotfiles_track
       - run: mise run test:e2e e2e/cli/test_dotfiles_history_policies
       - run: mise run test:e2e e2e/cli/test_dotfiles_rollback

--- a/docs/cli/bootstrap/dotfiles/origin/set.md
+++ b/docs/cli/bootstrap/dotfiles/origin/set.md
@@ -15,9 +15,9 @@ Connect a setup repository
 
   **Default:** `main`
 - **`--name <NAME>`** — This machine's name in the repository (default: the hostname)
-- **`--sync <MODE>`** — How the repository is used: sync (default), fetch-only, or manual
+- **`--sync <MODE>`** — How the repository is used: sync, fetch-only, or manual
 
-  **Default:** `sync`
+  Prompts when omitted. With --yes, accepts the configured mode (default: sync), including automatic publication and incoming writes. Use --sync manual to keep automatic local history without automatic network activity.
 - **`--include-existing`** — Upload the checkpoints recorded before now too
 - **`--allow-committed-private`** — Continue although the repository's history holds private content
 - **`--encrypt-backups`** — Encrypt this machine's recovery refs with age for its recipients (see --recipient)

--- a/docs/cli/bootstrap/dotfiles/track.md
+++ b/docs/cli/bootstrap/dotfiles/track.md
@@ -25,6 +25,7 @@ Linux box can share the same live path with different contents.
 - **`--no-autosave`** — Save only on `mise bootstrap dotfiles save <path>`, never automatically
 - **`--no-share`** — Keep the file out of the shared setup (still backed up)
 - **`--no-backup`** — Keep the file out of remote backups (still protected locally)
+- **`--private`** — Keep file contents entirely local: disable both sharing and remote backups
 - **`--local`** — Write to config.local.toml (this machine only) instead of config.toml
 - **`-y --yes`** — Accept without prompting
 - **`-h --help`** — Print help

--- a/docs/cli/bootstrap/dotfiles/track.md
+++ b/docs/cli/bootstrap/dotfiles/track.md
@@ -25,7 +25,7 @@ Linux box can share the same live path with different contents.
 - **`--no-autosave`** — Save only on `mise bootstrap dotfiles save <path>`, never automatically
 - **`--no-share`** — Keep the file out of the shared setup (still backed up)
 - **`--no-backup`** — Keep the file out of remote backups (still protected locally)
-- **`--private`** — Keep file contents entirely local: disable both sharing and remote backups
+- **`--private`** — Disable future sharing and remote backups; existing uploads are not erased
 - **`--local`** — Write to config.local.toml (this machine only) instead of config.toml
 - **`-y --yes`** — Accept without prompting
 - **`-h --help`** — Print help

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -5,10 +5,7 @@
 > Their interfaces and storage formats may change before stabilization.
 > This notice concerns the new tracking workflows, not ordinary symlink, copy,
 > template, and managed-edit workflows.
-
-Tracking files in place and their recovery history are **experimental**. Run
-`mise settings experimental=true` to opt in. Existing symlink, copy,
-template, and managed-edit workflows do not require experimental mode.
+> Enable these workflows with `mise settings experimental=true`.
 
 `[dotfiles]` declares how each of your configuration files is managed. The
 recommended way to adopt a file you already edit in place is to **track** it:

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -1,9 +1,10 @@
 # Dotfiles
 
 > [!WARNING]
-> The top-level `mise dotfiles` command is deprecated and hidden from help. It
-> will begin warning in mise 2027.2.0 and be removed in mise 2028.2.0. Use
-> `mise bootstrap dotfiles` instead.
+> Tracking, checkpoints, rollback, watching, and synchronization are experimental.
+> Their interfaces and storage formats may change before stabilization.
+> This notice concerns the new tracking workflows, not ordinary symlink, copy,
+> template, and managed-edit workflows.
 
 Tracking files in place and their recovery history are **experimental**. Run
 `mise settings experimental=true` to opt in. Existing symlink, copy,
@@ -52,6 +53,13 @@ They are never applied implicitly by `mise install` or `mise bootstrap packages`
 The nested apply command runs the configured `pre-dotfiles` and
 `post-dotfiles` bootstrap hooks.
 
+## Command compatibility
+
+> [!WARNING]
+> The top-level `mise dotfiles` command is deprecated and hidden from help. It
+> will begin warning in mise 2027.2.0 and be removed in mise 2028.2.0. Use
+> `mise bootstrap dotfiles` instead.
+
 ## Tracking files in place
 
 `mise bootstrap dotfiles track <path>…` writes a `mode = "track"` entry for
@@ -77,7 +85,9 @@ wrote is not active.
 | `encrypt`  | `false` | Encrypt shared contents for `[history.encryption].recipients`; local files remain plaintext.                                                                |
 | `backup`   | `true`  | Include the file in this machine's remote backups (plaintext, or encrypted when the connection was made with `--encrypt-backups`).                          |
 
-`mise bootstrap dotfiles track --no-autosave|--no-share|--no-backup` sets them;
+`mise bootstrap dotfiles track --no-autosave|--no-share|--no-backup` sets them.
+`--private` sets both `share = false` and `backup = false` to keep contents local;
+the path and declaration can still be shared, and earlier uploads are not erased.
 `--local` writes the entry to `config.local.toml` (this machine only). A local
 override of an inherited entry restates the effective entry with only the
 changed field, so its variants and other policies are kept.

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,8 +1,11 @@
 # Dotfiles history
 
 > [!WARNING]
-> Dotfile tracking and history are experimental. Enable them with
-> `mise settings experimental=true`. Interfaces and storage formats may change.
+> Tracking, checkpoints, rollback, watching, and synchronization are experimental.
+> Their interfaces and storage formats may change before stabilization.
+> This notice concerns the new tracking workflows, not ordinary symlink, copy,
+> template, and managed-edit workflows.
+> Enable these workflows with `mise settings experimental=true`.
 
 mise keeps checkpoints of your configuration files: the global mise config
 directory, the dotfiles root, every `[dotfiles]` entry, and any file you
@@ -28,8 +31,9 @@ mise bootstrap dotfiles history diff                                       # wha
 mise bootstrap dotfiles save --description "before the theme change"
 ```
 
-Nothing leaves the machine: checkpoints live under `$MISE_STATE_DIR/history/`,
-readable only by you.
+Without a connected origin, nothing leaves the machine: checkpoints live under
+`$MISE_STATE_DIR/history/`, readable only by you. Connecting an origin enables
+sharing and remote backups according to the policies you review.
 
 ## What a checkpoint records
 
@@ -289,6 +293,12 @@ dotfiles apply` keeps deploying your own `[dotfiles]` declarations (symlinks,
 copies, templates, edits), while `pull` writes what other machines shared
 through the setup repository.
 
+When `--sync` is omitted, interactive `origin set` asks whether to publish saved
+edits and apply incoming changes automatically. Answering no selects `manual`;
+local autosave continues. `--sync manual|sync|fetch-only` selects a mode directly.
+`--yes` accepts the configured mode (default `sync`) without this question, so
+scripts should specify `--sync` explicitly.
+
 `origin set` prints exactly what will happen before anything leaves the
 machine and asks for confirmation (`--yes` skips it): the sync mode, what is
 published per stream, what is not shared and why, what is backed up (in
@@ -517,6 +527,19 @@ are found, and credential stores under the config directory
 (`github_tokens.toml`, `age.txt`, `*.key`, …) are neither shared nor backed
 up. A per-file `[dotfiles]` declaration is the only override, and
 `mise bootstrap dotfiles paths` lists every private file so the choice stays visible.
+
+### Keeping file contents entirely local
+
+`mise bootstrap dotfiles track ~/.config/app/credentials --private` sets both
+`share = false` and `backup = false`. The file remains in local history. Its
+path and declaration can still appear in shared configuration; keep the declaration
+machine-local too with `--local` when needed. `--no-share` alone still allows
+remote backups. These choices do not erase previously published Git objects.
+
+The origin preview lists current captured paths under **Local only**, **Shared
+setup**, and **Remote backup**, with encryption status. Shared and backed-up files
+appear in both outgoing groups. Existing history is uploaded only when selected;
+review the separate historical-backup disclosure as well.
 
 ## Retention
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -87,13 +87,13 @@
 - [Docker Compose Projects](https://mise.jdx.dev/bootstrap/compose.html): [bootstrap.compose] declaratively manages long-running Docker Compose projects after packages, privileged files, directories, and system services have converged.
 - [Secret Inputs](https://mise.jdx.dev/bootstrap/secrets.html): [bootstrap.secrets] declares the sensitive inputs a bootstrap configuration needs without storing their values in mise configuration.
 - [Repos](https://mise.jdx.dev/bootstrap/repos.html): mise can declare git repositories in [bootstrap.repos] and apply them with mise bootstrap repos apply or as part of mise bootstrap.
-- [Dotfiles](https://mise.jdx.dev/dotfiles.html): [!WARNING] The top-level mise dotfiles command is deprecated and hidden from help. It will begin warning in mise 2027.2.0 and be removed in mise 2028.2.0. Use mise bootstrap dotfiles instead.
+- [Dotfiles](https://mise.jdx.dev/dotfiles.html): [!WARNING] Tracking, checkpoints, rollback, watching, and synchronization are experimental. Their interfaces and storage formats may change before stabilization.
 - [Shell Activation](https://mise.jdx.dev/bootstrap/shell.html): mise can declaratively add shell activation snippets for bash, zsh, and fish with [bootstrap.mise_shell_activate], applied by mise bootstrap mise-shell-activate apply or as part of mise bootstrap.
 - [macOS Defaults](https://mise.jdx.dev/bootstrap/macos-defaults.html): mise can declare macOS user defaults (preferences) in the [bootstrap.macos.defaults] section of mise.toml and apply them with mise bootstrap macos defaults apply or as part of mise bootstrap.
 - [launchd](https://mise.jdx.dev/bootstrap/launchd.html): mise can declare macOS user LaunchAgents in [bootstrap.macos.launchd.agents] and apply them with mise bootstrap macos launchd-agents apply or as part of mise bootstrap.
 - [systemd](https://mise.jdx.dev/bootstrap/systemd.html): mise can declare Linux systemd user services and timers in [bootstrap.linux.systemd.units] and apply them with mise bootstrap linux systemd-units apply or as part of mise bootstrap.
 - [User Login Shell](https://mise.jdx.dev/bootstrap/user.html): mise can declare the current user's login shell in [bootstrap.user] and apply it with mise bootstrap user apply or as part of mise bootstrap.
-- [Dotfiles history](https://mise.jdx.dev/history.html): [!WARNING] Dotfile tracking and history are experimental. Enable them with mise settings experimental=true. Interfaces and storage formats may change.
+- [Dotfiles history](https://mise.jdx.dev/history.html): [!WARNING] Tracking, checkpoints, rollback, watching, and synchronization are experimental. Their interfaces and storage formats may change before stabilization.
 
 ## Environments
 

--- a/e2e/cli/test_dotfiles_onboarding
+++ b/e2e/cli/test_dotfiles_onboarding
@@ -29,10 +29,17 @@ assert_contains 'cat connect.log' 'A file can be both shared and backed up'
 assert_not_contains "git --git-dir=$origin ls-tree -r --name-only main" '.private-config'
 assert_not_contains "git --git-dir=$origin ls-tree -r --name-only main" '.backup-config'
 assert_contains "git --git-dir=$origin ls-tree -r --name-only main" '.shared-config'
-for ref in $(git --git-dir="$origin" for-each-ref --format='%(refname)' refs/mise-history); do
+refs=$(git --git-dir="$origin" for-each-ref --format='%(refname)' refs/mise-history)
+assert_succeed "test -n '$refs'"
+found_backup=false
+for ref in $refs; do
+  if git --git-dir="$origin" ls-tree -r --name-only "$ref" | grep -q '.backup-config'; then
+    found_backup=true
+  fi
   assert_not_contains "git --git-dir=$origin ls-tree -r --name-only $ref" '.private-config'
   assert_not_contains "git --git-dir=$origin ls-tree -r --name-only $ref" '.shared-config'
 done
+assert "echo $found_backup" 'true'
 assert_contains "mise bootstrap dotfiles status" 'mode manual'
 # Local autosave does not publish in manual mode.
 head=$(git --git-dir="$origin" rev-parse main)

--- a/e2e/cli/test_dotfiles_onboarding
+++ b/e2e/cli/test_dotfiles_onboarding
@@ -2,6 +2,7 @@
 # Sharing and backups are distinct destinations; private contents stay local.
 # shellcheck disable=SC2016
 require_cmd git
+export MISE_EXPERIMENTAL=1
 
 printf 'private contents\n' >~/.private-config
 printf 'shared contents\n' >~/.shared-config
@@ -11,12 +12,17 @@ assert_succeed "mise bootstrap dotfiles track ~/.shared-config --no-backup"
 assert_succeed "mise bootstrap dotfiles track ~/.backup-config --no-share"
 assert "mise bootstrap dotfiles paths --json | jq -r '.entries[] | select(.path == \"~/.private-config\") | [.autosave,.share,.backup] | @csv'" 'true,false,false'
 assert_contains "mise bootstrap dotfiles track ~/.private-config --private --no-autosave 2>&1" "manual saving selected"
+assert_contains "mise bootstrap dotfiles track ~/.private-config 2>&1" "manual saving selected"
+printf 'machine-local contents\n' >~/.example.local.toml
+assert_succeed "mise bootstrap dotfiles track ~/.example.local.toml"
 
 origin="$PWD/origin.git"
 git init -q --bare "$origin"
 mise bootstrap dotfiles origin set "file://$origin" --sync manual --include-existing --yes >connect.log 2>&1
 assert_contains 'cat connect.log' 'Sync mode manual:'
 assert_contains 'cat connect.log' '~/.private-config (local history only)'
+assert_contains 'cat connect.log' '~/.example.local.toml (local history only)'
+assert_not_contains 'cat connect.log' '~/.example.local.toml (plaintext)'
 assert_contains 'cat connect.log' '~/.shared-config (plaintext)'
 assert_contains 'cat connect.log' '~/.backup-config (plaintext)'
 assert_contains 'cat connect.log' 'A file can be both shared and backed up'
@@ -44,3 +50,13 @@ printf 'variant contents\n' >~/.variant
 assert_succeed 'mise bootstrap dotfiles track ~/.variant --private'
 assert "mise bootstrap dotfiles paths --json | jq -r '.entries[] | select(.path == \"~/.variant\") | [.share,.backup] | @csv'" 'false,false'
 assert_contains "cat $MISE_CONFIG_DIR/config.toml" 'encrypt = true'
+
+# Retracking the same selector must preserve privacy without duplicating it.
+case "$(uname -s)" in
+  Darwin) this_os=macos ;;
+  *) this_os=linux ;;
+esac
+printf 'os-specific contents\n' >~/.os-private
+assert_succeed "mise bootstrap dotfiles track ~/.os-private --os $this_os --private"
+assert_succeed "mise bootstrap dotfiles track ~/.os-private --os $this_os"
+assert "mise bootstrap dotfiles paths --json | jq -r '.entries[] | select(.path == \"~/.os-private\") | [.share,.backup] | @csv'" 'false,false'

--- a/e2e/cli/test_dotfiles_onboarding
+++ b/e2e/cli/test_dotfiles_onboarding
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Sharing and backups are distinct destinations; private contents stay local.
+# shellcheck disable=SC2016
+require_cmd git
+
+printf 'private contents\n' >~/.private-config
+printf 'shared contents\n' >~/.shared-config
+printf 'backup contents\n' >~/.backup-config
+assert_contains "mise bootstrap dotfiles track ~/.private-config --private 2>&1" "automatic capture is inactive"
+assert_succeed "mise bootstrap dotfiles track ~/.shared-config --no-backup"
+assert_succeed "mise bootstrap dotfiles track ~/.backup-config --no-share"
+assert "mise bootstrap dotfiles paths --json | jq -r '.entries[] | select(.path == \"~/.private-config\") | [.autosave,.share,.backup] | @csv'" 'true,false,false'
+assert_contains "mise bootstrap dotfiles track ~/.private-config --private --no-autosave 2>&1" "manual saving selected"
+
+origin="$PWD/origin.git"
+git init -q --bare "$origin"
+mise bootstrap dotfiles origin set "file://$origin" --sync manual --include-existing --yes >connect.log 2>&1
+assert_contains 'cat connect.log' 'Sync mode manual:'
+assert_contains 'cat connect.log' '~/.private-config (local history only)'
+assert_contains 'cat connect.log' '~/.shared-config (plaintext)'
+assert_contains 'cat connect.log' '~/.backup-config (plaintext)'
+assert_contains 'cat connect.log' 'A file can be both shared and backed up'
+assert_not_contains "git --git-dir=$origin ls-tree -r --name-only main" '.private-config'
+assert_not_contains "git --git-dir=$origin ls-tree -r --name-only main" '.backup-config'
+assert_contains "git --git-dir=$origin ls-tree -r --name-only main" '.shared-config'
+for ref in $(git --git-dir="$origin" for-each-ref --format='%(refname)' refs/mise-history); do
+  assert_not_contains "git --git-dir=$origin ls-tree -r --name-only $ref" '.private-config'
+  assert_not_contains "git --git-dir=$origin ls-tree -r --name-only $ref" '.shared-config'
+done
+assert_contains "mise bootstrap dotfiles status" 'mode manual'
+# Local autosave does not publish in manual mode.
+head=$(git --git-dir="$origin" rev-parse main)
+printf 'new shared contents\n' >~/.shared-config
+assert_succeed 'mise bootstrap dotfiles watch --once'
+assert "git --git-dir=$origin rev-parse main" "$head"
+assert_succeed 'mise bootstrap dotfiles sync'
+assert "git --git-dir=$origin show main:tracked/home/.shared-config" 'new shared contents'
+
+# An inherited variant must not override --private, and encryption is retained.
+cat <<'CONFIG' >>"$MISE_CONFIG_DIR/config.toml"
+"~/.variant" = { mode = "track", encrypt = true, variants = [{ default = true, share = true }] }
+CONFIG
+printf 'variant contents\n' >~/.variant
+assert_succeed 'mise bootstrap dotfiles track ~/.variant --private'
+assert "mise bootstrap dotfiles paths --json | jq -r '.entries[] | select(.path == \"~/.variant\") | [.share,.backup] | @csv'" 'false,false'
+assert_contains "cat $MISE_CONFIG_DIR/config.toml" 'encrypt = true'

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1777,10 +1777,9 @@ The setup branch
 This machine's name in the repository (default: the hostname)
 .TP
 \fB\-\-sync\fR \fI<MODE>\fR
-How the repository is used: sync (default), fetch\-only, or manual
-.RS
-\fIDefault: \fRsync
-.RE
+How the repository is used: sync, fetch\-only, or manual
+
+Prompts when omitted. With \-\-yes, accepts the configured mode (default: sync), including automatic publication and incoming writes. Use \-\-sync manual to keep automatic local history without automatic network activity.
 .TP
 \fB\-\-include\-existing\fR
 Upload the checkpoints recorded before now too
@@ -2043,6 +2042,9 @@ Keep the file out of the shared setup (still backed up)
 .TP
 \fB\-\-no\-backup\fR
 Keep the file out of remote backups (still protected locally)
+.TP
+\fB\-\-private\fR
+Keep file contents entirely local: disable both sharing and remote backups
 .TP
 \fB\-\-local\fR
 Write to config.local.toml (this machine only) instead of config.toml

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -2044,7 +2044,7 @@ Keep the file out of the shared setup (still backed up)
 Keep the file out of remote backups (still protected locally)
 .TP
 \fB\-\-private\fR
-Keep file contents entirely local: disable both sharing and remote backups
+Disable future sharing and remote backups; existing uploads are not erased
 .TP
 \fB\-\-local\fR
 Write to config.local.toml (this machine only) instead of config.toml

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -837,7 +837,12 @@ in the global config; the mode to `settings.history.sync`.
                 flag --name help="This machine's name in the repository (default: the hostname)" {
                     arg <NAME>
                 }
-                flag --sync help="How the repository is used: sync (default), fetch-only, or manual" default=sync {
+                flag --sync help="How the repository is used: sync, fetch-only, or manual" {
+                    long_help #"""
+How the repository is used: sync, fetch-only, or manual
+
+Prompts when omitted. With --yes, accepts the configured mode (default: sync), including automatic publication and incoming writes. Use --sync manual to keep automatic local history without automatic network activity.
+"""#
                     arg <MODE>
                 }
                 flag --include-existing help="Upload the checkpoints recorded before now too"
@@ -1022,6 +1027,7 @@ Linux box can share the same live path with different contents.
             flag --no-autosave help="Save only on `mise bootstrap dotfiles save <path>`, never automatically"
             flag --no-share help="Keep the file out of the shared setup (still backed up)"
             flag --no-backup help="Keep the file out of remote backups (still protected locally)"
+            flag --private help="Keep file contents entirely local: disable both sharing and remote backups"
             flag --local help="Write to config.local.toml (this machine only) instead of config.toml"
             flag "-y --yes" help="Accept without prompting"
             flag "-h --help" help="Print help" action=help builtin=#true

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -1027,7 +1027,7 @@ Linux box can share the same live path with different contents.
             flag --no-autosave help="Save only on `mise bootstrap dotfiles save <path>`, never automatically"
             flag --no-share help="Keep the file out of the shared setup (still backed up)"
             flag --no-backup help="Keep the file out of remote backups (still protected locally)"
-            flag --private help="Keep file contents entirely local: disable both sharing and remote backups"
+            flag --private help="Disable future sharing and remote backups; existing uploads are not erased"
             flag --local help="Write to config.local.toml (this machine only) instead of config.toml"
             flag "-y --yes" help="Accept without prompting"
             flag "-h --help" help="Print help" action=help builtin=#true

--- a/src/cli/dotfiles/capture_health.rs
+++ b/src/cli/dotfiles/capture_health.rs
@@ -63,7 +63,9 @@ pub(crate) fn advice(state: Watcher) -> &'static str {
 /// Warns when enrollment succeeded but nothing saves edits automatically.
 pub(crate) async fn report() {
     match watcher().await {
-        Ok(Watcher::Running) => {}
+        Ok(Watcher::Running) => {
+            info!("history: watcher running; autosave-enabled files are saved automatically")
+        }
         Ok(state) => warn!("history: {}", advice(state)),
         Err(err) => {
             warn!("history: could not determine whether edits are saved automatically: {err:#}")

--- a/src/cli/dotfiles/origin.rs
+++ b/src/cli/dotfiles/origin.rs
@@ -53,9 +53,13 @@ pub(crate) struct DotfilesOriginSet {
     #[usage(long, value_name = "NAME")]
     name: Option<String>,
 
-    /// How the repository is used: sync (default), fetch-only, or manual
-    #[usage(long, value_name = "MODE", default = "sync")]
-    sync: String,
+    /// How the repository is used: sync, fetch-only, or manual
+    ///
+    /// Prompts when omitted. With --yes, accepts the configured mode (default: sync),
+    /// including automatic publication and incoming writes. Use --sync manual
+    /// to keep automatic local history without automatic network activity.
+    #[usage(long, value_name = "MODE")]
+    sync: Option<String>,
 
     /// Upload the checkpoints recorded before now too
     #[usage(long)]
@@ -132,7 +136,22 @@ impl DotfilesOriginSet {
         if !crate::config::Settings::get().history.enabled {
             bail!("history is disabled (history.enabled = false)");
         }
-        let mode = SyncMode::parse(&self.sync)?;
+        let mode = match self.sync.as_deref() {
+            Some(mode) => SyncMode::parse(mode)?,
+            None if self.yes || crate::config::Settings::get().yes => SyncMode::current()?,
+            None => match crate::ui::prompt::confirm_with_default(
+                "Automatically publish saved edits AND apply incoming changes to live files? Choose no for manual sharing; local autosave continues in either mode.",
+                false,
+            )? {
+                crate::ui::prompt::Confirmation::Yes => SyncMode::Sync,
+                crate::ui::prompt::Confirmation::No => SyncMode::Manual,
+                crate::ui::prompt::Confirmation::Unavailable => {
+                    bail!(
+                        "not connected: choose --sync manual, --sync sync, or --sync fetch-only to connect without a mode prompt"
+                    );
+                }
+            },
+        };
         let (store, tracked, _) = super::history::open().await?;
         if let Some(reason) = store.unavailable() {
             bail!("cannot connect a setup repository: {reason}");

--- a/src/cli/dotfiles/track.rs
+++ b/src/cli/dotfiles/track.rs
@@ -49,6 +49,10 @@ pub(crate) struct DotfilesTrack {
     #[usage(long)]
     no_backup: bool,
 
+    /// Keep file contents entirely local: disable both sharing and remote backups
+    #[usage(long)]
+    private: bool,
+
     /// Write to config.local.toml (this machine only) instead of config.toml
     #[usage(long)]
     local: bool,
@@ -143,7 +147,13 @@ impl DotfilesTrack {
             }
             return Err(err.wrap_err(format!("{} was left unchanged", display_path(&config_path))));
         }
-        crate::cli::dotfiles::capture_health::report().await;
+        if self.no_autosave {
+            info!(
+                "history: manual saving selected; run `mise bootstrap dotfiles save <path>` after editing"
+            );
+        } else {
+            crate::cli::dotfiles::capture_health::report().await;
+        }
         Ok(())
     }
 
@@ -159,11 +169,14 @@ impl DotfilesTrack {
         if self.no_autosave {
             policy.autosave = false;
         }
-        if self.no_share {
+        if self.no_share || self.private {
             policy.share = false;
         }
-        if self.no_backup {
+        if self.no_backup || self.private {
             policy.backup = false;
+        }
+        if policy.encrypt {
+            table.insert("encrypt", Value::Boolean(toml_edit::Formatted::new(true)));
         }
         if !policy.autosave {
             table.insert("autosave", Value::Boolean(toml_edit::Formatted::new(false)));
@@ -176,6 +189,11 @@ impl DotfilesTrack {
         }
         let mut variants: Vec<Variant> =
             existing.map(|req| req.variants.clone()).unwrap_or_default();
+        if self.private {
+            for variant in &mut variants {
+                variant.share = Some(false);
+            }
+        }
         if self.os.is_some() || self.profile.is_some() {
             // Adding a specialization must not remove the stream that
             // already serves machines without that specialization.
@@ -191,7 +209,7 @@ impl DotfilesTrack {
                 os: self.os.iter().cloned().collect(),
                 profile: self.profile.clone(),
                 default: false,
-                share: None,
+                share: self.private.then_some(false),
             };
             if !variants.contains(&variant) {
                 variants.push(variant);

--- a/src/cli/dotfiles/track.rs
+++ b/src/cli/dotfiles/track.rs
@@ -72,6 +72,7 @@ impl DotfilesTrack {
         let original = doc.to_string();
         let existed = config_path.exists();
         let mut declared: Vec<(String, PathBuf)> = vec![];
+        let mut manual = vec![];
         for target_raw in &self.targets {
             let target = crate::system::files::resolve_target_arg(target_raw)
                 .components()
@@ -98,6 +99,9 @@ impl DotfilesTrack {
                 );
             }
             let entry = self.entry(existing);
+            if entry.get("autosave").and_then(Value::as_bool) == Some(false) {
+                manual.push(target_key.clone());
+            }
             let dotfiles = doc
                 .entry("dotfiles")
                 .or_insert(Item::Table(toml_edit::Table::new()));
@@ -147,11 +151,13 @@ impl DotfilesTrack {
             }
             return Err(err.wrap_err(format!("{} was left unchanged", display_path(&config_path))));
         }
-        if self.no_autosave {
+        if !manual.is_empty() {
             info!(
-                "history: manual saving selected; run `mise bootstrap dotfiles save <path>` after editing"
+                "history: manual saving selected for {}; run `mise bootstrap dotfiles save <path>` after editing",
+                manual.join(", ")
             );
-        } else {
+        }
+        if manual.len() < declared.len() {
             crate::cli::dotfiles::capture_health::report().await;
         }
         Ok(())
@@ -211,7 +217,11 @@ impl DotfilesTrack {
                 default: false,
                 share: self.private.then_some(false),
             };
-            if !variants.contains(&variant) {
+            if !variants.iter().any(|existing| {
+                existing.os == variant.os
+                    && existing.profile == variant.profile
+                    && existing.default == variant.default
+            }) {
                 variants.push(variant);
             }
         }

--- a/src/cli/dotfiles/track.rs
+++ b/src/cli/dotfiles/track.rs
@@ -49,7 +49,7 @@ pub(crate) struct DotfilesTrack {
     #[usage(long)]
     no_backup: bool,
 
-    /// Keep file contents entirely local: disable both sharing and remote backups
+    /// Disable future sharing and remote backups; existing uploads are not erased
     #[usage(long)]
     private: bool,
 

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -294,6 +294,51 @@ async fn set_inner(
             miseprintln!("  {}", display_path(path));
         }
     }
+    // Show actual paths in both outgoing channels: not sharing a file does
+    // not imply that its recovery history stays local.
+    let shared_paths: BTreeMap<_, _> = shared
+        .files
+        .values()
+        .map(|file| (&file.local, file))
+        .collect();
+    miseprintln!(
+        "File destinations (current captured files; historical backups follow the policies below):"
+    );
+    for group in ["Local only", "Shared setup", "Remote backup"] {
+        miseprintln!("  {group}:");
+        let mut count = 0;
+        for (path, (_, policy)) in &walk.files {
+            let shared_file = shared_paths.get(path);
+            let backup =
+                policy.backup && (!policy.encrypt || !matches!(backups, BackupPlan::Plain));
+            let included = match group {
+                "Local only" => shared_file.is_none() && !backup,
+                "Shared setup" => shared_file.is_some(),
+                _ => backup,
+            };
+            if !included {
+                continue;
+            }
+            count += 1;
+            let protection = match group {
+                "Local only" => "local history only",
+                "Shared setup" if shared_file.is_some_and(|file| file.encrypt) => {
+                    "encrypted contents; path visible"
+                }
+                "Remote backup" if !matches!(backups, BackupPlan::Plain) => {
+                    "encrypted contents and paths"
+                }
+                _ => "plaintext",
+            };
+            miseprintln!("    {} ({protection})", display_path(path));
+        }
+        if count == 0 {
+            miseprintln!("    (none)");
+        }
+    }
+    miseprintln!(
+        "A file can be both shared and backed up. `track <path> --private` disables both for its contents; its declaration may still be shared. Previously published content is not erased."
+    );
     let backed_up = walk
         .files
         .iter()

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -5,7 +5,7 @@
 //! the repository's history, and how an existing unmarked repository would
 //! be adopted.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use eyre::{Result, bail};
@@ -301,6 +301,7 @@ async fn set_inner(
         .values()
         .map(|file| (&file.local, file))
         .collect();
+    let private_paths: BTreeSet<_> = walk.private.iter().map(|file| &file.path).collect();
     miseprintln!(
         "File destinations (current captured files; historical backups follow the policies below):"
     );
@@ -309,8 +310,9 @@ async fn set_inner(
         let mut count = 0;
         for (path, (_, policy)) in &walk.files {
             let shared_file = shared_paths.get(path);
-            let backup =
-                policy.backup && (!policy.encrypt || !matches!(backups, BackupPlan::Plain));
+            let backup = !private_paths.contains(path)
+                && policy.backup
+                && (!policy.encrypt || !matches!(backups, BackupPlan::Plain));
             let included = match group {
                 "Local only" => shared_file.is_none() && !backup,
                 "Shared setup" => shared_file.is_some(),
@@ -342,8 +344,10 @@ async fn set_inner(
     let backed_up = walk
         .files
         .iter()
-        .filter(|(_, (_, policy))| {
-            policy.backup && (!policy.encrypt || !matches!(backups, BackupPlan::Plain))
+        .filter(|(path, (_, policy))| {
+            !private_paths.contains(path)
+                && policy.backup
+                && (!policy.encrypt || !matches!(backups, BackupPlan::Plain))
         })
         .count();
     match &backups {


### PR DESCRIPTION
Connecting dotfile history should make it clear which files leave the machine and whether incoming edits will be written automatically. Interactive `origin set` now asks that separately from connection confirmation, while `--sync` selects a mode directly and `--yes` accepts the configured mode for existing automation.

The connection preview lists actual captured paths under local-only, shared-setup, and remote-backup destinations with encryption status. `track --private` disables both sharing and backups, including explicit variant sharing overrides; retracking preserves encryption. Watcher/manual-save guidance and the tracking documentation are clarified.

Stacked on #12895 (`bootstrap/11-encrypted-backups`). File declarations can still be shared, and changing a policy does not erase previous uploads.

Validation: new onboarding/privacy E2E and existing tracking, manual/automatic sync, encrypted backup/file, and sync-preflight E2E passed. Build, generated CLI documentation, scoped safe hk checks, and strict workspace Clippy (`--workspace --all-features --all-targets -- -D warnings`) passed on the completed stack.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*



## Current stack integration (531b9bfc5)

Rebased onto the current encryption stack. Fixed all three initial findings: private-file backup previews now match upload eligibility; retracking reports the resulting autosave policy; private OS/profile variants are not duplicated when retracked. Added onboarding regressions with tracking enabled without experimental opt-in. Local onboarding, tracking, and full two-machine sync E2Es passed, including whole-setup pauses, incremental conflict resolution, stale-edit protection, and declined-origin state isolation. Full render and lint-fix passed.

CI dispatched for this exact head: [test workflow](https://github.com/jdx/mise/actions/runs/34064079038); results pending.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `--private` tracking to disable future sharing and remote backups while retaining local history and encryption.
  - Added clearer destination visibility when connecting a setup repository, including local-only, shared, and backed-up files.
  - `origin set --sync` now supports sync, fetch-only, and manual modes, with prompting when no mode is specified.
  - Added clearer status information when file watching is active.

- **Documentation**
  - Updated dotfiles and history documentation with privacy behavior, experimental feature guidance, and compatibility details.

- **Tests**
  - Expanded end-to-end coverage for onboarding, watching, synchronization, encryption, private files, and repeated tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what data leaves the machine during origin connect and how sync mode is chosen; mistakes could expose private files or enable unwanted auto-sync, though previews and `--private` are designed to reduce that.
> 
> **Overview**
> Adds **`track --private`** to turn off both sharing and remote backups while keeping local history (and forcing variant `share` off); retracking preserves privacy and encryption without duplicating OS/profile variants.
> 
> **`origin set`** no longer silently defaults `--sync`: interactive runs prompt whether to auto-publish and apply incoming changes; omitting `--sync` with **`--yes`** keeps the configured default (`sync`). The connect preview now groups captured paths under **Local only**, **Shared setup**, and **Remote backup** (with encryption labels) and clarifies that sharing ≠ backup.
> 
> **Tracking UX:** manual-save paths get an explicit log line; autosave health runs only when some tracked paths still autosave; a running watcher logs an info message.
> 
> Docs and generated CLI help (`usage`, man) reflect the new flags and experimental notices; macOS CI runs new **`test_dotfiles_onboarding`** E2E for privacy, origin preview, and manual sync behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7757ff150f00a23ce8e224d0f0768d4cfd865b11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->