### PR TITLE
feat(install): live install region for interactive terminals

### DIFF
--- a/e2e/cli/test_install_text_progress
+++ b/e2e/cli/test_install_text_progress
@@ -7,6 +7,7 @@ export MISE_FORCE_PROGRESS=0
 output=$(mise install dummy@1.0.0 2>&1)
 printf '%s\n' "$output" >output.log
 assert_contains 'cat output.log' 'installing 1 tool'
+assert_contains 'cat output.log' 'by @jdx – installing 1 tool'
 assert_contains 'cat output.log' '✓ dummy@1.0.0'
 assert_contains 'cat output.log' '████████████████ 1/1 · installed 1 tool in'
 if [[ $output == *'[1/'* || $output == *$'\033['* ]]; then

--- a/e2e/cli/test_install_text_progress
+++ b/e2e/cli/test_install_text_progress
@@ -55,6 +55,18 @@ if [[ $output == *'failed: running postinstall hook'* ]]; then
   fail "failure line reported a phase as the reason: $output"
 fi
 
+# Removals get the same session: one permanent line per tool and a summary in
+# removal verbs, instead of a kept "remove <path>" row per version.
+output=$(mise uninstall dummy@1.0.0 dummy@1.0.1 2>&1)
+printf '%s\n' "$output" >output.log
+assert_contains 'cat output.log' 'removing 2 tools'
+assert_contains 'cat output.log' '✓ dummy@1.0.0'
+assert_contains 'cat output.log' '✓ dummy@1.0.1'
+assert_contains 'cat output.log' '2/2 · removed 2 tools in'
+if [[ $output == *'remove ~'* || $output == *'remove /'* ]]; then
+  fail "removal rows should not print the install path: $output"
+fi
+
 # Explicit output modes keep their existing behavior.
 echo '[tools]' >mise.toml
 for mode in '--quiet' '--verbose' '--raw' '--dry-run'; do

--- a/e2e/cli/test_install_tty_progress
+++ b/e2e/cli/test_install_tty_progress
@@ -57,6 +57,7 @@ plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
 assert re.search(r"\x1b\[[0-9;]*[ABCDEFGHJKST]|\x1b\[\?25[lh]", raw), raw
 assert "░" in plain or "█" in plain, plain
 assert re.search(r"[01]/1", plain), plain
+assert "by @jdx" in plain, plain
 
 # The row named the phase. (A hook's stdout is a transient status line in the
 # interactive display, as it always was; the append-only reporter is what
@@ -95,6 +96,8 @@ assert re.search(r"✓ dummy@1\.0\.0\s+\d+(\.\d+)?(ms|s)", plain), plain
 for line in plain.replace("\r", "\n").splitlines():
     assert len(line.rstrip()) <= 50, f"{len(line)} cells at 50 columns: {line!r}\n{plain}"
 assert "█" * 11 not in plain, plain
+# The byline is the last thing the header gives up, and at 50 columns it goes.
+assert "by @jdx" not in plain, plain
 
 # An AI agent's terminal is a PTY that records frames instead of redrawing
 # them. It must get the append-only output CI gets, or every tick reprints

--- a/e2e/cli/test_install_tty_progress
+++ b/e2e/cli/test_install_tty_progress
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# An interactive terminal gets the live install region: a header with the
+# install-wide bar, one row per active tool, and the same permanent completion
+# lines the append-only reporter prints. This drives mise through a PTY with CI
+# unset so the animated display is actually chosen.
+export CI=0 MISE_DEBUG=0 MISE_TRACE=0 MISE_LOG_LEVEL=info
+export MISE_FORCE_PROGRESS=0
+
+cat >mise.toml <<'TOML'
+[tools]
+dummy = { version = "1.0.0", postinstall = "sleep 1; echo hook-finished" }
+TOML
+
+python3 - <<'PY'
+import errno
+import os
+import pty
+import re
+import subprocess
+
+def run(args, env):
+    master, slave = pty.openpty()
+    proc = subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=slave, env=env)
+    os.close(slave)
+    output = bytearray()
+    try:
+        while True:
+            try:
+                chunk = os.read(master, 8192)
+            except OSError as error:
+                if error.errno == errno.EIO:
+                    break
+                raise
+            if not chunk:
+                break
+            output.extend(chunk)
+    finally:
+        os.close(master)
+    return proc.wait(), output.decode(errors="replace")
+
+env = dict(os.environ, COLUMNS="120", LINES="40")
+env.pop("CI", None)
+env["CI"] = "0"
+code, raw = run(["mise", "install"], env)
+assert code == 0, raw
+plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
+
+# The live region was drawn: cursor controls appear, and the header carries
+# the install-wide bar with its whole-tool count.
+assert "\x1b[" in raw, raw
+assert "░" in plain or "█" in plain, plain
+assert re.search(r"[01]/1", plain), plain
+
+# The row named the phase. (A hook's stdout is a transient status line in the
+# interactive display, as it always was; the append-only reporter is what
+# prints it per line.)
+assert "running postinstall hook" in plain, plain
+
+# The bar never reads full while the tool is still working: with one tool the
+# header shows at most 23 of 24 cells until the completion line lands.
+for line in plain.splitlines():
+    if "0/1" in line and "█" * 24 in line:
+        raise AssertionError("bar was full before the install finished:\n" + plain)
+
+# The permanent record matches the append-only reporter: one completion line
+# per tool with its duration, then a summary. The old per-tool "installed"
+# row and the old "[cur/total]" header are gone.
+assert re.search(r"✓ dummy@1\.0\.0\s+\d+(\.\d+)?(ms|s)", plain), plain
+assert "installed 1 tool in" in plain, plain
+assert "[0/1]" not in plain and "[1/1]" not in plain, plain
+
+# A version that is already installed is reported as such, not as a fresh
+# install. (A bare `mise install` with nothing to do says "all tools are
+# installed" before any reporter exists, so ask for the version explicitly.)
+code, raw = run(["mise", "install", "dummy@1.0.0"], env)
+assert code == 0, raw
+plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
+assert "already installed" in plain, plain
+
+# --verbose keeps the classic per-line reporter.
+code, raw = run(["mise", "install", "--force", "--verbose"], env)
+assert code == 0, raw
+plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
+assert "installed 1 tool in" not in plain, plain
+PY

--- a/e2e/cli/test_install_tty_progress
+++ b/e2e/cli/test_install_tty_progress
@@ -14,13 +14,18 @@ TOML
 
 python3 - <<'PY'
 import errno
+import fcntl
 import os
 import pty
 import re
+import struct
 import subprocess
+import termios
 
-def run(args, env):
+def run(args, env, columns=120):
     master, slave = pty.openpty()
+    # A fresh PTY has no size; mise reads the window size, not $COLUMNS.
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 40, columns, 0, 0))
     proc = subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=slave, env=env)
     os.close(slave)
     output = bytearray()
@@ -46,9 +51,10 @@ code, raw = run(["mise", "install"], env)
 assert code == 0, raw
 plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
 
-# The live region was drawn: cursor controls appear, and the header carries
-# the install-wide bar with its whole-tool count.
-assert "\x1b[" in raw, raw
+# The live region was drawn: cursor movement or line erasure appears (colors
+# alone would not prove a redraw), and the header carries the install-wide bar
+# with its whole-tool count.
+assert re.search(r"\x1b\[[0-9;]*[ABCDEFGHJKST]|\x1b\[\?25[lh]", raw), raw
 assert "░" in plain or "█" in plain, plain
 assert re.search(r"[01]/1", plain), plain
 
@@ -77,6 +83,18 @@ code, raw = run(["mise", "install", "dummy@1.0.0"], env)
 assert code == 0, raw
 plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
 assert "already installed" in plain, plain
+
+# A narrow terminal gets a layout that fits it rather than wrapped lines: the
+# header drops its version and shrinks the bar, rows drop their bar, and the
+# permanent lines stay within the width. Every line of the recorded output is
+# checked, so a live-region frame that overflowed would fail too.
+code, raw = run(["mise", "install", "--force", "dummy@1.0.0"], env, columns=50)
+assert code == 0, raw
+plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
+assert re.search(r"✓ dummy@1\.0\.0\s+\d+(\.\d+)?(ms|s)", plain), plain
+for line in plain.replace("\r", "\n").splitlines():
+    assert len(line.rstrip()) <= 50, f"{len(line)} cells at 50 columns: {line!r}\n{plain}"
+assert "█" * 11 not in plain, plain
 
 # An AI agent's terminal is a PTY that records frames instead of redrawing
 # them. It must get the append-only output CI gets, or every tick reprints

--- a/e2e/cli/test_install_tty_progress
+++ b/e2e/cli/test_install_tty_progress
@@ -78,6 +78,16 @@ assert code == 0, raw
 plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
 assert "already installed" in plain, plain
 
+# An AI agent's terminal is a PTY that records frames instead of redrawing
+# them. It must get the append-only output CI gets, or every tick reprints
+# the whole live region.
+agent_env = dict(env, CLAUDECODE="1")
+code, raw = run(["mise", "install", "--force", "dummy@1.0.0"], agent_env)
+assert code == 0, raw
+assert not re.search(r"\x1b\[[0-9;]*[ABCDEFGHJKST]|\x1b\[\?25[lh]", raw), raw
+plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
+assert "installed 1 tool in" in plain, plain
+
 # --verbose keeps the classic per-line reporter.
 code, raw = run(["mise", "install", "--force", "--verbose"], env)
 assert code == 0, raw

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3344,6 +3344,9 @@ pub(crate) trait Backend: Debug + Send + Sync {
         // uninstall so shared and system installs cannot have their marker
         // cleared while an install is still in progress.
         let state_version = tv.tv_pathname();
+        // Another mise may be installing this exact version. Say so while we
+        // wait on it: a row that sits in "resolving" for a minute looks hung.
+        ctx.pr.set_message("waiting for install lock".into());
         let _state_lock = install_state::lock_tool_version(&tv.ba().short, &state_version)?;
 
         let mut install_satisfied = self

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3346,8 +3346,10 @@ pub(crate) trait Backend: Debug + Send + Sync {
         let state_version = tv.tv_pathname();
         // Another mise may be installing this exact version. Say so while we
         // wait on it: a row that sits in "resolving" for a minute looks hung.
-        ctx.pr.set_message("waiting for install lock".into());
-        let _state_lock = install_state::lock_tool_version(&tv.ba().short, &state_version)?;
+        let _state_lock =
+            install_state::lock_tool_version_with_notice(&tv.ba().short, &state_version, &|| {
+                ctx.pr.set_message("waiting for install lock".into());
+            })?;
 
         let mut install_satisfied = self
             .is_install_satisfied_or_false(&ctx.config, &tv, true)

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -1107,6 +1107,12 @@ impl NPMBackend {
         };
         opts.ignore_scripts = matches!(allow_builds, AllowBuilds::None);
 
+        // Before aube reports its first phase it vets the package — the
+        // typosquat, download-count and age gates — and looks up the version
+        // the request resolves to, both against the registry. Without a name
+        // for that the row sits on the wrapper's "installing" for however long
+        // the registry takes.
+        ctx.pr.set_message("checking package".into());
         let package = package.to_string();
         let install = aube::embed::add_with_overrides(
             &install_path,
@@ -1555,12 +1561,15 @@ const AUBE_OPERATION_WEIGHTS: [f64; 3] = [0.15, 0.80, 0.05];
 
 /// Turns aube's event stream into the reporter's phase and progress calls.
 ///
-/// Aube reports the phase on every snapshot rather than as transitions, so
-/// this remembers the last phase seen and advances the reporter's operation
-/// when it changes. One instance per install.
+/// The plan itself — these three weights, plus the removal a forced reinstall
+/// puts in front of them — is declared by the install wrapper through
+/// [`Backend::install_operation_weights`] before the worker starts; this only
+/// walks through it. Aube reports the phase on every snapshot rather than as
+/// transitions, so this remembers the last phase seen and advances the
+/// reporter's operation when it changes. One instance per install.
 #[derive(Default)]
 struct AubeProgress {
-    operation: Option<usize>,
+    operation: usize,
 }
 
 impl AubeProgress {
@@ -1576,17 +1585,16 @@ impl AubeProgress {
                 Some(InstallPhase::Linking) => 2,
                 Some(InstallPhase::Complete) => AUBE_OPERATION_WEIGHTS.len(),
             };
-            let current = match self.operation {
-                Some(current) => current,
-                None => {
-                    pr.start_operations_weighted(&AUBE_OPERATION_WEIGHTS);
-                    0
-                }
-            };
-            for _ in current..operation {
+            // A snapshot from a phase already left would paint that phase's
+            // label and counts over the current one. Neither the operation nor
+            // the row goes backwards.
+            if operation < self.operation {
+                return;
+            }
+            for _ in self.operation..operation {
                 pr.next_operation();
             }
-            self.operation = Some(operation.max(current));
+            self.operation = operation;
         }
         apply_aube_event(event, pr);
     }
@@ -3257,8 +3265,7 @@ pkg@1.2.0 '1.2.0'
         let report = ProgressRecorder::default();
         let mut progress = AubeProgress::default();
 
-        // The first snapshot declares the plan; resolving counts against a
-        // frontier that can still grow.
+        // Resolving counts against a frontier that can still grow.
         progress.apply(snapshot(Some(InstallPhase::Resolving), 3, 10, 0), &report);
         progress.apply(snapshot(Some(InstallPhase::Resolving), 12, 10, 0), &report);
         // Fetching is the next operation; the tally is packages in place.
@@ -3272,7 +3279,6 @@ pkg@1.2.0 '1.2.0'
         assert_eq!(
             *report.0.lock().unwrap(),
             [
-                "start [0.15, 0.8, 0.05]",
                 "items 3/10",
                 "items 12/12",
                 "next",
@@ -3290,18 +3296,10 @@ pkg@1.2.0 '1.2.0'
         let report = ProgressRecorder::default();
         let mut progress = AubeProgress::default();
         progress.apply(snapshot(Some(InstallPhase::Linking), 4, 4, 4), &report);
-        // A late resolving snapshot must not rewind the operation.
-        progress.apply(snapshot(Some(InstallPhase::Resolving), 4, 4, 4), &report);
-        assert_eq!(
-            *report.0.lock().unwrap(),
-            [
-                "start [0.15, 0.8, 0.05]",
-                "next",
-                "next",
-                "items 4/4",
-                "items 4/4"
-            ]
-        );
+        // A late resolving snapshot must neither rewind the operation nor
+        // repaint the row with the old phase's counts.
+        progress.apply(snapshot(Some(InstallPhase::Resolving), 2, 4, 0), &report);
+        assert_eq!(*report.0.lock().unwrap(), ["next", "next", "items 4/4"]);
     }
 
     #[test]

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -1563,21 +1563,33 @@ fn apply_aube_event(event: aube::embed::InstallEvent, pr: &dyn SingleReport) {
 
             // The first snapshot lands before resolution has counted anything;
             // `0/0 pkgs` is worse than no tally at all.
-            let mut message = if total == 0 {
-                label.to_string()
+            let mut detail = if total == 0 {
+                String::new()
             } else {
-                format!("{label} {cur}/{total} pkgs")
+                format!("{cur}/{total} pkgs")
             };
             // Bytes actually transferred — no denominator, so nothing here can
             // be wrong the way a percentage would be. Omitted entirely for an
             // install served from the store, which downloads nothing.
             if snap.downloaded_bytes > 0 {
-                message.push_str(&format!(
-                    " · {}",
-                    ByteSize::b(snap.downloaded_bytes).display().iec()
-                ));
+                if !detail.is_empty() {
+                    detail.push_str(" · ");
+                }
+                detail.push_str(
+                    &ByteSize::b(snap.downloaded_bytes)
+                        .display()
+                        .iec()
+                        .to_string(),
+                );
             }
-            pr.set_message(message);
+            // The phase is the message; the tally is detail, so a reporter with
+            // room for it can show the two apart and one without can fold them.
+            if detail.is_empty() {
+                pr.set_message(label.to_string());
+            } else {
+                pr.set_message(format!("{label} {detail}"));
+                pr.set_detail(detail);
+            }
         }
         // Text aube would have written to stderr itself. Warnings are the
         // user's business; a fatal error also comes back as the returned

--- a/src/backend/npm.rs
+++ b/src/backend/npm.rs
@@ -285,6 +285,18 @@ fn aube_install_tree_is_healthy(install_path: &Path) -> bool {
 
 #[async_trait]
 impl Backend for NPMBackend {
+    /// The embedded installer reports resolve → fetch → link through
+    /// [`AubeProgress`]; these are aube's own bar weights for those phases.
+    /// The subprocess package managers never advance operations, so for them
+    /// the bar simply waits for the worker like any plugin backend.
+    async fn install_operation_weights(
+        &self,
+        _tv: &ToolVersion,
+        _ctx: &InstallContext,
+    ) -> Vec<f64> {
+        AUBE_OPERATION_WEIGHTS.to_vec()
+    }
+
     fn get_type(&self) -> BackendType {
         BackendType::Npm
     }
@@ -1106,16 +1118,17 @@ impl NPMBackend {
         // Drain events alongside the install rather than after it: the
         // reporter only enqueues (it must never wait on us while holding an
         // install worker), so nothing renders unless someone is pulling.
+        let mut progress = AubeProgress::default();
         let result = loop {
             tokio::select! {
                 res = &mut install => break res,
-                Some(event) = rx.recv() => apply_aube_event(event, ctx.pr.as_ref()),
+                Some(event) = rx.recv() => progress.apply(event, ctx.pr.as_ref()),
             }
         };
         // Events queued between the last poll and the install returning —
         // notably the terminal `Complete` snapshot.
         while let Ok(event) = rx.try_recv() {
-            apply_aube_event(event, ctx.pr.as_ref());
+            progress.apply(event, ctx.pr.as_ref());
         }
         result.map_err(|e| self.format_aube_install_error(e))?;
         Ok(())
@@ -1536,6 +1549,49 @@ fn aube_prompt_message(prompt: &aube::embed::InstallPrompt) -> String {
 /// anything fetches them. The result is a bar pinned near 15% with an ETA
 /// swinging between 5s and 30s. The package tally below is the honest number,
 /// and mise's spinner already says the work is live.
+/// Resolving fills a small leading slice, fetching most of the rest, and
+/// linking holds the tail — the shape aube's own bar uses.
+const AUBE_OPERATION_WEIGHTS: [f64; 3] = [0.15, 0.80, 0.05];
+
+/// Turns aube's event stream into the reporter's phase and progress calls.
+///
+/// Aube reports the phase on every snapshot rather than as transitions, so
+/// this remembers the last phase seen and advances the reporter's operation
+/// when it changes. One instance per install.
+#[derive(Default)]
+struct AubeProgress {
+    operation: Option<usize>,
+}
+
+impl AubeProgress {
+    fn apply(&mut self, event: aube::embed::InstallEvent, pr: &dyn SingleReport) {
+        use aube::embed::{InstallEvent, InstallPhase};
+
+        if let InstallEvent::Progress(snap) = &event {
+            // Complete sits past the last declared operation, which the model
+            // reads as "all declared work done, waiting for the worker".
+            let operation = match snap.phase {
+                Some(InstallPhase::Resolving) | None => 0,
+                Some(InstallPhase::Fetching) => 1,
+                Some(InstallPhase::Linking) => 2,
+                Some(InstallPhase::Complete) => AUBE_OPERATION_WEIGHTS.len(),
+            };
+            let current = match self.operation {
+                Some(current) => current,
+                None => {
+                    pr.start_operations_weighted(&AUBE_OPERATION_WEIGHTS);
+                    0
+                }
+            };
+            for _ in current..operation {
+                pr.next_operation();
+            }
+            self.operation = Some(operation.max(current));
+        }
+        apply_aube_event(event, pr);
+    }
+}
+
 fn apply_aube_event(event: aube::embed::InstallEvent, pr: &dyn SingleReport) {
     use aube::embed::{InstallEvent, InstallOutputLevel, InstallPhase};
 
@@ -1582,13 +1638,12 @@ fn apply_aube_event(event: aube::embed::InstallEvent, pr: &dyn SingleReport) {
                         .to_string(),
                 );
             }
-            // The phase is the message; the tally is detail, so a reporter with
-            // room for it can show the two apart and one without can fold them.
-            if detail.is_empty() {
-                pr.set_message(label.to_string());
-            } else {
-                pr.set_message(format!("{label} {detail}"));
-                pr.set_detail(detail);
+            // The phase is the message; the tally is detail. Reporters with room
+            // show them apart; those with one status line fold them back.
+            pr.set_message(label.to_string());
+            pr.set_detail(detail);
+            if total > 0 && snap.phase != Some(InstallPhase::Complete) {
+                pr.set_items(cur as u64, total as u64);
             }
         }
         // Text aube would have written to stderr itself. Warnings are the
@@ -3161,6 +3216,92 @@ pkg@1.2.0 '1.2.0'
         // Hyphen only inside build metadata (not legal semver, but be defensive)
         // — we treat it as stable since the version core has no pre-release.
         assert!(!is_semver_prerelease("1.0.0+build-5"));
+    }
+
+    /// Records the progress calls a reporter receives, in order.
+    #[derive(Debug, Default)]
+    struct ProgressRecorder(std::sync::Mutex<Vec<String>>);
+
+    impl SingleReport for ProgressRecorder {
+        fn start_operations_weighted(&self, weights: &[f64]) {
+            self.0.lock().unwrap().push(format!("start {:?}", weights));
+        }
+        fn next_operation(&self) {
+            self.0.lock().unwrap().push("next".into());
+        }
+        fn set_items(&self, done: u64, total: u64) {
+            self.0.lock().unwrap().push(format!("items {done}/{total}"));
+        }
+    }
+
+    fn snapshot(
+        phase: Option<aube::embed::InstallPhase>,
+        resolved: usize,
+        total: usize,
+        fetched: usize,
+    ) -> aube::embed::InstallEvent {
+        aube::embed::InstallEvent::Progress(aube::embed::InstallProgressSnapshot {
+            phase,
+            resolved,
+            total,
+            reused: 0,
+            downloaded: fetched,
+            downloaded_bytes: 0,
+            estimated_bytes: 0,
+        })
+    }
+
+    #[test]
+    fn aube_snapshots_drive_operations_and_item_progress() {
+        use aube::embed::InstallPhase;
+        let report = ProgressRecorder::default();
+        let mut progress = AubeProgress::default();
+
+        // The first snapshot declares the plan; resolving counts against a
+        // frontier that can still grow.
+        progress.apply(snapshot(Some(InstallPhase::Resolving), 3, 10, 0), &report);
+        progress.apply(snapshot(Some(InstallPhase::Resolving), 12, 10, 0), &report);
+        // Fetching is the next operation; the tally is packages in place.
+        progress.apply(snapshot(Some(InstallPhase::Fetching), 12, 12, 5), &report);
+        progress.apply(snapshot(Some(InstallPhase::Fetching), 12, 12, 12), &report);
+        // Skipping straight to Complete still advances past every operation,
+        // once, and reports no tally for a phase with nothing left to count.
+        progress.apply(snapshot(Some(InstallPhase::Complete), 12, 12, 12), &report);
+        progress.apply(snapshot(Some(InstallPhase::Complete), 12, 12, 12), &report);
+
+        assert_eq!(
+            *report.0.lock().unwrap(),
+            [
+                "start [0.15, 0.8, 0.05]",
+                "items 3/10",
+                "items 12/12",
+                "next",
+                "items 5/12",
+                "items 12/12",
+                "next",
+                "next",
+            ]
+        );
+    }
+
+    #[test]
+    fn aube_progress_never_walks_operations_backwards() {
+        use aube::embed::InstallPhase;
+        let report = ProgressRecorder::default();
+        let mut progress = AubeProgress::default();
+        progress.apply(snapshot(Some(InstallPhase::Linking), 4, 4, 4), &report);
+        // A late resolving snapshot must not rewind the operation.
+        progress.apply(snapshot(Some(InstallPhase::Resolving), 4, 4, 4), &report);
+        assert_eq!(
+            *report.0.lock().unwrap(),
+            [
+                "start [0.15, 0.8, 0.05]",
+                "next",
+                "next",
+                "items 4/4",
+                "items 4/4"
+            ]
+        );
     }
 
     #[test]

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -11,6 +11,7 @@ use crate::toolset::{
     NeededVersions, ToolVersion, ToolsetBuilder, get_versions_needed_by_tracked_configs,
     get_versions_needed_by_tracked_stubs,
 };
+use crate::ui::install_progress::removal_progress;
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::prompt;
 use crate::{backend::Backend, config, env, exit};
@@ -183,32 +184,68 @@ async fn delete(
     explain: Option<&NeededVersions>,
 ) -> Result<()> {
     let mpr = MultiProgressReport::get();
+    if dry_run {
+        for (p, tv) in to_delete {
+            if let Some(needed) = explain {
+                explain_removal(&tv, needed);
+            }
+            let prefix = format!("{} {} ", tv.style(), style("[dryrun]").bold());
+            let pr = mpr.add(&prefix);
+            p.uninstall_version(config, &tv, pr.as_ref(), true).await?;
+            pr.finish();
+        }
+        return Ok(());
+    }
+
+    // Ask about everything first, then remove. A prompt in the middle of a
+    // live region has to pause it, and the answers are the same either way.
+    let mut confirmed = Vec::with_capacity(to_delete.len());
     for (p, tv) in to_delete {
         if let Some(needed) = explain {
             explain_removal(&tv, needed);
         }
-        let mut prefix = tv.style();
-        if dry_run {
-            prefix = format!("{} {} ", prefix, style("[dryrun]").bold());
+        if Settings::get().yes || prompt::confirm_with_all(format!("remove {} ?", tv))?.is_yes() {
+            confirmed.push((p, tv));
         }
-        if !dry_run
-            && !Settings::get().yes
-            && !prompt::confirm_with_all(format!("remove {} ?", tv))?.is_yes()
-        {
-            continue;
+    }
+
+    let mut progress = removal_progress(
+        &mpr,
+        confirmed
+            .iter()
+            .map(|(_, tv)| (removal_key(tv), tv.style())),
+    );
+    for (p, tv) in confirmed {
+        let tool = progress
+            .as_ref()
+            .and_then(|progress| progress.start_tool(&removal_key(&tv)));
+        let pr = match &tool {
+            Some(tool) => tool.reporter(),
+            None => mpr.add(&tv.style()),
+        };
+        let result = p.uninstall_version(config, &tv, pr.as_ref(), false).await;
+        if let Some(tool) = &tool {
+            tool.complete(result.as_ref().err().map(|e| e.to_string()).as_deref());
         }
-        let pr = mpr.add(&prefix);
-        p.uninstall_version(config, &tv, pr.as_ref(), dry_run)
-            .await?;
-        if !dry_run {
-            if let Err(err) = crate::tool_purgatory::forget_path(&tv.install_path()) {
-                warn!("failed to clear tool purgatory entry: {err:#}");
-            }
-            runtime_symlinks::remove_missing_symlinks(p)?;
+        result?;
+        if let Err(err) = crate::tool_purgatory::forget_path(&tv.install_path()) {
+            warn!("failed to clear tool purgatory entry: {err:#}");
         }
-        pr.finish();
+        runtime_symlinks::remove_missing_symlinks(p)?;
+        if tool.is_none() {
+            pr.finish();
+        }
+    }
+    if let Some(progress) = progress.as_mut() {
+        progress.finish(vec![]);
     }
     Ok(())
+}
+
+/// The session key for a version being removed: the same `short@version`
+/// shape the install scheduler uses.
+fn removal_key(tv: &ToolVersion) -> String {
+    format!("{}@{}", tv.ba().short, tv.version)
 }
 
 /// Say why `tv` is up for removal.

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -8,6 +8,7 @@ use crate::backend::Backend;
 use crate::cli::args::ToolArg;
 use crate::config::Config;
 use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolsetBuilder};
+use crate::ui::install_progress::removal_progress;
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::{config, dirs, exit, file};
 
@@ -76,7 +77,7 @@ impl Uninstall {
             .collect::<Vec<_>>();
 
         let mpr = MultiProgressReport::get();
-        let mut has_work = false;
+        let mut to_remove = Vec::with_capacity(tool_versions.len());
         for (plugin, tv) in tool_versions {
             // `is_version_installed` resolves the install path, so it says no for a link whose
             // target is gone -- and that entry is precisely what someone running `uninstall` is
@@ -89,13 +90,37 @@ impl Uninstall {
                 warn!("{} is not installed", tv.style());
                 continue;
             }
+            to_remove.push((plugin, tv));
+        }
+        let has_work = !to_remove.is_empty();
 
-            has_work = true;
-            let pr = mpr.add(&tv.style());
-            if let Err(err) = plugin
+        // A dry run keeps its per-line report: it exists to be read.
+        let mut progress = if self.is_dry_run() {
+            None
+        } else {
+            removal_progress(
+                &mpr,
+                to_remove
+                    .iter()
+                    .map(|(_, tv)| (format!("{}@{}", tv.ba().short, tv.version), tv.style())),
+            )
+        };
+        for (plugin, tv) in to_remove {
+            let key = format!("{}@{}", tv.ba().short, tv.version);
+            let tool = progress
+                .as_ref()
+                .and_then(|progress| progress.start_tool(&key));
+            let pr = match &tool {
+                Some(tool) => tool.reporter(),
+                None => mpr.add(&tv.style()),
+            };
+            let result = plugin
                 .uninstall_version(&config, &tv, pr.as_ref(), self.is_dry_run())
-                .await
-            {
+                .await;
+            if let Some(tool) = &tool {
+                tool.complete(result.as_ref().err().map(|e| e.to_string()).as_deref());
+            }
+            if let Err(err) = result {
                 error!("{err}");
                 return Err(eyre!(err).wrap_err(format!("failed to uninstall {tv}")));
             }
@@ -105,8 +130,13 @@ impl Uninstall {
                 if let Err(err) = crate::tool_purgatory::forget_path(&tv.install_path()) {
                     warn!("failed to clear tool purgatory entry: {err:#}");
                 }
-                pr.finish_with_message("uninstalled".into());
+                if tool.is_none() {
+                    pr.finish_with_message("uninstalled".into());
+                }
             }
+        }
+        if let Some(progress) = progress.as_mut() {
+            progress.finish(vec![]);
         }
 
         if self.is_dry_run() {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -20,6 +20,7 @@ use crate::toolset::{
     ToolsetBuilder, get_versions_needed_by_tracked_configs_excluding_locks,
     get_versions_needed_by_tracked_stubs,
 };
+use crate::ui::install_progress::removal_progress;
 use crate::ui::multi_progress_report::MultiProgressReport;
 use crate::ui::progress_report::SingleReport;
 use crate::{config, env, exit, runtime_symlinks, ui};
@@ -635,7 +636,10 @@ impl Upgrade {
         };
 
         // Only uninstall old versions of tools that were successfully upgraded
-        // and are not needed by any tracked config
+        // and are not needed by any tracked config. Immediate removals are
+        // collected and run as one session below, so each finished removal is
+        // a single permanent line rather than a kept row.
+        let mut immediate: Vec<ToolVersion> = Vec::new();
         for (o, old_version) in to_remove {
             if successful_versions
                 .iter()
@@ -657,19 +661,7 @@ impl Upgrade {
                 }
 
                 match prune_mode {
-                    PruneMode::Immediate => {
-                        let pr = mpr.add(&format!("uninstall {}@{}", o.name, old_version));
-                        if let Err(e) = self
-                            .uninstall_old_version(config, &old_tv, pr.as_ref())
-                            .await
-                        {
-                            warn!("Failed to uninstall old version of {}: {}", o.name, e);
-                        } else if let Err(err) =
-                            crate::tool_purgatory::forget_path(&old_tv.install_path())
-                        {
-                            warn!("failed to clear tool purgatory entry: {err:#}");
-                        }
-                    }
+                    PruneMode::Immediate => immediate.push(old_tv),
                     PruneMode::Deferred(after) => {
                         if let Err(err) = crate::tool_purgatory::schedule(&old_tv, after) {
                             warn!(
@@ -687,6 +679,47 @@ impl Upgrade {
                     }
                     PruneMode::None => unreachable!(),
                 }
+            }
+        }
+
+        if !immediate.is_empty() {
+            let mut progress = removal_progress(
+                &mpr,
+                immediate
+                    .iter()
+                    .map(|tv| (format!("{}@{}", tv.ba().short, tv.version), tv.style())),
+            );
+            for old_tv in immediate {
+                let key = format!("{}@{}", old_tv.ba().short, old_tv.version);
+                let tool = progress
+                    .as_ref()
+                    .and_then(|progress| progress.start_tool(&key));
+                let pr = match &tool {
+                    Some(tool) => tool.reporter(),
+                    None => mpr.add(&format!("uninstall {}", old_tv.style())),
+                };
+                let result = self
+                    .uninstall_old_version(config, &old_tv, pr.as_ref())
+                    .await;
+                if let Some(tool) = &tool {
+                    tool.complete(result.as_ref().err().map(|e| e.to_string()).as_deref());
+                }
+                match result {
+                    Err(e) => warn!(
+                        "Failed to uninstall old version of {}: {}",
+                        old_tv.ba().short,
+                        e
+                    ),
+                    Ok(()) => {
+                        if let Err(err) = crate::tool_purgatory::forget_path(&old_tv.install_path())
+                        {
+                            warn!("failed to clear tool purgatory entry: {err:#}");
+                        }
+                    }
+                }
+            }
+            if let Some(progress) = progress.as_mut() {
+                progress.finish(vec![]);
             }
         }
 

--- a/src/deps_graph.rs
+++ b/src/deps_graph.rs
@@ -123,6 +123,18 @@ where
         self.graph.node_count() == 0
     }
 
+    /// Keys this node still depends on. Completed nodes have left the graph,
+    /// so this shrinks as dependencies finish.
+    pub(crate) fn dependencies_of(&self, key: &K) -> Vec<K> {
+        let Some(&idx) = self.node_indices.get(key) else {
+            return vec![];
+        };
+        self.graph
+            .neighbors_directed(idx, Direction::Outgoing)
+            .filter_map(|dep| self.graph.node_weight(dep).map(|n| (self.key_fn)(n)))
+            .collect()
+    }
+
     /// Returns the keys of all blocked nodes (dependency failures or cycles).
     pub(crate) fn blocked_keys(&self) -> Vec<K> {
         self.graph

--- a/src/env.rs
+++ b/src/env.rs
@@ -862,6 +862,12 @@ pub(crate) static NO_COLOR: Lazy<bool> = Lazy::new(|| var("NO_COLOR").is_ok_and(
 /// Force progress bars even in non-TTY (for debugging)
 pub(crate) static MISE_FORCE_PROGRESS: Lazy<bool> =
     Lazy::new(|| var_is_true("MISE_FORCE_PROGRESS"));
+/// stderr is a PTY that logs every frame instead of redrawing it. AI coding
+/// agents run commands in such terminals: `isatty` says yes, but cursor-up and
+/// erase-line are recorded rather than applied, so an animated display becomes
+/// one copy of the whole live region per tick. Treated like CI.
+pub(crate) static FRAME_LOGGING_TERMINAL: Lazy<bool> =
+    Lazy::new(|| var_is_true("CLAUDECODE") || var("AI_AGENT").is_ok_and(|v| !v.is_empty()));
 
 // python
 pub(crate) static PYENV_ROOT: Lazy<PathBuf> =

--- a/src/lock_file.rs
+++ b/src/lock_file.rs
@@ -31,6 +31,13 @@ impl LockFile {
     }
 
     pub(crate) fn lock(self) -> Result<fslock::LockFile> {
+        self.lock_with_notice(&|| {})
+    }
+
+    /// Like [`Self::lock`], but also runs a borrowed `on_wait` when the lock is
+    /// contended. For callers whose progress reporter cannot move into the
+    /// `'static` callback but should still say why the install is paused.
+    pub(crate) fn lock_with_notice(self, on_wait: &dyn Fn()) -> Result<fslock::LockFile> {
         if let Some(parent) = self.path.parent() {
             create_dir_all(parent)?;
         }
@@ -39,6 +46,7 @@ impl LockFile {
             if let Some(f) = self.on_locked {
                 f(&self.path)
             }
+            on_wait();
             lock.lock()?;
         }
         Ok(lock)

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -937,11 +937,21 @@ fn tool_version_lock(short: &str, v: &str) -> LockFile {
 /// marker and install path. The marker path is only the lock identity; the
 /// lock itself remains a separate stable file under the lockfiles cache.
 pub(crate) fn lock_tool_version(short: &str, v: &str) -> Result<fslock::LockFile> {
+    lock_tool_version_with_notice(short, v, &|| {})
+}
+
+/// [`lock_tool_version`] that also tells the caller when it is actually
+/// waiting, so an install can report the pause instead of looking hung.
+pub(crate) fn lock_tool_version_with_notice(
+    short: &str,
+    v: &str,
+    on_wait: &dyn Fn(),
+) -> Result<fslock::LockFile> {
     tool_version_lock(short, v)
         .with_callback(|lock| {
             debug!("waiting for tool-version lock on {}", display_path(lock));
         })
-        .lock()
+        .lock_with_notice(on_wait)
 }
 
 pub(crate) fn clear_incomplete_marker(short: &str, v: &str) -> Result<()> {
@@ -1106,6 +1116,49 @@ mod tests {
             Some(&installs_path)
         );
         assert!(!tools["babashka"].explicit_backend);
+    }
+
+    #[test]
+    fn lock_notice_fires_only_when_contended() {
+        let short = format!("lock_notice_test_{}", std::process::id());
+        let noticed = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = || noticed.load(std::sync::atomic::Ordering::SeqCst);
+        // Uncontended: no notice.
+        let first = {
+            let noticed = noticed.clone();
+            super::lock_tool_version_with_notice(&short, "1.0.0", &|| {
+                noticed.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            })
+            .unwrap()
+        };
+        assert_eq!(count(), 0);
+        // Contended from another thread: exactly one notice, then it acquires
+        // once the first holder lets go.
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let waiter = {
+            let short = short.clone();
+            let noticed = noticed.clone();
+            std::thread::spawn(move || {
+                let lock = super::lock_tool_version_with_notice(&short, "1.0.0", &|| {
+                    noticed.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                })
+                .unwrap();
+                acquired_tx.send(()).unwrap();
+                drop(lock);
+            })
+        };
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        assert_eq!(count(), 1, "the waiter should have reported the wait");
+        assert!(
+            acquired_rx.try_recv().is_err(),
+            "must not acquire while held"
+        );
+        drop(first);
+        acquired_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("waiter acquires after release");
+        waiter.join().unwrap();
+        assert_eq!(count(), 1);
     }
 
     #[test]

--- a/src/toolset/install_state.rs
+++ b/src/toolset/install_state.rs
@@ -1134,6 +1134,7 @@ mod tests {
         assert_eq!(count(), 0);
         // Contended from another thread: exactly one notice, then it acquires
         // once the first holder lets go.
+        let (noticed_tx, noticed_rx) = mpsc::channel();
         let (acquired_tx, acquired_rx) = mpsc::channel();
         let waiter = {
             let short = short.clone();
@@ -1141,14 +1142,17 @@ mod tests {
             std::thread::spawn(move || {
                 let lock = super::lock_tool_version_with_notice(&short, "1.0.0", &|| {
                     noticed.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    noticed_tx.send(()).unwrap();
                 })
                 .unwrap();
                 acquired_tx.send(()).unwrap();
                 drop(lock);
             })
         };
-        std::thread::sleep(std::time::Duration::from_millis(200));
-        assert_eq!(count(), 1, "the waiter should have reported the wait");
+        noticed_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("the waiter should have reported the wait");
+        assert_eq!(count(), 1);
         assert!(
             acquired_rx.try_recv().is_err(),
             "must not acquire while held"

--- a/src/toolset/tool_deps.rs
+++ b/src/toolset/tool_deps.rs
@@ -98,6 +98,11 @@ impl ToolDeps {
         self.inner.complete_failure(&tool_key(tr));
     }
 
+    /// Tools this request is still waiting on, by key.
+    pub(super) fn pending_dependencies(&self, tr: &ToolRequest) -> Vec<ToolKey> {
+        self.inner.dependencies_of(&tool_key(tr))
+    }
+
     /// Returns the list of blocked tools (those whose dependencies failed or are in cycles)
     pub(super) fn blocked_tools(&self) -> Vec<ToolRequest> {
         self.inner.blocked_nodes()

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -23,8 +23,8 @@ use crate::toolset::tool_deps::{ToolDeps, ensure_compatible_install_requests, to
 use crate::toolset::tool_request::ToolRequest;
 use crate::toolset::tool_source::ToolSource;
 use crate::toolset::tool_version::{ResolveOptions, ToolVersion};
+use crate::ui::install_progress::{InstallProgress, ToolProgress, install_progress};
 use crate::ui::multi_progress_report::MultiProgressReport;
-use crate::ui::text_install_progress::{TextInstallProgress, TextToolProgress};
 use crate::{backend, config, hooks, runtime_symlinks, shims};
 
 impl Toolset {
@@ -280,14 +280,17 @@ impl Toolset {
         } else {
             opts.reason.clone()
         };
-        mpr.init_footer(opts.dry_run, &footer_reason, versions.len());
-        let mut text_progress = (mpr.use_text_install_output()
-            && !opts.raw
-            && !opts.dry_run
-            && !versions.is_empty())
-        .then(|| {
-            TextInstallProgress::new(versions.iter().map(|tr| (tool_key(tr), tr.to_string())))
-        });
+        let mut install_progress = (!opts.raw && !opts.dry_run)
+            .then(|| {
+                install_progress(
+                    &mpr,
+                    versions.iter().map(|tr| (tool_key(tr), tr.to_string())),
+                )
+            })
+            .flatten();
+        if install_progress.is_none() {
+            mpr.init_footer(opts.dry_run, &footer_reason, versions.len());
+        }
 
         hooks::run_one_hook_with_context(
             config,
@@ -330,7 +333,7 @@ impl Toolset {
 
         // Build dependency graph and install using Kahn's algorithm
         let (installed, failed, attempted_failures) = self
-            .install_with_deps(config, versions, opts, text_progress.as_ref())
+            .install_with_deps(config, versions, opts, install_progress.as_deref())
             .await;
         let failed_backends = attempted_failures
             .iter()
@@ -348,11 +351,12 @@ impl Toolset {
         let mut all_failed = disabled_backend_errors;
         all_failed.extend(plugin_errors);
         all_failed.extend(failed);
-        if let Some(progress) = text_progress.as_mut() {
+        if let Some(progress) = install_progress.as_mut() {
             progress.finish(
                 all_failed
                     .iter()
-                    .map(|(tr, error)| (tool_key(tr), error.to_string())),
+                    .map(|(tr, error)| (tool_key(tr), error.to_string()))
+                    .collect(),
             );
         }
 
@@ -503,7 +507,7 @@ impl Toolset {
         config: &Arc<Config>,
         versions: Vec<ToolRequest>,
         opts: &InstallOptions,
-        text_progress: Option<&TextInstallProgress>,
+        install_progress: Option<&dyn InstallProgress>,
     ) -> (
         Vec<ToolVersion>,
         Vec<(ToolRequest, eyre::Error)>,
@@ -532,6 +536,18 @@ impl Toolset {
                 return (vec![], failed, vec![]);
             }
         };
+
+        // Tell the display which tools are held behind which, before anything
+        // starts, so a row can say "waiting for node" instead of nothing.
+        if let Some(progress) = install_progress {
+            let deps = tool_deps.lock().await;
+            for tr in &versions {
+                let pending = deps.pending_dependencies(tr);
+                if !pending.is_empty() {
+                    progress.set_waiting(&tool_key(tr), pending);
+                }
+            }
+        }
 
         let mut rx = tool_deps.lock().await.subscribe();
 
@@ -608,10 +624,10 @@ impl Toolset {
                             let opts = opts.clone();
                             let tr_clone = tr.clone();
 
-                            let progress = text_progress.and_then(|p| p.start_tool(&tool_key(&tr)));
+                            let progress = install_progress.and_then(|p| p.start_tool(&tool_key(&tr)));
                             let handle = jset.spawn(async move {
                                 let _permit = permit;
-                                let result = Self::install_single_tool(&config, &ts, &tr, &opts, progress.as_ref()).await;
+                                let result = Self::install_single_tool(&config, &ts, &tr, &opts, progress.as_deref()).await;
                                 if let Some(progress) = progress {
                                     let error = result.as_ref().err().map(|e| e.to_string());
                                     progress.complete(error.as_deref());
@@ -681,7 +697,7 @@ impl Toolset {
         ts: &Arc<Toolset>,
         tr: &ToolRequest,
         opts: &Arc<InstallOptions>,
-        text_progress: Option<&TextToolProgress>,
+        tool_progress: Option<&dyn ToolProgress>,
     ) -> Result<ToolVersion> {
         let mpr = MultiProgressReport::get();
         let pre_resolve_backend = tr.backend()?;
@@ -703,9 +719,9 @@ impl Toolset {
         let ctx = InstallContext {
             config: config.clone(),
             ts: ts.clone(),
-            pr: if let Some(progress) = text_progress {
+            pr: if let Some(progress) = tool_progress {
                 progress.set_prefix(tv.style());
-                Box::new(progress.clone())
+                progress.reporter()
             } else {
                 mpr.add_with_options(&tv.style(), opts.dry_run)
             },

--- a/src/ui/install_progress.rs
+++ b/src/ui/install_progress.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use super::multi_progress_report::MultiProgressReport;
 use super::progress_report::SingleReport;
-use super::text_install_progress::{State, TextInstallProgress};
+use super::text_install_progress::{Action, State, TextInstallProgress};
 use super::tty_install_progress::TtyInstallProgress;
 
 /// One tool's reporter inside an install session.
@@ -45,7 +45,25 @@ pub(crate) fn install_progress(
     mpr: &Arc<MultiProgressReport>,
     tools: impl Iterator<Item = (String, String)>,
 ) -> Option<Box<dyn InstallProgress>> {
-    let state = State::new(tools);
+    progress_for(mpr, Action::Install, tools)
+}
+
+/// The same session for `prune`, `uninstall` and `upgrade`'s old versions.
+/// Hundreds of `remove …` rows kept in a live region were what made a large
+/// prune unreadable; here each finished removal is one permanent line.
+pub(crate) fn removal_progress(
+    mpr: &Arc<MultiProgressReport>,
+    tools: impl Iterator<Item = (String, String)>,
+) -> Option<Box<dyn InstallProgress>> {
+    progress_for(mpr, Action::Remove, tools)
+}
+
+fn progress_for(
+    mpr: &Arc<MultiProgressReport>,
+    action: Action,
+    tools: impl Iterator<Item = (String, String)>,
+) -> Option<Box<dyn InstallProgress>> {
+    let state = State::for_action(action, tools);
     if state.is_empty() {
         return None;
     }

--- a/src/ui/install_progress.rs
+++ b/src/ui/install_progress.rs
@@ -1,0 +1,59 @@
+//! Install-wide progress: one model, two renderers.
+//!
+//! [`crate::ui::text_install_progress`] appends snapshots for captured stderr and
+//! CI; [`crate::ui::tty_install_progress`] redraws a live region for an
+//! interactive terminal. Both read the same [`State`], so they cannot disagree
+//! about what is done, what is running, or how far along it is.
+use std::sync::Arc;
+
+use super::multi_progress_report::MultiProgressReport;
+use super::progress_report::SingleReport;
+use super::text_install_progress::{State, TextInstallProgress};
+use super::tty_install_progress::TtyInstallProgress;
+
+/// One tool's reporter inside an install session.
+pub(crate) trait ToolProgress: SingleReport {
+    /// The resolved `tool@version`, known only after resolution.
+    fn set_prefix(&self, prefix: String);
+
+    /// The worker's result. Authoritative over anything the backend reported:
+    /// a backend may finish its report before its postinstall work returns.
+    fn complete(&self, error: Option<&str>);
+
+    /// A handle backends can drive through [`SingleReport`].
+    fn reporter(&self) -> Box<dyn SingleReport>;
+}
+
+/// The whole install: which tools exist, what each is waiting on, and how it ended.
+pub(crate) trait InstallProgress: Send + Sync {
+    /// Begin one tool's work. `None` for a request that was not part of this
+    /// session, so the caller falls back to the standard reporter rather than
+    /// panicking in the scheduler.
+    fn start_tool(&self, key: &str) -> Option<Box<dyn ToolProgress>>;
+
+    /// A tool the scheduler is holding until these dependencies finish.
+    fn set_waiting(&self, key: &str, dependencies: Vec<String>);
+
+    /// Tools that never reached a worker (blocked by a failed dependency, or
+    /// refused before scheduling) and the final summary.
+    fn finish(&mut self, failures: Vec<(String, String)>);
+}
+
+/// Pick the renderer for this terminal, or `None` when the existing per-tool
+/// reporters should be used unchanged (`--verbose`, `--raw`, `--quiet`).
+pub(crate) fn install_progress(
+    mpr: &Arc<MultiProgressReport>,
+    tools: impl Iterator<Item = (String, String)>,
+) -> Option<Box<dyn InstallProgress>> {
+    let state = State::new(tools);
+    if state.is_empty() {
+        return None;
+    }
+    if mpr.use_tty_install_output() {
+        Some(Box::new(TtyInstallProgress::new(state)))
+    } else if mpr.use_text_install_output() {
+        Some(Box::new(TextInstallProgress::new(state)))
+    } else {
+        None
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,7 @@ pub(crate) use prompt::confirm;
 #[cfg_attr(any(test, windows), path = "ctrlc_stub.rs")]
 pub(crate) mod ctrlc;
 pub(crate) mod info;
+pub(crate) mod install_progress;
 pub(crate) mod multi_progress_report;
 pub(crate) mod progress_report;
 pub(crate) mod prompt;
@@ -12,3 +13,4 @@ pub(crate) mod text_install_progress;
 pub(crate) mod theme;
 pub(crate) mod time;
 pub(crate) mod tree;
+pub(crate) mod tty_install_progress;

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -174,6 +174,12 @@ impl MultiProgressReport {
         !self.quiet && !self.use_progress_ui && !settings.verbose && !settings.raw
     }
 
+    /// The live install region replaces the per-tool clx rows and the old
+    /// header whenever the animated display is on at all.
+    pub(crate) fn use_tty_install_output(&self) -> bool {
+        self.use_progress_ui
+    }
+
     pub(crate) fn add(&self, prefix: &str) -> Box<dyn SingleReport> {
         self.add_with_options(prefix, false)
     }

--- a/src/ui/multi_progress_report.rs
+++ b/src/ui/multi_progress_report.rs
@@ -79,7 +79,9 @@ impl MultiProgressReport {
         let settings = Settings::get();
         let has_stderr = console::user_attended_stderr();
         let force_progress = *env::MISE_FORCE_PROGRESS;
-        let ci = settings.ci;
+        // A terminal that records frames instead of redrawing them gets the
+        // same append-only output as CI, for the same reason.
+        let ci = settings.ci || *env::FRAME_LOGGING_TERMINAL;
 
         progress_trace!(
             "MultiProgressReport::new: raw={}, quiet={}, verbose={}, has_stderr={}, force_progress={}, ci={}",

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -57,6 +57,14 @@ pub(crate) trait SingleReport: Send + Sync + std::fmt::Debug {
     fn set_detail(&self, detail: String) {
         let _ = detail;
     }
+
+    /// Progress through the current operation in whole items rather than
+    /// bytes — packages resolved, packages fetched. Drives the bar the same way
+    /// `set_length`/`set_position` do, but is never formatted as a size or
+    /// folded into a transfer rate.
+    fn set_items(&self, done: u64, total: u64) {
+        let _ = (done, total);
+    }
     fn inc(&self, _delta: u64) {}
     fn set_position(&self, _delta: u64) {}
     fn set_length(&self, _length: u64) {}
@@ -113,6 +121,10 @@ fn normal_prefix(pad: usize, prefix: &str) -> String {
 #[derive(Debug)]
 pub(crate) struct ProgressReport {
     job: Arc<ProgressJob>,
+    /// The phase and any secondary detail, folded into one `message` prop:
+    /// this row has a single status cell.
+    phase: Mutex<String>,
+    detail: Mutex<String>,
 }
 
 impl ProgressReport {
@@ -138,7 +150,22 @@ impl ProgressReport {
             .prop("message", "")
             .start();
 
-        ProgressReport { job }
+        ProgressReport {
+            job,
+            phase: Mutex::new(String::new()),
+            detail: Mutex::new(String::new()),
+        }
+    }
+
+    fn render_message(&self) {
+        let phase = self.phase.lock().unwrap();
+        let detail = self.detail.lock().unwrap();
+        let message = if detail.is_empty() {
+            phase.clone()
+        } else {
+            format!("{phase}  {detail}")
+        };
+        self.job.prop("message", &message);
     }
 }
 
@@ -148,7 +175,13 @@ impl SingleReport for ProgressReport {
     }
 
     fn set_message(&self, message: String) {
-        self.job.prop("message", &message.replace('\r', ""));
+        *self.phase.lock().unwrap() = message.replace('\r', "");
+        self.render_message();
+    }
+
+    fn set_detail(&self, detail: String) {
+        *self.detail.lock().unwrap() = detail.replace('\r', "");
+        self.render_message();
     }
 
     fn inc(&self, delta: u64) {
@@ -201,6 +234,7 @@ impl SingleReport for QuietReport {}
 pub(crate) struct VerboseReport {
     prefix: String,
     prev_message: Mutex<String>,
+    prev_detail: Mutex<String>,
     pad: usize,
     total_operations: Mutex<Option<usize>>,
     current_operation: Mutex<usize>,
@@ -215,6 +249,7 @@ impl VerboseReport {
         VerboseReport {
             prefix,
             prev_message: Mutex::new("".to_string()),
+            prev_detail: Mutex::new("".to_string()),
             pad,
             total_operations: Mutex::new(None),
             current_operation: Mutex::new(0),
@@ -232,6 +267,21 @@ impl SingleReport for VerboseReport {
         // `shows_process_output` suppresses the failure replay.
         let prefix = pad_prefix(self.pad, &self.prefix);
         log::info!("{prefix} {message}");
+    }
+    fn set_detail(&self, detail: String) {
+        // One line per change, folded with the phase, the way this reporter
+        // printed the combined message before phase and detail were split.
+        if detail.trim().is_empty() {
+            return;
+        }
+        let phase = self.prev_message.lock().unwrap().clone();
+        let mut prev = self.prev_detail.lock().unwrap();
+        if *prev == detail {
+            return;
+        }
+        let prefix = pad_prefix(self.pad, &self.prefix);
+        log::info!("{prefix} {phase} {detail}");
+        *prev = detail;
     }
     fn shows_process_output(&self) -> bool {
         true

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -50,6 +50,13 @@ pub(crate) trait SingleReport: Send + Sync + std::fmt::Debug {
     fn shows_process_output(&self) -> bool {
         false
     }
+
+    /// Secondary progress that is not a byte transfer — an embedded package
+    /// manager's `32/48 pkgs`. Reporters with one status line fold it into the
+    /// message; the install renderers show it beside the phase.
+    fn set_detail(&self, detail: String) {
+        let _ = detail;
+    }
     fn inc(&self, _delta: u64) {}
     fn set_position(&self, _delta: u64) {}
     fn set_length(&self, _length: u64) {}

--- a/src/ui/progress_report.rs
+++ b/src/ui/progress_report.rs
@@ -314,10 +314,11 @@ impl SingleReport for VerboseReport {
         *self.current_operation.lock().unwrap() = 1;
     }
     fn next_operation(&self) {
-        let total = *self.total_operations.lock().unwrap();
-        if total.is_some() {
+        if let Some(total) = *self.total_operations.lock().unwrap() {
             let mut current = self.current_operation.lock().unwrap();
-            *current += 1;
+            // A backend may step past its last declared operation to say "all
+            // declared work is done"; the counter stays at the last one.
+            *current = (*current + 1).min(total);
         }
     }
 }

--- a/src/ui/text_install_progress.rs
+++ b/src/ui/text_install_progress.rs
@@ -315,8 +315,25 @@ impl Tool {
         })
     }
 
-    /// The permanent line for a finished tool, padded to `width`.
-    pub(super) fn completion_line(&self, width: usize, now: Instant) -> String {
+    /// What the interactive display's indented child row shows: an explicit
+    /// detail, or the item tally a package manager drives the bar with. A byte
+    /// transfer belongs to the parent row and is not repeated underneath it.
+    pub(super) fn child_detail(&self, now: Instant) -> Option<String> {
+        match self.transfer {
+            Some(transfer) if transfer.bytes && self.detail.is_none() => None,
+            _ => Some(self.transfer_detail(now)).filter(|detail| !detail.is_empty()),
+        }
+    }
+
+    /// The permanent line for a finished tool, padded to `width`. Given the
+    /// terminal's `columns`, the artifact name is dropped rather than wrapped:
+    /// the line is a record, and a wrapped record reads as two.
+    pub(super) fn completion_line(
+        &self,
+        width: usize,
+        now: Instant,
+        columns: Option<usize>,
+    ) -> String {
         let outcome = self
             .outcome
             .expect("only finished tools have a completion line");
@@ -331,11 +348,17 @@ impl Tool {
             Outcome::Skipped => (ProgressIcon::Skipped, " · already installed".into()),
             Outcome::Failed => (ProgressIcon::Error, format!(" · failed: {}", self.message)),
         };
-        let artifact = match (&self.artifact, outcome) {
-            (Some(artifact), Outcome::Installed) => format!("  {}", style::edim(artifact)),
-            _ => String::new(),
-        };
-        format!("{icon} {prefix}{duration}{detail}{artifact}")
+        let line = format!("{icon} {prefix}{duration}{detail}");
+        match (&self.artifact, outcome) {
+            (Some(artifact), Outcome::Installed) => {
+                let with_artifact = format!("{line}  {}", style::edim(artifact));
+                match columns {
+                    Some(columns) if console::measure_text_width(&with_artifact) > columns => line,
+                    _ => with_artifact,
+                }
+            }
+            _ => line,
+        }
     }
 }
 
@@ -604,6 +627,7 @@ impl State {
         index: usize,
         outcome: Outcome,
         now: Instant,
+        columns: Option<usize>,
     ) -> Option<String> {
         let width = self.width();
         if self.tools[index].outcome.is_some() {
@@ -620,7 +644,7 @@ impl State {
         for tool in &mut self.tools {
             tool.waiting_on.retain(|dep| dep != &key);
         }
-        Some(self.tools[index].completion_line(width, now))
+        Some(self.tools[index].completion_line(width, now, columns))
     }
 
     /// Fail every listed tool that never reached a worker, returning their lines.
@@ -628,6 +652,7 @@ impl State {
         &mut self,
         failures: Vec<(String, String)>,
         now: Instant,
+        columns: Option<usize>,
     ) -> Vec<String> {
         let mut lines = vec![];
         for (key, error) in failures {
@@ -635,7 +660,7 @@ impl State {
                 && self.tools[index].outcome.is_none()
             {
                 self.tools[index].message = first_line(&error);
-                lines.extend(self.finish_tool(index, Outcome::Failed, now));
+                lines.extend(self.finish_tool(index, Outcome::Failed, now, columns));
             }
         }
         lines
@@ -761,7 +786,7 @@ impl InstallProgress for TextInstallProgress {
         self.stop();
         let mut state = self.state.lock().unwrap();
         let now = Instant::now();
-        for line in state.fail_unstarted(failures, now) {
+        for line in state.fail_unstarted(failures, now, None) {
             info!("{line}");
         }
         info!("{}", state.summary(now));
@@ -800,7 +825,7 @@ impl ToolProgress for TextToolProgress {
         if let Some(error) = error {
             state.tools[self.index].message = first_line(error);
         }
-        if let Some(line) = state.finish_tool(self.index, outcome, Instant::now()) {
+        if let Some(line) = state.finish_tool(self.index, outcome, Instant::now(), None) {
             info!("{line}");
         }
     }
@@ -908,7 +933,7 @@ mod tests {
         let start = Instant::now();
         let mut state = state(start);
         state.tools[0].started = Some(start);
-        state.finish_tool(0, Outcome::Installed, start + Duration::from_secs(1));
+        state.finish_tool(0, Outcome::Installed, start + Duration::from_secs(1), None);
         state.tools[1].started = Some(start + Duration::from_secs(2));
         state.tools[1].message = "extracting".into();
         let snapshot =
@@ -966,8 +991,13 @@ mod tests {
         assert_eq!(state.tools[0].message, "removing");
         state.tools[0].apply_message("remove ~/.local/share/mise/installs/tool0/1".into());
         assert_eq!(state.tools[0].message, "removing");
-        state.finish_tool(0, Outcome::Installed, start + Duration::from_millis(40));
-        state.finish_tool(1, Outcome::Installed, start);
+        state.finish_tool(
+            0,
+            Outcome::Installed,
+            start + Duration::from_millis(40),
+            None,
+        );
+        state.finish_tool(1, Outcome::Installed, start, None);
         let summary = console::strip_ansi_codes(&state.summary(start)).into_owned();
         assert_eq!(summary, "████████████████ 2/2 · removed 2 tools in 0ms");
     }
@@ -983,7 +1013,7 @@ mod tests {
         // Only the slot-bound tool is counted as merely queued.
         assert!(snapshot.ends_with("1 queued"), "{snapshot}");
         // Finishing a dependency drops it from the wait.
-        state.finish_tool(0, Outcome::Installed, start);
+        state.finish_tool(0, Outcome::Installed, start, None);
         assert_eq!(state.tools[2].waiting_on, vec!["1".to_string()]);
     }
 
@@ -993,12 +1023,17 @@ mod tests {
         let mut state = state(start);
         state.tools[0].started = Some(start);
         let finished = state
-            .finish_tool(0, Outcome::Installed, start + Duration::from_millis(250))
+            .finish_tool(
+                0,
+                Outcome::Installed,
+                start + Duration::from_millis(250),
+                None,
+            )
             .unwrap();
         assert!(finished.contains("250ms"));
-        assert!(state.finish_tool(0, Outcome::Failed, start).is_none());
-        state.finish_tool(1, Outcome::Skipped, start);
-        state.finish_tool(2, Outcome::Failed, start);
+        assert!(state.finish_tool(0, Outcome::Failed, start, None).is_none());
+        state.finish_tool(1, Outcome::Skipped, start, None);
+        state.finish_tool(2, Outcome::Failed, start, None);
         let summary = console::strip_ansi_codes(&state.summary(start)).into_owned();
         assert_eq!(
             summary,
@@ -1045,7 +1080,7 @@ mod tests {
         let mut state = state(start);
         // One finished, one exactly halfway through a single-operation install.
         state.tools[0].started = Some(start);
-        state.finish_tool(0, Outcome::Installed, start);
+        state.finish_tool(0, Outcome::Installed, start, None);
         state.tools[1].started = Some(start);
         state.tools[1].weights = vec![1.0];
         state.tools[1].transfer = Some(transfer(50, 100, start));
@@ -1116,7 +1151,7 @@ mod tests {
         // tool0 and tool1 wait for a slot; tool2 waits for tool0.
         assert_eq!(state.queued_count(), 2);
         state.tools[0].started = Some(start);
-        state.finish_tool(0, Outcome::Installed, start);
+        state.finish_tool(0, Outcome::Installed, start, None);
         // tool2's wait drained: it is a plain queued tool now.
         assert!(state.tools[2].waiting_message().is_none());
         assert_eq!(state.queued_count(), 2);
@@ -1220,13 +1255,71 @@ mod tests {
         let line = shared
             .lock()
             .unwrap()
-            .finish_tool(0, Outcome::Installed, start + Duration::from_millis(300))
+            .finish_tool(
+                0,
+                Outcome::Installed,
+                start + Duration::from_millis(300),
+                None,
+            )
             .unwrap();
         let line = console::strip_ansi_codes(&line).into_owned();
         assert_eq!(
             line,
             "✓ tool0@1  300ms · cached  node-v24.20.0-linux-x64.tar.xz"
         );
+    }
+
+    #[test]
+    fn the_child_row_keeps_item_tallies_and_leaves_bytes_to_the_parent() {
+        let start = Instant::now();
+        let mut state = state(start);
+        state.tools[0].started = Some(start);
+        let tool = &mut state.tools[0];
+        // A package manager's count is the child's, with or without a detail.
+        tool.set_items(3, 10);
+        assert_eq!(tool.child_detail(start).as_deref(), Some("3/10"));
+        tool.set_detail("3/10 pkgs · 1.2 MiB".into());
+        assert_eq!(
+            tool.child_detail(start).as_deref(),
+            Some("3/10 pkgs · 1.2 MiB")
+        );
+        // A download is the parent row's figure; without a detail there is
+        // nothing left for a child row to say.
+        tool.set_detail(String::new());
+        tool.set_length(1_000);
+        tool.inc(500);
+        assert_eq!(tool.child_detail(start), None);
+        tool.set_detail("verifying checksum".into());
+        assert_eq!(
+            tool.child_detail(start).as_deref(),
+            Some("verifying checksum")
+        );
+    }
+
+    #[test]
+    fn a_narrow_terminal_drops_the_artifact_rather_than_wrapping_the_line() {
+        let start = Instant::now();
+        let mut state = state(start);
+        state.tools[0].started = Some(start);
+        state.tools[0].artifact = Some("node-v24.20.0-linux-x64.tar.xz".into());
+        state.tools[0].outcome = Some(Outcome::Installed);
+        let line = |columns| {
+            let line = state.tools[0].completion_line(
+                state.width(),
+                start + Duration::from_millis(300),
+                columns,
+            );
+            console::strip_ansi_codes(&line).into_owned()
+        };
+        // Unbounded (the append-only reporter) and roomy terminals keep it.
+        assert_eq!(
+            line(None),
+            "✓ tool0@1  300ms  node-v24.20.0-linux-x64.tar.xz"
+        );
+        assert_eq!(line(Some(80)), line(None));
+        // At 40 columns the full line would wrap; the artifact is the part
+        // that goes, and the line is not padded out to the width it gave up.
+        assert_eq!(line(Some(40)), "✓ tool0@1  300ms");
     }
 
     #[test]
@@ -1240,7 +1333,7 @@ mod tests {
         assert_eq!(state.tools[0].fraction, 0.99);
         let bar = console::strip_ansi_codes(&state.bar_only(24)).into_owned();
         assert_eq!(bar, "███████████████████████░");
-        state.finish_tool(0, Outcome::Installed, start);
+        state.finish_tool(0, Outcome::Installed, start, None);
         let bar = console::strip_ansi_codes(&state.bar_only(24)).into_owned();
         assert_eq!(bar, "████████████████████████");
     }
@@ -1249,9 +1342,9 @@ mod tests {
     fn failures_take_their_share_of_the_bar_in_red() {
         let start = Instant::now();
         let mut state = state(start);
-        state.finish_tool(0, Outcome::Installed, start);
-        state.finish_tool(1, Outcome::Failed, start);
-        state.finish_tool(2, Outcome::Failed, start);
+        state.finish_tool(0, Outcome::Installed, start, None);
+        state.finish_tool(1, Outcome::Failed, start, None);
+        state.finish_tool(2, Outcome::Failed, start, None);
         let bar = state.bar();
         let plain = console::strip_ansi_codes(&bar).into_owned();
         assert_eq!(plain, "████████████████ 3/3");

--- a/src/ui/text_install_progress.rs
+++ b/src/ui/text_install_progress.rs
@@ -480,7 +480,11 @@ impl State {
         let index = self.index_of(key)?;
         let tool = &mut self.tools[index];
         tool.started = Some(Instant::now());
-        tool.message = "resolving".into();
+        // A removal has nothing to resolve; its one phase is the verb itself.
+        tool.message = match self.action {
+            Action::Install => "resolving".into(),
+            Action::Remove => "removing".into(),
+        };
         Some(index)
     }
 
@@ -729,12 +733,18 @@ pub(crate) struct TextInstallProgress {
     state: Arc<Mutex<State>>,
     stop: mpsc::Sender<()>,
     thread: Option<JoinHandle<()>>,
+    finished: bool,
 }
 
 impl TextInstallProgress {
     pub(super) fn new(state: State) -> Self {
         let total = state.tools.len();
-        info!("{} {total} {}", state.action.present(), tool_noun(total));
+        info!(
+            "{} – {} {total} {}",
+            style::edim("by @jdx"),
+            state.action.present(),
+            tool_noun(total)
+        );
         let state = Arc::new(Mutex::new(state));
         let (stop, rx) = mpsc::channel();
         let shared = state.clone();
@@ -758,6 +768,7 @@ impl TextInstallProgress {
             state,
             stop,
             thread: Some(thread),
+            finished: false,
         }
     }
 
@@ -783,6 +794,7 @@ impl InstallProgress for TextInstallProgress {
     }
 
     fn finish(&mut self, failures: Vec<(String, String)>) {
+        self.finished = true;
         self.stop();
         let mut state = self.state.lock().unwrap();
         let now = Instant::now();
@@ -795,6 +807,11 @@ impl InstallProgress for TextInstallProgress {
 
 impl Drop for TextInstallProgress {
     fn drop(&mut self) {
+        // A session dropped on an error path still closes with its summary,
+        // so the record says how far it got before the error that follows.
+        if !self.finished {
+            InstallProgress::finish(self, vec![]);
+        }
         self.stop();
     }
 }
@@ -986,6 +1003,9 @@ mod tests {
             (0..2).map(|i| (i.to_string(), format!("tool{i}@1"))),
         );
         state.started = start;
+        // Starting a removal names the verb; there is nothing to resolve.
+        assert_eq!(state.start_tool("0"), Some(0));
+        assert_eq!(state.tools[0].message, "removing");
         state.tools[0].started = Some(start);
         state.tools[0].apply_message("uninstall".into());
         assert_eq!(state.tools[0].message, "removing");

--- a/src/ui/text_install_progress.rs
+++ b/src/ui/text_install_progress.rs
@@ -1,53 +1,61 @@
-//! Append-only install progress for captured stderr and CI terminals.
+//! Append-only install progress for captured stderr and CI terminals, and the
+//! progress model it shares with the interactive renderer.
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
+use super::install_progress::{InstallProgress, ToolProgress};
 use super::multi_progress_report::MultiProgressReport;
 use super::progress_report::{ProgressIcon, SingleReport};
 use super::style;
 
 const INTERVAL: Duration = Duration::from_secs(3);
-const BAR_WIDTH: usize = 16;
+pub(super) const BAR_WIDTH: usize = 16;
 
 #[derive(Debug)]
-struct Tool {
-    key: String,
-    prefix: String,
-    started: Option<Instant>,
-    message: String,
-    outcome: Option<Outcome>,
+pub(super) struct Tool {
+    pub(super) key: String,
+    pub(super) prefix: String,
+    pub(super) started: Option<Instant>,
+    pub(super) message: String,
+    pub(super) outcome: Option<Outcome>,
     skipped: bool,
     /// Relative cost of each install operation, in the order they run, as the
     /// backend estimated it. Empty until the backend declares its plan.
-    weights: Vec<f64>,
-    completed_ops: usize,
-    transfer: Option<Transfer>,
+    pub(super) weights: Vec<f64>,
+    pub(super) completed_ops: usize,
+    pub(super) transfer: Option<Transfer>,
+    /// Secondary progress from work that is not a byte transfer — an embedded
+    /// package manager's `32/48 pkgs`. Shown where transfer bytes would be.
+    pub(super) detail: Option<String>,
     /// The file the backend chose to download, from its `download <name>`
     /// status. Kept for the completion line: "which artifact did it pick?" is a
     /// question people ask the log after the fact, and a fast install never
     /// lives long enough to appear in a snapshot.
-    artifact: Option<String>,
+    pub(super) artifact: Option<String>,
     /// The backend found the artifact already downloaded and skipped the fetch.
     /// Without saying so, a 0.3s install of an 80 MB tool looks like a lie.
-    reused: bool,
+    pub(super) reused: bool,
+    /// Tools this one is held behind. Drained as they finish, so the row
+    /// always names what is actually still in the way.
+    pub(super) waiting_on: Vec<String>,
     /// Never decreases. A backend that restarts a download (a range request
     /// that the server refuses, a retry) would otherwise walk the bar
     /// backwards, which reads as the install having gone wrong.
-    fraction: f64,
+    pub(super) fraction: f64,
 }
 
 /// Byte progress for the operation currently running.
 #[derive(Debug, Clone, Copy)]
-struct Transfer {
-    done: u64,
-    total: u64,
+pub(super) struct Transfer {
+    pub(super) done: u64,
+    pub(super) total: u64,
     started: Instant,
     /// Bytes already on disk when this transfer began, from a resumed
     /// download. Excluded from the rate so a resume does not report a
     /// throughput the network never achieved.
-    resumed_at: u64,
+    pub(super) resumed_at: u64,
 }
 
 impl Transfer {
@@ -60,7 +68,7 @@ impl Transfer {
         }
     }
 
-    fn fraction(&self) -> Option<f64> {
+    pub(super) fn fraction(&self) -> Option<f64> {
         (self.total > 0).then(|| (self.done as f64 / self.total as f64).clamp(0.0, 1.0))
     }
 
@@ -75,6 +83,25 @@ impl Transfer {
 }
 
 impl Tool {
+    pub(super) fn new(key: String, prefix: String) -> Self {
+        Self {
+            key,
+            prefix,
+            started: None,
+            message: "queued".into(),
+            outcome: None,
+            skipped: false,
+            weights: vec![],
+            completed_ops: 0,
+            transfer: None,
+            detail: None,
+            artifact: None,
+            reused: false,
+            waiting_on: vec![],
+            fraction: 0.0,
+        }
+    }
+
     /// How far through its own install this tool is, in [0, 1].
     ///
     /// Operations are weighted by the backend's estimate of their cost, and the
@@ -100,18 +127,131 @@ impl Tool {
         ((done + current) / total).clamp(0.0, 0.99)
     }
 
-    fn advance(&mut self) {
+    pub(super) fn advance(&mut self) {
         self.fraction = self.compute_fraction().max(self.fraction);
     }
 
+    pub(super) fn is_active(&self) -> bool {
+        self.started.is_some() && self.outcome.is_none()
+    }
+
+    pub(super) fn is_queued(&self) -> bool {
+        self.started.is_none() && self.outcome.is_none()
+    }
+
+    /// What the row says while nothing else does: which tools it is behind.
+    pub(super) fn waiting_message(&self) -> Option<String> {
+        (self.is_queued() && !self.waiting_on.is_empty())
+            .then(|| format!("waiting for {}", self.waiting_on.join(", ")))
+    }
+
+    /// A backend's status message. The phase is normalized so the bar can
+    /// recognize it; the artifact and a skipped fetch are kept as facts.
+    pub(super) fn apply_message(&mut self, message: String) {
+        let message = message.replace(['\r', '\n'], " ");
+        let mut words = message.split_whitespace();
+        let mut reused = false;
+        let mut operations_done = false;
+        let (phase, artifact) = match words.next() {
+            Some("download") => ("downloading", words.next()),
+            Some("cached") => {
+                reused = true;
+                ("reusing download", words.next())
+            }
+            Some("checksum") => ("verifying checksum", None),
+            Some("extract") => ("extracting", None),
+            Some("install") => ("installing", None),
+            // The postinstall hook means every declared operation is behind us.
+            // Plugin backends (asdf, vfox) never call next_operation, so
+            // without this their bar sits at zero until the worker returns.
+            Some("running") if message == "running custom postinstall hook" => {
+                operations_done = true;
+                ("running postinstall hook", None)
+            }
+            _ => (message.as_str(), None),
+        };
+        self.message = phase.to_string();
+        self.reused |= reused;
+        if let Some(artifact) = artifact {
+            self.artifact = Some(artifact.to_string());
+        }
+        if operations_done {
+            self.completed_ops = self.weights.len();
+            self.transfer = None;
+        }
+        self.advance();
+    }
+
+    pub(super) fn start_operations(&mut self, weights: &[f64]) {
+        let weights: Vec<f64> = weights.iter().copied().filter(|w| *w > 0.0).collect();
+        self.weights = if weights.is_empty() {
+            vec![1.0]
+        } else {
+            weights
+        };
+        self.advance();
+    }
+
+    pub(super) fn next_operation(&mut self) {
+        self.completed_ops = (self.completed_ops + 1).min(self.weights.len());
+        // Byte progress belongs to the operation that just ended.
+        self.transfer = None;
+        self.advance();
+    }
+
+    /// A length always opens a new transfer, even when it equals the last one:
+    /// the downloader announces it once per attempt, and a retry that kept the
+    /// previous state would fold the failed attempt's bytes and time into this
+    /// one's rate.
+    pub(super) fn set_length(&mut self, length: u64) {
+        self.transfer = Some(Transfer::new(length));
+        self.advance();
+    }
+
+    pub(super) fn set_position(&mut self, position: u64) {
+        // A server that sends no content-length never calls set_length, so the
+        // first bytes open a transfer with an unknown total.
+        let transfer = self.transfer.get_or_insert_with(|| Transfer::new(0));
+        // A resumed download reports its starting offset here.
+        if transfer.done == 0 && position > 0 {
+            transfer.resumed_at = position;
+        }
+        transfer.done = position;
+        self.advance();
+    }
+
+    pub(super) fn inc(&mut self, delta: u64) {
+        let transfer = self.transfer.get_or_insert_with(|| Transfer::new(0));
+        transfer.done = transfer.done.saturating_add(delta);
+        self.advance();
+    }
+
+    pub(super) fn set_detail(&mut self, detail: String) {
+        self.detail = (!detail.trim().is_empty()).then_some(detail);
+    }
+
+    pub(super) fn set_skipped(&mut self, skipped: bool) {
+        self.skipped = skipped;
+    }
+
+    /// The worker's outcome, given its error if it had one.
+    pub(super) fn outcome_for(&self, error: Option<&str>) -> Outcome {
+        match error {
+            Some(_) => Outcome::Failed,
+            None if self.skipped => Outcome::Skipped,
+            None => Outcome::Installed,
+        }
+    }
+
     /// `42.1/78.3 MB · 12.4 MB/s`, dropping whichever half is unknown. A server
-    /// that sends no content-length still gets a running byte count.
-    fn transfer_detail(&self, now: Instant) -> String {
+    /// that sends no content-length still gets a running byte count. Falls
+    /// back to non-transfer detail such as a package count.
+    pub(super) fn transfer_detail(&self, now: Instant) -> String {
         let Some(transfer) = self.transfer else {
-            return String::new();
+            return self.detail.clone().unwrap_or_default();
         };
         if transfer.done == 0 && transfer.total == 0 {
-            return String::new();
+            return self.detail.clone().unwrap_or_default();
         }
         let bytes = if transfer.total > 0 {
             format!(
@@ -127,9 +267,32 @@ impl Tool {
             None => bytes,
         }
     }
+
+    /// The permanent line for a finished tool, padded to `width`.
+    pub(super) fn completion_line(&self, width: usize, now: Instant) -> String {
+        let outcome = self
+            .outcome
+            .expect("only finished tools have a completion line");
+        let prefix = console::pad_str(&self.prefix, width, console::Alignment::Left, None);
+        let duration = self
+            .started
+            .map(|started| format!("  {}", elapsed(started, now)))
+            .unwrap_or_default();
+        let (icon, detail) = match outcome {
+            Outcome::Installed if self.reused => (ProgressIcon::Success, " · cached".into()),
+            Outcome::Installed => (ProgressIcon::Success, String::new()),
+            Outcome::Skipped => (ProgressIcon::Skipped, " · already installed".into()),
+            Outcome::Failed => (ProgressIcon::Error, format!(" · failed: {}", self.message)),
+        };
+        let artifact = match (&self.artifact, outcome) {
+            (Some(artifact), Outcome::Installed) => format!("  {}", style::edim(artifact)),
+            _ => String::new(),
+        };
+        format!("{icon} {prefix}{duration}{detail}{artifact}")
+    }
 }
 
-fn format_bytes(bytes: u64) -> String {
+pub(super) fn format_bytes(bytes: u64) -> String {
     const KB: f64 = 1_000.0;
     const MB: f64 = 1_000_000.0;
     const GB: f64 = 1_000_000_000.0;
@@ -155,8 +318,12 @@ fn format_bytes_in(bytes: u64, total: u64) -> String {
         (GB, 1)
     } else if total as f64 >= MB {
         (MB, 1)
-    } else if total as f64 >= KB {
+    } else if total as f64 >= 10.0 * KB {
         (KB, 0)
+    } else if total as f64 >= KB {
+        // Small enough that whole kilobytes would round a half-done transfer
+        // to zero.
+        (KB, 1)
     } else {
         (1.0, 0)
     };
@@ -164,20 +331,36 @@ fn format_bytes_in(bytes: u64, total: u64) -> String {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Outcome {
+pub(super) enum Outcome {
     Installed,
     Skipped,
     Failed,
 }
 
 #[derive(Debug)]
-struct State {
-    tools: Vec<Tool>,
-    started: Instant,
+pub(super) struct State {
+    pub(super) tools: Vec<Tool>,
+    pub(super) started: Instant,
 }
 
 impl State {
-    fn width(&self) -> usize {
+    pub(super) fn new(tools: impl Iterator<Item = (String, String)>) -> Self {
+        // Match the dependency scheduler's deduplication of repeated requests.
+        let mut seen = HashSet::new();
+        Self {
+            started: Instant::now(),
+            tools: tools
+                .filter(|(key, _)| seen.insert(key.clone()))
+                .map(|(key, prefix)| Tool::new(key, prefix))
+                .collect(),
+        }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.tools.is_empty()
+    }
+
+    pub(super) fn width(&self) -> usize {
         self.tools
             .iter()
             .map(|t| console::measure_text_width(&t.prefix))
@@ -185,39 +368,93 @@ impl State {
             .unwrap_or(0)
     }
 
+    pub(super) fn index_of(&self, key: &str) -> Option<usize> {
+        self.tools.iter().position(|t| t.key == key)
+    }
+
+    pub(super) fn start_tool(&mut self, key: &str) -> Option<usize> {
+        let index = self.index_of(key)?;
+        let tool = &mut self.tools[index];
+        tool.started = Some(Instant::now());
+        tool.message = "resolving".into();
+        Some(index)
+    }
+
+    pub(super) fn set_waiting(&mut self, key: &str, dependencies: Vec<String>) {
+        if let Some(index) = self.index_of(key) {
+            self.tools[index].waiting_on = dependencies;
+        }
+    }
+
+    pub(super) fn count(&self, outcome: Outcome) -> usize {
+        self.tools
+            .iter()
+            .filter(|t| t.outcome == Some(outcome))
+            .count()
+    }
+
+    pub(super) fn complete_count(&self) -> usize {
+        self.tools.iter().filter(|t| t.outcome.is_some()).count()
+    }
+
+    pub(super) fn queued_count(&self) -> usize {
+        self.tools.iter().filter(|t| t.is_queued()).count()
+    }
+
+    pub(super) fn all_done(&self) -> bool {
+        self.tools.iter().all(|t| t.outcome.is_some())
+    }
+
+    /// Overall fraction in [0, 1] and the share of it that is failed tools.
+    pub(super) fn progress(&self) -> (f64, f64) {
+        let total = self.tools.len();
+        if total == 0 {
+            return (1.0, 0.0);
+        }
+        (
+            self.tools.iter().map(|t| t.fraction).sum::<f64>() / total as f64,
+            self.count(Outcome::Failed) as f64 / total as f64,
+        )
+    }
+
+    /// Bytes per second across every active transfer, when any is moving.
+    pub(super) fn aggregate_rate(&self, now: Instant) -> Option<f64> {
+        let rates: Vec<f64> = self
+            .tools
+            .iter()
+            .filter(|t| t.is_active())
+            .filter_map(|t| t.transfer.and_then(|x| x.rate(now)))
+            .collect();
+        (!rates.is_empty()).then(|| rates.iter().sum())
+    }
+
     /// The bar fills fractionally — a tool halfway through its own install
     /// occupies half the width a finished one would — while the count beside it
     /// stays whole tools, which is the number that can be verified against the
     /// completion lines above.
-    fn bar(&self) -> String {
-        let total = self.tools.len();
-        let complete = self.tools.iter().filter(|t| t.outcome.is_some()).count();
-        let (progress, failed_share) = if total == 0 {
-            (1.0, 0.0)
-        } else {
-            let failed = self
-                .tools
-                .iter()
-                .filter(|t| t.outcome == Some(Outcome::Failed))
-                .count();
-            (
-                self.tools.iter().map(|t| t.fraction).sum::<f64>() / total as f64,
-                failed as f64 / total as f64,
-            )
-        };
-        let filled = ((progress * BAR_WIDTH as f64).round() as usize).min(BAR_WIDTH);
+    pub(super) fn bar(&self) -> String {
+        format!("{} {}", self.bar_only(BAR_WIDTH), self.count_label())
+    }
+
+    pub(super) fn count_label(&self) -> String {
+        format!("{}/{}", self.complete_count(), self.tools.len())
+    }
+
+    pub(super) fn bar_only(&self, width: usize) -> String {
+        let (progress, failed_share) = self.progress();
+        let filled = filled_cells(progress, width, self.all_done());
         // A failed tool still counts as finished work, but a fully cyan bar over
         // "installed 0 tools · 1 failed" reads as success. Its share is red.
-        let failed = ((failed_share * BAR_WIDTH as f64).round() as usize).min(filled);
+        let failed = ((failed_share * width as f64).round() as usize).min(filled);
         format!(
-            "{}{}{} {complete}/{total}",
+            "{}{}{}",
             style::ecyan("█".repeat(filled - failed)),
             style::ered("█".repeat(failed)),
-            style::edim("░".repeat(BAR_WIDTH - filled))
+            style::edim("░".repeat(width - filled))
         )
     }
 
-    fn snapshot(&self, now: Instant) -> String {
+    pub(super) fn snapshot(&self, now: Instant) -> String {
         let mut lines = vec![format!("{} · {}", self.bar(), elapsed(self.started, now))];
         // Columns size to their content on every snapshot. A fixed width would
         // either truncate a status like "running postinstall hook" or reserve
@@ -225,12 +462,12 @@ impl State {
         let rows: Vec<_> = self
             .tools
             .iter()
-            .filter(|t| t.outcome.is_none())
+            .filter(|t| t.is_active())
             .filter_map(|tool| {
                 let started = tool.started?;
                 Some((
                     tool.prefix.as_str(),
-                    tool.message.as_str(),
+                    tool.message.clone(),
                     tool.transfer_detail(now),
                     elapsed(started, now),
                     tool.artifact.as_deref(),
@@ -238,13 +475,13 @@ impl State {
             })
             .collect();
         let width = self.width();
-        let message_width = column_width(rows.iter().map(|r| r.1));
+        let message_width = column_width(rows.iter().map(|r| r.1.as_str()));
         let detail_width = column_width(rows.iter().map(|r| r.2.as_str()));
         for (prefix, message, detail, elapsed, artifact) in rows {
             let mut line = format!(
                 "  {}  {}",
                 console::pad_str(prefix, width, console::Alignment::Left, None),
-                console::pad_str(message, message_width, console::Alignment::Left, None),
+                console::pad_str(&message, message_width, console::Alignment::Left, None),
             );
             if detail_width > 0 {
                 line.push_str("  ");
@@ -262,65 +499,78 @@ impl State {
             }
             lines.push(line);
         }
-        let queued = self
-            .tools
-            .iter()
-            .filter(|t| t.started.is_none() && t.outcome.is_none())
-            .count();
+        // Tools held behind a dependency say which one; the rest are just
+        // waiting for a slot, and a count is all there is to say about them.
+        let mut queued = 0;
+        for tool in self.tools.iter().filter(|t| t.is_queued()) {
+            match tool.waiting_message() {
+                Some(waiting) => lines.push(format!(
+                    "  {}  {}",
+                    console::pad_str(&tool.prefix, width, console::Alignment::Left, None),
+                    style::edim(waiting)
+                )),
+                None => queued += 1,
+            }
+        }
         if queued > 0 {
             lines.push(format!("  {queued} queued"));
         }
         lines.join("\n")
     }
 
-    fn finish_tool(&mut self, index: usize, outcome: Outcome, now: Instant) -> Option<String> {
+    /// Record a tool's outcome and return its permanent line, or `None` when
+    /// it had already finished so nothing is reported or counted twice.
+    pub(super) fn finish_tool(
+        &mut self,
+        index: usize,
+        outcome: Outcome,
+        now: Instant,
+    ) -> Option<String> {
         let width = self.width();
-        let tool = &mut self.tools[index];
-        if tool.outcome.is_some() {
+        if self.tools[index].outcome.is_some() {
             return None;
         }
-        tool.outcome = Some(outcome);
-        tool.fraction = 1.0;
-        tool.transfer = None;
-        let prefix = console::pad_str(&tool.prefix, width, console::Alignment::Left, None);
-        let duration = tool
-            .started
-            .map(|started| format!("  {}", elapsed(started, now)))
-            .unwrap_or_default();
-        let (icon, detail) = match outcome {
-            Outcome::Installed if tool.reused => (ProgressIcon::Success, " · cached".into()),
-            Outcome::Installed => (ProgressIcon::Success, String::new()),
-            Outcome::Skipped => (ProgressIcon::Skipped, " · already installed".into()),
-            Outcome::Failed => (ProgressIcon::Error, format!(" · failed: {}", tool.message)),
-        };
-        let artifact = match (&tool.artifact, outcome) {
-            (Some(artifact), Outcome::Installed) => format!("  {}", style::edim(artifact)),
-            _ => String::new(),
-        };
-        Some(format!("{icon} {prefix}{duration}{detail}{artifact}"))
+        let key = self.tools[index].key.clone();
+        {
+            let tool = &mut self.tools[index];
+            tool.outcome = Some(outcome);
+            tool.fraction = 1.0;
+            tool.transfer = None;
+        }
+        // Whatever was waiting on this tool is no longer waiting on it.
+        for tool in &mut self.tools {
+            tool.waiting_on.retain(|dep| dep != &key);
+        }
+        Some(self.tools[index].completion_line(width, now))
     }
 
-    fn summary(&self, now: Instant) -> String {
-        let installed = self
-            .tools
-            .iter()
-            .filter(|t| t.outcome == Some(Outcome::Installed))
-            .count();
-        let skipped = self
-            .tools
-            .iter()
-            .filter(|t| t.outcome == Some(Outcome::Skipped))
-            .count();
-        let failed = self
-            .tools
-            .iter()
-            .filter(|t| t.outcome == Some(Outcome::Failed))
-            .count();
-        let mut result = format!(
-            "{} · installed {installed} {}",
-            self.bar(),
-            tool_noun(installed)
-        );
+    /// Fail every listed tool that never reached a worker, returning their lines.
+    pub(super) fn fail_unstarted(
+        &mut self,
+        failures: Vec<(String, String)>,
+        now: Instant,
+    ) -> Vec<String> {
+        let mut lines = vec![];
+        for (key, error) in failures {
+            if let Some(index) = self.index_of(&key)
+                && self.tools[index].outcome.is_none()
+            {
+                self.tools[index].message = first_line(&error);
+                lines.extend(self.finish_tool(index, Outcome::Failed, now));
+            }
+        }
+        lines
+    }
+
+    pub(super) fn summary(&self, now: Instant) -> String {
+        format!("{} · {}", self.bar(), self.summary_text(now))
+    }
+
+    pub(super) fn summary_text(&self, now: Instant) -> String {
+        let installed = self.count(Outcome::Installed);
+        let skipped = self.count(Outcome::Skipped);
+        let failed = self.count(Outcome::Failed);
+        let mut result = format!("installed {installed} {}", tool_noun(installed));
         if skipped > 0 {
             result.push_str(&format!(" · {skipped} already installed"));
         }
@@ -332,7 +582,19 @@ impl State {
     }
 }
 
-fn first_line(error: &str) -> String {
+/// Cells to fill for `progress` of `width`. While anything is unfinished the
+/// last cell stays empty: a fraction capped at 0.99 still rounds to every cell
+/// of a wide bar, and a full bar over "0/1" is a lie the eye reads first.
+pub(super) fn filled_cells(progress: f64, width: usize, done: bool) -> usize {
+    let cells = (progress * width as f64).floor() as usize;
+    if done {
+        cells.min(width)
+    } else {
+        cells.min(width.saturating_sub(1))
+    }
+}
+
+pub(super) fn first_line(error: &str) -> String {
     error.lines().next().unwrap_or("installation failed").into()
 }
 
@@ -340,12 +602,12 @@ fn column_width<'a>(cells: impl Iterator<Item = &'a str>) -> usize {
     cells.map(console::measure_text_width).max().unwrap_or(0)
 }
 
-fn tool_noun(count: usize) -> &'static str {
+pub(super) fn tool_noun(count: usize) -> &'static str {
     if count == 1 { "tool" } else { "tools" }
 }
 
-fn elapsed(start: Instant, now: Instant) -> String {
-    let duration = now.duration_since(start);
+pub(super) fn elapsed(start: Instant, now: Instant) -> String {
+    let duration = now.saturating_duration_since(start);
     if duration < Duration::from_secs(1) {
         format!("{}ms", duration.as_millis())
     } else {
@@ -362,31 +624,10 @@ pub(crate) struct TextInstallProgress {
 }
 
 impl TextInstallProgress {
-    pub(crate) fn new(tools: impl Iterator<Item = (String, String)>) -> Self {
-        // Match the dependency scheduler's deduplication of repeated requests.
-        let mut seen = HashSet::new();
-        let state = Arc::new(Mutex::new(State {
-            started: Instant::now(),
-            tools: tools
-                .filter(|(key, _)| seen.insert(key.clone()))
-                .map(|(key, prefix)| Tool {
-                    key,
-                    prefix,
-                    started: None,
-                    message: "queued".into(),
-                    outcome: None,
-                    skipped: false,
-                    weights: vec![],
-                    completed_ops: 0,
-                    transfer: None,
-                    artifact: None,
-                    reused: false,
-                    fraction: 0.0,
-                })
-                .collect(),
-        }));
-        let total = state.lock().unwrap().tools.len();
+    pub(super) fn new(state: State) -> Self {
+        let total = state.tools.len();
         info!("installing {total} {}", tool_noun(total));
+        let state = Arc::new(Mutex::new(state));
         let (stop, rx) = mpsc::channel();
         let shared = state.clone();
         let thread = thread::spawn(move || {
@@ -394,7 +635,7 @@ impl TextInstallProgress {
                 let render = || {
                     let state = shared.lock().unwrap();
                     // Completed tools have already printed their individual results.
-                    if state.tools.iter().any(|t| t.outcome.is_none()) {
+                    if !state.all_done() {
                         info!("{}", state.snapshot(Instant::now()));
                     }
                 };
@@ -412,44 +653,35 @@ impl TextInstallProgress {
         }
     }
 
-    /// Returns `None` for a request that was not part of this session, letting the
-    /// caller fall back to the standard reporter instead of panicking mid-install.
-    pub(crate) fn start_tool(&self, key: &str) -> Option<TextToolProgress> {
-        let mut state = self.state.lock().unwrap();
-        let index = state.tools.iter().position(|t| t.key == key)?;
-        let tool = &mut state.tools[index];
-        tool.started = Some(Instant::now());
-        tool.message = "resolving".into();
-        Some(TextToolProgress {
-            state: self.state.clone(),
-            index,
-        })
-    }
-
-    pub(crate) fn finish(&mut self, failures: impl Iterator<Item = (String, String)>) {
-        self.stop();
-        let mut state = self.state.lock().unwrap();
-        let now = Instant::now();
-        for (key, error) in failures {
-            if let Some(index) = state
-                .tools
-                .iter()
-                .position(|t| t.key == key && t.outcome.is_none())
-            {
-                state.tools[index].message = first_line(&error);
-                if let Some(line) = state.finish_tool(index, Outcome::Failed, now) {
-                    info!("{line}");
-                }
-            }
-        }
-        info!("{}", state.summary(now));
-    }
-
     fn stop(&mut self) {
         let _ = self.stop.send(());
         if let Some(thread) = self.thread.take() {
             let _ = thread.join();
         }
+    }
+}
+
+impl InstallProgress for TextInstallProgress {
+    fn start_tool(&self, key: &str) -> Option<Box<dyn ToolProgress>> {
+        let index = self.state.lock().unwrap().start_tool(key)?;
+        Some(Box::new(TextToolProgress {
+            state: self.state.clone(),
+            index,
+        }))
+    }
+
+    fn set_waiting(&self, key: &str, dependencies: Vec<String>) {
+        self.state.lock().unwrap().set_waiting(key, dependencies);
+    }
+
+    fn finish(&mut self, failures: Vec<(String, String)>) {
+        self.stop();
+        let mut state = self.state.lock().unwrap();
+        let now = Instant::now();
+        for line in state.fail_unstarted(failures, now) {
+            info!("{line}");
+        }
+        info!("{}", state.summary(now));
     }
 }
 
@@ -466,79 +698,42 @@ pub(crate) struct TextToolProgress {
 }
 
 impl TextToolProgress {
-    /// Mutate this tool's state and refresh its cached fraction. Every progress
-    /// signal goes through here so the bar can never be stale relative to the
-    /// rows printed beside it.
     fn with_tool(&self, f: impl FnOnce(&mut Tool)) {
-        let mut state = self.state.lock().unwrap();
-        let tool = &mut state.tools[self.index];
-        f(tool);
-        tool.advance();
+        f(&mut self.state.lock().unwrap().tools[self.index]);
+    }
+}
+
+impl ToolProgress for TextToolProgress {
+    fn set_prefix(&self, prefix: String) {
+        self.with_tool(|tool| tool.prefix = prefix);
     }
 
-    pub(crate) fn set_prefix(&self, prefix: String) {
-        self.state.lock().unwrap().tools[self.index].prefix = prefix;
-    }
-
-    /// The worker result is authoritative: backends sometimes finish their
-    /// report before their postinstall work has actually returned.
-    ///
     /// `error` is the worker's own failure. Without it the line would report
     /// whatever phase the tool happened to be in when it died, which reads as a
     /// reason ("failed: ✓ Cosign verified") without being one.
-    pub(crate) fn complete(&self, error: Option<&str>) {
+    fn complete(&self, error: Option<&str>) {
         let mut state = self.state.lock().unwrap();
-        let outcome = match error {
-            Some(error) => {
-                state.tools[self.index].message = first_line(error);
-                Outcome::Failed
-            }
-            None if state.tools[self.index].skipped => Outcome::Skipped,
-            None => Outcome::Installed,
-        };
+        let outcome = state.tools[self.index].outcome_for(error);
+        if let Some(error) = error {
+            state.tools[self.index].message = first_line(error);
+        }
         if let Some(line) = state.finish_tool(self.index, outcome, Instant::now()) {
             info!("{line}");
         }
+    }
+
+    fn reporter(&self) -> Box<dyn SingleReport> {
+        Box::new(self.clone())
     }
 }
 
 impl SingleReport for TextToolProgress {
     fn set_message(&self, message: String) {
-        // Keep counters from embedded package managers, but omit artifact names
-        // from the common download/checksum/extract status messages.
-        let message = message.replace(['\r', '\n'], " ");
-        let mut words = message.split_whitespace();
-        let mut reused = false;
-        let mut operations_done = false;
-        let (phase, artifact) = match words.next() {
-            Some("download") => ("downloading", words.next()),
-            Some("cached") => {
-                reused = true;
-                ("reusing download", words.next())
-            }
+        self.with_tool(|tool| tool.apply_message(message));
+    }
 
-            Some("checksum") => ("verifying checksum", None),
-            Some("extract") => ("extracting", None),
-            Some("install") => ("installing", None),
-            Some("running") if message == "running custom postinstall hook" => {
-                operations_done = true;
-                ("running postinstall hook", None)
-            }
-            _ => (message.as_str(), None),
-        };
-        let phase = phase.to_string();
-        let artifact = artifact.map(str::to_string);
-        self.with_tool(|tool| {
-            tool.message = phase;
-            tool.reused |= reused;
-            if operations_done {
-                tool.completed_ops = tool.weights.len();
-                tool.transfer = None;
-            }
-            if let Some(artifact) = artifact {
-                tool.artifact = Some(artifact);
-            }
-        });
+    fn set_detail(&self, detail: String) {
+        self.with_tool(|tool| tool.set_detail(detail));
     }
 
     /// A child process's own output is the diagnostic value of an install log,
@@ -564,59 +759,31 @@ impl SingleReport for TextToolProgress {
     }
 
     fn start_operations(&self, count: usize) {
-        self.with_tool(|tool| tool.weights = vec![1.0; count.max(1)]);
+        self.with_tool(|tool| tool.start_operations(&vec![1.0; count.max(1)]));
     }
 
     fn start_operations_weighted(&self, weights: &[f64]) {
-        let weights: Vec<f64> = weights.iter().copied().filter(|w| *w > 0.0).collect();
-        self.with_tool(|tool| {
-            tool.weights = if weights.is_empty() {
-                vec![1.0]
-            } else {
-                weights.clone()
-            }
-        });
+        self.with_tool(|tool| tool.start_operations(weights));
     }
 
     fn next_operation(&self) {
-        self.with_tool(|tool| {
-            tool.completed_ops = (tool.completed_ops + 1).min(tool.weights.len());
-            // Byte progress belongs to the operation that just ended.
-            tool.transfer = None;
-        });
+        self.with_tool(|tool| tool.next_operation());
     }
 
     fn set_length(&self, length: u64) {
-        // A length always opens a new transfer, even when it equals the last
-        // one: the downloader announces it once per attempt, and a retry that
-        // kept the previous state would fold the failed attempt's bytes and
-        // time into this one's rate.
-        self.with_tool(|tool| tool.transfer = Some(Transfer::new(length)));
+        self.with_tool(|tool| tool.set_length(length));
     }
 
     fn set_position(&self, position: u64) {
-        self.with_tool(|tool| {
-            // A server that sends no content-length never calls set_length, so
-            // the first bytes open a transfer with an unknown total.
-            let transfer = tool.transfer.get_or_insert_with(|| Transfer::new(0));
-            // A resumed download reports its starting offset here.
-            if transfer.done == 0 && position > 0 {
-                transfer.resumed_at = position;
-            }
-            transfer.done = position;
-        });
+        self.with_tool(|tool| tool.set_position(position));
     }
 
     fn inc(&self, delta: u64) {
-        self.with_tool(|tool| {
-            let transfer = tool.transfer.get_or_insert_with(|| Transfer::new(0));
-            transfer.done = transfer.done.saturating_add(delta);
-        });
+        self.with_tool(|tool| tool.inc(delta));
     }
 
     fn finish_with_icon(&self, _message: String, icon: ProgressIcon) {
-        self.state.lock().unwrap().tools[self.index].skipped =
-            matches!(icon, ProgressIcon::Skipped);
+        self.with_tool(|tool| tool.set_skipped(matches!(icon, ProgressIcon::Skipped)));
     }
 }
 
@@ -625,24 +792,26 @@ mod tests {
     use super::*;
 
     fn state(started: Instant) -> State {
-        State {
+        let mut state = State::new((0..3).map(|i| (i.to_string(), format!("tool{i}@1"))));
+        state.started = started;
+        state
+    }
+
+    fn tool_progress(state: State) -> (Arc<Mutex<State>>, TextToolProgress) {
+        let shared = Arc::new(Mutex::new(state));
+        let progress = TextToolProgress {
+            state: shared.clone(),
+            index: 0,
+        };
+        (shared, progress)
+    }
+
+    fn transfer(done: u64, total: u64, started: Instant) -> Transfer {
+        Transfer {
+            done,
+            total,
             started,
-            tools: (0..3)
-                .map(|i| Tool {
-                    key: i.to_string(),
-                    prefix: format!("tool{i}@1"),
-                    started: None,
-                    message: "queued".into(),
-                    outcome: None,
-                    skipped: false,
-                    weights: vec![],
-                    completed_ops: 0,
-                    transfer: None,
-                    artifact: None,
-                    reused: false,
-                    fraction: 0.0,
-                })
-                .collect(),
+            resumed_at: 0,
         }
     }
 
@@ -670,6 +839,21 @@ mod tests {
     }
 
     #[test]
+    fn a_tool_held_behind_a_dependency_says_which_one() {
+        let start = Instant::now();
+        let mut state = state(start);
+        state.set_waiting("2", vec!["0".into(), "1".into()]);
+        state.tools[0].started = Some(start);
+        let snapshot = console::strip_ansi_codes(&state.snapshot(start)).into_owned();
+        assert!(snapshot.contains("tool2@1  waiting for 0, 1"), "{snapshot}");
+        // Only the slot-bound tool is counted as merely queued.
+        assert!(snapshot.ends_with("1 queued"), "{snapshot}");
+        // Finishing a dependency drops it from the wait.
+        state.finish_tool(0, Outcome::Installed, start);
+        assert_eq!(state.tools[2].waiting_on, vec!["1".to_string()]);
+    }
+
+    #[test]
     fn terminal_results_are_not_reported_or_counted_twice() {
         let start = Instant::now();
         let mut state = state(start);
@@ -690,12 +874,7 @@ mod tests {
 
     #[test]
     fn backend_finish_does_not_complete_a_worker() {
-        let start = Instant::now();
-        let shared = Arc::new(Mutex::new(state(start)));
-        let progress = TextToolProgress {
-            state: shared.clone(),
-            index: 0,
-        };
+        let (shared, progress) = tool_progress(state(Instant::now()));
         progress.finish_with_message("installed".into());
         assert!(shared.lock().unwrap().tools[0].outcome.is_none());
         progress.set_message("running postinstall hook".into());
@@ -708,12 +887,7 @@ mod tests {
 
     #[test]
     fn a_failure_reports_the_error_not_the_phase_it_died_in() {
-        let start = Instant::now();
-        let shared = Arc::new(Mutex::new(state(start)));
-        let progress = TextToolProgress {
-            state: shared.clone(),
-            index: 0,
-        };
+        let (shared, progress) = tool_progress(state(Instant::now()));
         // A phase message can even read as a success on its own.
         progress.set_message("✓ Cosign verified".into());
         progress.complete(Some("checksum mismatch\nsecond line"));
@@ -722,28 +896,13 @@ mod tests {
 
     #[test]
     fn a_skip_survives_a_successful_completion() {
-        let start = Instant::now();
-        let shared = Arc::new(Mutex::new(state(start)));
-        let progress = TextToolProgress {
-            state: shared.clone(),
-            index: 0,
-        };
+        let (shared, progress) = tool_progress(state(Instant::now()));
         progress.finish_with_icon("already installed".into(), ProgressIcon::Skipped);
         progress.complete(None);
         assert_eq!(
             shared.lock().unwrap().tools[0].outcome,
             Some(Outcome::Skipped)
         );
-    }
-
-    #[test]
-    fn stopping_joins_the_heartbeat_without_waiting_for_a_tick() {
-        let start = Instant::now();
-        let mut progress =
-            TextInstallProgress::new(std::iter::once(("tool".into(), "tool@1".into())));
-        progress.stop();
-        assert!(progress.thread.is_none());
-        assert!(start.elapsed() < INTERVAL);
     }
 
     #[test]
@@ -755,12 +914,7 @@ mod tests {
         state.finish_tool(0, Outcome::Installed, start);
         state.tools[1].started = Some(start);
         state.tools[1].weights = vec![1.0];
-        state.tools[1].transfer = Some(Transfer {
-            done: 50,
-            total: 100,
-            started: start,
-            resumed_at: 0,
-        });
+        state.tools[1].transfer = Some(transfer(50, 100, start));
         state.tools[1].advance();
         // 1.0 + ~0.5 + 0.0 over three tools is half the bar, while the count
         // beside it still reports whole tools.
@@ -775,22 +929,16 @@ mod tests {
         let tool = &mut state.tools[0];
         tool.started = Some(start);
         // download, checksum, extract
-        tool.weights = vec![0.7, 0.15, 0.15];
-        tool.advance();
+        tool.start_operations(&[0.7, 0.15, 0.15]);
         assert_eq!(tool.fraction, 0.0);
         // Halfway through the download is 35% of the tool, not 1/6.
-        tool.transfer = Some(Transfer {
-            done: 1,
-            total: 2,
-            started: start,
-            resumed_at: 0,
-        });
+        tool.transfer = Some(transfer(1, 2, start));
         tool.advance();
         assert!((tool.fraction - 0.35).abs() < 1e-9, "{}", tool.fraction);
         // The tail stays reserved for the work that follows the last operation.
-        tool.completed_ops = 3;
-        tool.transfer = None;
-        tool.advance();
+        tool.next_operation();
+        tool.next_operation();
+        tool.next_operation();
         assert_eq!(tool.fraction, 0.99);
     }
 
@@ -800,22 +948,11 @@ mod tests {
         let mut state = state(start);
         let tool = &mut state.tools[0];
         tool.weights = vec![1.0];
-        tool.transfer = Some(Transfer {
-            done: 90,
-            total: 100,
-            started: start,
-            resumed_at: 0,
-        });
+        tool.transfer = Some(transfer(90, 100, start));
         tool.advance();
         let high = tool.fraction;
         // A restarted download reports byte zero again.
-        tool.transfer = Some(Transfer {
-            done: 0,
-            total: 100,
-            started: start,
-            resumed_at: 0,
-        });
-        tool.advance();
+        tool.set_length(100);
         assert_eq!(tool.fraction, high);
     }
 
@@ -824,23 +961,13 @@ mod tests {
         let start = Instant::now();
         let mut state = state(start);
         let tool = &mut state.tools[0];
-        tool.transfer = Some(Transfer {
-            done: 42_100_000,
-            total: 78_300_000,
-            started: start,
-            resumed_at: 0,
-        });
+        tool.transfer = Some(transfer(42_100_000, 78_300_000, start));
         let detail = tool.transfer_detail(start + Duration::from_secs(4));
         assert_eq!(detail, "42.1/78.3 MB · 10.5 MB/s");
 
         // A server that sends no length still gets a running count, and a rate
         // needs enough of a sample to mean anything.
-        tool.transfer = Some(Transfer {
-            done: 1_500_000,
-            total: 0,
-            started: start,
-            resumed_at: 0,
-        });
+        tool.transfer = Some(transfer(1_500_000, 0, start));
         assert_eq!(
             tool.transfer_detail(start + Duration::from_millis(100)),
             "1.5 MB"
@@ -848,37 +975,61 @@ mod tests {
     }
 
     #[test]
-    fn a_resumed_download_does_not_inflate_the_rate() {
+    fn non_transfer_detail_fills_the_same_column() {
         let start = Instant::now();
         let mut state = state(start);
         let tool = &mut state.tools[0];
-        tool.transfer = Some(Transfer {
-            done: 0,
-            total: 100_000_000,
-            started: start,
-            resumed_at: 0,
-        });
+        tool.set_detail("32/48 pkgs".into());
+        assert_eq!(tool.transfer_detail(start), "32/48 pkgs");
+        // Bytes take precedence while they are moving.
+        tool.transfer = Some(transfer(500, 1000, start));
+        assert_eq!(tool.transfer_detail(start), "0.5/1 kB");
+    }
+
+    #[test]
+    fn a_resumed_download_does_not_inflate_the_rate() {
+        let start = Instant::now();
+        let mut state = state(start);
+        state.tools[0].transfer = Some(transfer(0, 100_000_000, start));
+        let (shared, progress) = tool_progress(state);
         // 90 MB was already on disk; only the 10 MB since counts toward rate.
-        let progress = TextToolProgress {
-            state: Arc::new(Mutex::new(state)),
-            index: 0,
-        };
         progress.set_position(90_000_000);
         progress.inc(10_000_000);
-        let shared = progress.state.lock().unwrap();
+        let shared = shared.lock().unwrap();
         let detail = shared.tools[0].transfer_detail(start + Duration::from_secs(2));
         assert_eq!(detail, "100.0/100.0 MB · 5.0 MB/s");
     }
 
     #[test]
+    fn a_retried_attempt_starts_its_rate_from_zero() {
+        let (shared, progress) = tool_progress(state(Instant::now()));
+        progress.set_length(100);
+        progress.inc(60);
+        // Same total announced again: a new attempt, resuming at 60.
+        progress.set_length(100);
+        progress.set_position(60);
+        progress.inc(10);
+        let transfer = shared.lock().unwrap().tools[0].transfer.unwrap();
+        assert_eq!((transfer.done, transfer.resumed_at), (70, 60));
+    }
+
+    #[test]
+    fn bytes_without_a_length_still_show_a_running_count() {
+        let start = Instant::now();
+        let (shared, progress) = tool_progress(state(start));
+        progress.inc(1_500_000);
+        let state = shared.lock().unwrap();
+        assert_eq!(state.tools[0].transfer_detail(start), "1.5 MB");
+        // No total, so no fraction: the bar must not pretend to know.
+        assert_eq!(state.tools[0].transfer.unwrap().fraction(), None);
+    }
+
+    #[test]
     fn completion_line_names_the_artifact_and_says_when_it_was_reused() {
         let start = Instant::now();
-        let shared = Arc::new(Mutex::new(state(start)));
-        shared.lock().unwrap().tools[0].started = Some(start);
-        let progress = TextToolProgress {
-            state: shared.clone(),
-            index: 0,
-        };
+        let mut state = state(start);
+        state.tools[0].started = Some(start);
+        let (shared, progress) = tool_progress(state);
         progress.set_message("cached node-v24.20.0-linux-x64.tar.xz".into());
         {
             let state = shared.lock().unwrap();
@@ -896,6 +1047,22 @@ mod tests {
             line,
             "✓ tool0@1  300ms · cached  node-v24.20.0-linux-x64.tar.xz"
         );
+    }
+
+    #[test]
+    fn the_bar_keeps_a_cell_open_until_everything_is_done() {
+        let start = Instant::now();
+        let mut state = State::new(std::iter::once(("0".to_string(), "tool0@1".to_string())));
+        state.started = start;
+        state.tools[0].started = Some(start);
+        state.tools[0].start_operations(&[1.0]);
+        state.tools[0].apply_message("running custom postinstall hook".into());
+        assert_eq!(state.tools[0].fraction, 0.99);
+        let bar = console::strip_ansi_codes(&state.bar_only(24)).into_owned();
+        assert_eq!(bar, "███████████████████████░");
+        state.finish_tool(0, Outcome::Installed, start);
+        let bar = console::strip_ansi_codes(&state.bar_only(24)).into_owned();
+        assert_eq!(bar, "████████████████████████");
     }
 
     #[test]
@@ -919,12 +1086,7 @@ mod tests {
 
     #[test]
     fn the_postinstall_hook_completes_every_declared_operation() {
-        let start = Instant::now();
-        let shared = Arc::new(Mutex::new(state(start)));
-        let progress = TextToolProgress {
-            state: shared.clone(),
-            index: 0,
-        };
+        let (shared, progress) = tool_progress(state(Instant::now()));
         // A plugin backend that never calls next_operation.
         progress.start_operations(3);
         assert_eq!(shared.lock().unwrap().tools[0].fraction, 0.0);
@@ -935,41 +1097,23 @@ mod tests {
     }
 
     #[test]
-    fn a_retried_attempt_starts_its_rate_from_zero() {
+    fn stopping_joins_the_heartbeat_without_waiting_for_a_tick() {
         let start = Instant::now();
-        let shared = Arc::new(Mutex::new(state(start)));
-        let progress = TextToolProgress {
-            state: shared.clone(),
-            index: 0,
-        };
-        progress.set_length(100);
-        progress.inc(60);
-        // Same total announced again: a new attempt, resuming at 60.
-        progress.set_length(100);
-        progress.set_position(60);
-        progress.inc(10);
-        let transfer = shared.lock().unwrap().tools[0].transfer.unwrap();
-        assert_eq!((transfer.done, transfer.resumed_at), (70, 60));
-    }
-
-    #[test]
-    fn bytes_without_a_length_still_show_a_running_count() {
-        let start = Instant::now();
-        let shared = Arc::new(Mutex::new(state(start)));
-        let progress = TextToolProgress {
-            state: shared.clone(),
-            index: 0,
-        };
-        progress.inc(1_500_000);
-        let state = shared.lock().unwrap();
-        assert_eq!(state.tools[0].transfer_detail(start), "1.5 MB");
-        // No total, so no fraction: the bar must not pretend to know.
-        assert_eq!(state.tools[0].transfer.unwrap().fraction(), None);
+        let mut progress = TextInstallProgress::new(State::new(std::iter::once((
+            "tool".to_string(),
+            "tool@1".to_string(),
+        ))));
+        progress.stop();
+        assert!(progress.thread.is_none());
+        assert!(start.elapsed() < INTERVAL);
     }
 
     #[test]
     fn an_unknown_request_falls_back_instead_of_panicking() {
-        let progress = TextInstallProgress::new(std::iter::once(("tool".into(), "tool@1".into())));
+        let progress = TextInstallProgress::new(State::new(std::iter::once((
+            "tool".to_string(),
+            "tool@1".to_string(),
+        ))));
         assert!(progress.start_tool("tool").is_some());
         assert!(progress.start_tool("other").is_none());
     }

--- a/src/ui/text_install_progress.rs
+++ b/src/ui/text_install_progress.rs
@@ -180,6 +180,7 @@ impl Tool {
             Some("verify") => ("verifying", None),
             Some("extract") => ("extracting", None),
             Some("install") => ("installing", None),
+            Some("uninstall") | Some("remove") => ("removing", None),
             // The postinstall hook means every declared operation is behind us.
             // Plugin backends (asdf, vfox) never call next_operation, so
             // without this their bar sits at zero until the worker returns.
@@ -376,6 +377,30 @@ fn format_bytes_in(bytes: u64, total: u64) -> String {
     format!("{:.*}", decimals, bytes as f64 / unit)
 }
 
+/// What a session is doing to its tools. The same model and renderers serve
+/// both; only the verbs differ.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Action {
+    Install,
+    Remove,
+}
+
+impl Action {
+    pub(super) fn present(self) -> &'static str {
+        match self {
+            Action::Install => "installing",
+            Action::Remove => "removing",
+        }
+    }
+
+    pub(super) fn past(self) -> &'static str {
+        match self {
+            Action::Install => "installed",
+            Action::Remove => "removed",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum Outcome {
     Installed,
@@ -385,15 +410,25 @@ pub(super) enum Outcome {
 
 #[derive(Debug)]
 pub(super) struct State {
+    pub(super) action: Action,
     pub(super) tools: Vec<Tool>,
     pub(super) started: Instant,
 }
 
 impl State {
+    #[cfg(test)]
     pub(super) fn new(tools: impl Iterator<Item = (String, String)>) -> Self {
+        Self::for_action(Action::Install, tools)
+    }
+
+    pub(super) fn for_action(
+        action: Action,
+        tools: impl Iterator<Item = (String, String)>,
+    ) -> Self {
         // Match the dependency scheduler's deduplication of repeated requests.
         let mut seen = HashSet::new();
         Self {
+            action,
             started: Instant::now(),
             tools: tools
                 .filter(|(key, _)| seen.insert(key.clone()))
@@ -614,7 +649,11 @@ impl State {
         let installed = self.count(Outcome::Installed);
         let skipped = self.count(Outcome::Skipped);
         let failed = self.count(Outcome::Failed);
-        let mut result = format!("installed {installed} {}", tool_noun(installed));
+        let mut result = format!(
+            "{} {installed} {}",
+            self.action.past(),
+            tool_noun(installed)
+        );
         if skipped > 0 {
             result.push_str(&format!(" · {skipped} already installed"));
         }
@@ -670,7 +709,7 @@ pub(crate) struct TextInstallProgress {
 impl TextInstallProgress {
     pub(super) fn new(state: State) -> Self {
         let total = state.tools.len();
-        info!("installing {total} {}", tool_noun(total));
+        info!("{} {total} {}", state.action.present(), tool_noun(total));
         let state = Arc::new(Mutex::new(state));
         let (stop, rx) = mpsc::channel();
         let shared = state.clone();
@@ -912,6 +951,25 @@ mod tests {
                 "  tool2@1  verifying           3.0s",
             ]
         );
+    }
+
+    #[test]
+    fn a_removal_session_speaks_in_its_own_verbs() {
+        let start = Instant::now();
+        let mut state = State::for_action(
+            Action::Remove,
+            (0..2).map(|i| (i.to_string(), format!("tool{i}@1"))),
+        );
+        state.started = start;
+        state.tools[0].started = Some(start);
+        state.tools[0].apply_message("uninstall".into());
+        assert_eq!(state.tools[0].message, "removing");
+        state.tools[0].apply_message("remove ~/.local/share/mise/installs/tool0/1".into());
+        assert_eq!(state.tools[0].message, "removing");
+        state.finish_tool(0, Outcome::Installed, start + Duration::from_millis(40));
+        state.finish_tool(1, Outcome::Installed, start);
+        let summary = console::strip_ansi_codes(&state.summary(start)).into_owned();
+        assert_eq!(summary, "████████████████ 2/2 · removed 2 tools in 0ms");
     }
 
     #[test]

--- a/src/ui/text_install_progress.rs
+++ b/src/ui/text_install_progress.rs
@@ -46,11 +46,14 @@ pub(super) struct Tool {
     pub(super) fraction: f64,
 }
 
-/// Byte progress for the operation currently running.
+/// Progress through the operation currently running: bytes of a download, or
+/// whole items when a package manager counts packages instead.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct Transfer {
     pub(super) done: u64,
     pub(super) total: u64,
+    /// Bytes get sizes and a rate; items get neither.
+    pub(super) bytes: bool,
     started: Instant,
     /// Bytes already on disk when this transfer began, from a resumed
     /// download. Excluded from the rate so a resume does not report a
@@ -63,6 +66,17 @@ impl Transfer {
         Self {
             done: 0,
             total,
+            bytes: true,
+            started: Instant::now(),
+            resumed_at: 0,
+        }
+    }
+
+    fn items(done: u64, total: u64) -> Self {
+        Self {
+            done,
+            total,
+            bytes: false,
             started: Instant::now(),
             resumed_at: 0,
         }
@@ -76,6 +90,9 @@ impl Transfer {
     /// snapshot only lands every few seconds, so a sampled rate would report
     /// whichever moment it happened to catch.
     fn rate(&self, now: Instant) -> Option<f64> {
+        if !self.bytes {
+            return None;
+        }
         let seconds = now.saturating_duration_since(self.started).as_secs_f64();
         let moved = self.done.saturating_sub(self.resumed_at);
         (seconds > 0.5 && moved > 0).then(|| moved as f64 / seconds)
@@ -230,6 +247,14 @@ impl Tool {
         self.detail = (!detail.trim().is_empty()).then_some(detail);
     }
 
+    /// Whole-item progress through the current operation. Replaces whatever
+    /// transfer was there: a package manager that switches from resolving to
+    /// fetching reports a new tally against a new total.
+    pub(super) fn set_items(&mut self, done: u64, total: u64) {
+        self.transfer = Some(Transfer::items(done, total));
+        self.advance();
+    }
+
     pub(super) fn set_skipped(&mut self, skipped: bool) {
         self.skipped = skipped;
     }
@@ -244,14 +269,23 @@ impl Tool {
     }
 
     /// `42.1/78.3 MB · 12.4 MB/s`, dropping whichever half is unknown. A server
-    /// that sends no content-length still gets a running byte count. Falls
-    /// back to non-transfer detail such as a package count.
+    /// that sends no content-length still gets a running byte count.
+    ///
+    /// Explicit detail wins over the transfer: a package manager reports its
+    /// tally through `set_detail` and drives the bar with counts, and those
+    /// counts must not be printed as bytes.
     pub(super) fn transfer_detail(&self, now: Instant) -> String {
+        if let Some(detail) = &self.detail {
+            return detail.clone();
+        }
         let Some(transfer) = self.transfer else {
-            return self.detail.clone().unwrap_or_default();
+            return String::new();
         };
         if transfer.done == 0 && transfer.total == 0 {
-            return self.detail.clone().unwrap_or_default();
+            return String::new();
+        }
+        if !transfer.bytes {
+            return format!("{}/{}", transfer.done, transfer.total);
         }
         let bytes = if transfer.total > 0 {
             format!(
@@ -736,6 +770,10 @@ impl SingleReport for TextToolProgress {
         self.with_tool(|tool| tool.set_detail(detail));
     }
 
+    fn set_items(&self, done: u64, total: u64) {
+        self.with_tool(|tool| tool.set_items(done, total));
+    }
+
     /// A child process's own output is the diagnostic value of an install log,
     /// so it stays immediate. Only the phase messages a backend generates are
     /// folded into the periodic snapshot.
@@ -810,6 +848,7 @@ mod tests {
         Transfer {
             done,
             total,
+            bytes: true,
             started,
             resumed_at: 0,
         }
@@ -981,7 +1020,24 @@ mod tests {
         let tool = &mut state.tools[0];
         tool.set_detail("32/48 pkgs".into());
         assert_eq!(tool.transfer_detail(start), "32/48 pkgs");
-        // Bytes take precedence while they are moving.
+        // Items driving the bar must not print as bytes, with or without
+        // explicit detail, and never contribute a transfer rate.
+        tool.set_items(32, 48);
+        assert_eq!(tool.transfer_detail(start), "32/48 pkgs");
+        assert_eq!(
+            tool.transfer.unwrap().rate(start + Duration::from_secs(5)),
+            None
+        );
+        tool.set_detail(String::new());
+        assert_eq!(tool.transfer_detail(start), "32/48");
+        // Items fill the current operation exactly as bytes would. (The
+        // fraction is monotonic, so this tally must not fall below the 32/48
+        // already reported above.)
+        tool.start_operations(&[1.0]);
+        tool.set_items(36, 48);
+        assert!((tool.fraction - 0.75).abs() < 1e-9, "{}", tool.fraction);
+        // Without explicit detail, the transfer is bytes.
+        tool.set_detail(String::new());
         tool.transfer = Some(transfer(500, 1000, start));
         assert_eq!(tool.transfer_detail(start), "0.5/1 kB");
     }

--- a/src/ui/text_install_progress.rs
+++ b/src/ui/text_install_progress.rs
@@ -176,6 +176,8 @@ impl Tool {
                 ("reusing download", words.next())
             }
             Some("checksum") => ("verifying checksum", None),
+            Some("verify") if words.clone().next() == Some("size") => ("verifying size", None),
+            Some("verify") => ("verifying", None),
             Some("extract") => ("extracting", None),
             Some("install") => ("installing", None),
             // The postinstall hook means every declared operation is behind us.
@@ -278,14 +280,24 @@ impl Tool {
         if let Some(detail) = &self.detail {
             return detail.clone();
         }
-        let Some(transfer) = self.transfer else {
-            return String::new();
-        };
-        if transfer.done == 0 && transfer.total == 0 {
-            return String::new();
+        if let Some(bytes) = self.transfer_bytes(now) {
+            return bytes;
         }
-        if !transfer.bytes {
-            return format!("{}/{}", transfer.done, transfer.total);
+        match self.transfer {
+            Some(transfer) if !transfer.bytes && (transfer.done > 0 || transfer.total > 0) => {
+                format!("{}/{}", transfer.done, transfer.total)
+            }
+            _ => String::new(),
+        }
+    }
+
+    /// Just the byte transfer — `42.1/78.3 MB · 12.4 MB/s` — for a renderer
+    /// that shows detail and item counts somewhere else and must not print
+    /// them twice.
+    pub(super) fn transfer_bytes(&self, now: Instant) -> Option<String> {
+        let transfer = self.transfer?;
+        if !transfer.bytes || (transfer.done == 0 && transfer.total == 0) {
+            return None;
         }
         let bytes = if transfer.total > 0 {
             format!(
@@ -296,10 +308,10 @@ impl Tool {
         } else {
             format_bytes(transfer.done)
         };
-        match transfer.rate(now) {
+        Some(match transfer.rate(now) {
             Some(rate) => format!("{bytes} · {}/s", format_bytes(rate.round() as u64)),
             None => bytes,
-        }
+        })
     }
 
     /// The permanent line for a finished tool, padded to `width`.
@@ -431,8 +443,13 @@ impl State {
         self.tools.iter().filter(|t| t.outcome.is_some()).count()
     }
 
+    /// Tools waiting only for a job slot. Ones held behind a dependency have
+    /// their own row saying which, and are not counted here as well.
     pub(super) fn queued_count(&self) -> usize {
-        self.tools.iter().filter(|t| t.is_queued()).count()
+        self.tools
+            .iter()
+            .filter(|t| t.is_queued() && t.waiting_message().is_none())
+            .count()
     }
 
     pub(super) fn all_done(&self) -> bool {
@@ -493,6 +510,11 @@ impl State {
         // Columns size to their content on every snapshot. A fixed width would
         // either truncate a status like "running postinstall hook" or reserve
         // blank space for a transfer column most rows never fill.
+        // Rows are read in CI log viewers and narrow panes, so the fixed-shape
+        // cells come first — prefix, phase, elapsed — and the one variable cell,
+        // the transfer detail, is last and unpadded. The artifact name is not
+        // repeated here: it wraps a long row every three seconds, and the
+        // completion line records it once, in full, where it can be searched.
         let rows: Vec<_> = self
             .tools
             .iter()
@@ -502,50 +524,38 @@ impl State {
                 Some((
                     tool.prefix.as_str(),
                     tool.message.clone(),
-                    tool.transfer_detail(now),
                     elapsed(started, now),
-                    tool.artifact.as_deref(),
+                    tool.transfer_detail(now),
                 ))
             })
             .collect();
         let width = self.width();
         let message_width = column_width(rows.iter().map(|r| r.1.as_str()));
-        let detail_width = column_width(rows.iter().map(|r| r.2.as_str()));
-        for (prefix, message, detail, elapsed, artifact) in rows {
+        let elapsed_width = column_width(rows.iter().map(|r| r.2.as_str()));
+        for (prefix, message, elapsed, detail) in rows {
             let mut line = format!(
-                "  {}  {}",
+                "  {}  {}  {}",
                 console::pad_str(prefix, width, console::Alignment::Left, None),
                 console::pad_str(&message, message_width, console::Alignment::Left, None),
+                console::pad_str(&elapsed, elapsed_width, console::Alignment::Right, None),
             );
-            if detail_width > 0 {
-                line.push_str("  ");
-                line.push_str(&console::pad_str(
-                    &detail,
-                    detail_width,
-                    console::Alignment::Left,
-                    None,
-                ));
-            }
-            line.push_str(&format!("  {elapsed}"));
-            if let Some(artifact) = artifact {
-                // Last, dimmed, so its length cannot disturb the columns.
-                line.push_str(&format!("  {}", style::edim(artifact)));
+            if !detail.is_empty() {
+                line.push_str(&format!("  {detail}"));
             }
             lines.push(line);
         }
         // Tools held behind a dependency say which one; the rest are just
         // waiting for a slot, and a count is all there is to say about them.
-        let mut queued = 0;
         for tool in self.tools.iter().filter(|t| t.is_queued()) {
-            match tool.waiting_message() {
-                Some(waiting) => lines.push(format!(
+            if let Some(waiting) = tool.waiting_message() {
+                lines.push(format!(
                     "  {}  {}",
                     console::pad_str(&tool.prefix, width, console::Alignment::Left, None),
                     style::edim(waiting)
-                )),
-                None => queued += 1,
+                ));
             }
         }
+        let queued = self.queued_count();
         if queued > 0 {
             lines.push(format!("  {queued} queued"));
         }
@@ -874,7 +884,34 @@ mod tests {
         assert!(row.contains("extracting"), "{row}");
         // Its own 1.0s of work, not the 3.0s since the install started.
         assert!(row.trim_end().ends_with("1.0s"), "{row}");
+        // Nothing but the four cells: no artifact, no padded empty detail.
+        assert_eq!(row.trim_end(), "  tool1@1  extracting  1.0s", "{row}");
         assert!(snapshot.ends_with("1 queued"));
+    }
+
+    #[test]
+    fn snapshot_rows_put_detail_last_and_leave_no_gaps() {
+        let start = Instant::now();
+        let mut state = state(start);
+        for tool in &mut state.tools {
+            tool.started = Some(start);
+        }
+        state.tools[0].message = "extracting".into();
+        state.tools[0].artifact = Some("node-v22.23.2-linux-x64.tar.gz".into());
+        state.tools[1].message = "verifying checksum".into();
+        state.tools[1].transfer = Some(transfer(1_100_000, 2_300_000, start));
+        state.tools[2].apply_message("verify hk-x86_64-unknown-linux-gnu.tar.gz".into());
+        let snapshot =
+            console::strip_ansi_codes(&state.snapshot(start + Duration::from_secs(3))).into_owned();
+        let rows: Vec<&str> = snapshot.lines().skip(1).map(str::trim_end).collect();
+        assert_eq!(
+            rows,
+            [
+                "  tool0@1  extracting          3.0s",
+                "  tool1@1  verifying checksum  3.0s  1.1/2.3 MB · 367 kB/s",
+                "  tool2@1  verifying           3.0s",
+            ]
+        );
     }
 
     #[test]
@@ -1011,6 +1048,35 @@ mod tests {
             tool.transfer_detail(start + Duration::from_millis(100)),
             "1.5 MB"
         );
+    }
+
+    #[test]
+    fn dependency_waiting_tools_are_not_counted_as_queued() {
+        let start = Instant::now();
+        let mut state = state(start);
+        state.set_waiting("2", vec!["0".into()]);
+        // tool0 and tool1 wait for a slot; tool2 waits for tool0.
+        assert_eq!(state.queued_count(), 2);
+        state.tools[0].started = Some(start);
+        state.finish_tool(0, Outcome::Installed, start);
+        // tool2's wait drained: it is a plain queued tool now.
+        assert!(state.tools[2].waiting_message().is_none());
+        assert_eq!(state.queued_count(), 2);
+    }
+
+    #[test]
+    fn transfer_bytes_is_only_ever_bytes() {
+        let start = Instant::now();
+        let mut state = state(start);
+        let tool = &mut state.tools[0];
+        tool.set_detail("32/48 pkgs".into());
+        assert_eq!(tool.transfer_bytes(start), None);
+        assert_eq!(tool.transfer_detail(start), "32/48 pkgs");
+        // Item counts drive the bar but are not a byte transfer either.
+        tool.detail = None;
+        tool.set_items(32, 48);
+        assert_eq!(tool.transfer_bytes(start), None);
+        assert_eq!(tool.transfer_detail(start), "32/48");
     }
 
     #[test]

--- a/src/ui/tty_install_progress.rs
+++ b/src/ui/tty_install_progress.rs
@@ -147,18 +147,22 @@ fn refresh(state: &State, header: &Arc<ProgressJob>, rows: &Rows, now: Instant) 
             "prefix",
             &console::pad_str(&tool.prefix, width, console::Alignment::Left, None).to_string(),
         );
-        if let Some(waiting) = tool.waiting_message() {
+        let Some(started) = tool.started else {
+            // A held tool names what it is behind; once that drains it is only
+            // waiting for a slot, and the row must not keep the stale reason.
+            let waiting = tool
+                .waiting_message()
+                .unwrap_or_else(|| "queued".to_string());
             job.prop("left", &style::edim(waiting).to_string());
             job.prop("right", "");
             continue;
-        }
-        let Some(started) = tool.started else {
-            continue;
         };
         let mut left = tool.message.clone();
-        let detail = tool.transfer_detail(now);
-        if !detail.is_empty() && columns >= DETAIL_MIN_COLUMNS {
-            left.push_str(&format!("  {detail}"));
+        // Bytes only: detail and item counts have their own child row.
+        if let Some(bytes) = tool.transfer_bytes(now)
+            && columns >= DETAIL_MIN_COLUMNS
+        {
+            left.push_str(&format!("  {bytes}"));
         }
         job.prop("left", &left);
         let mut right = String::new();

--- a/src/ui/tty_install_progress.rs
+++ b/src/ui/tty_install_progress.rs
@@ -38,6 +38,8 @@ const OSC_SCALE: usize = 10_000;
 struct Layout {
     version: bool,
     byline: bool,
+    /// The header's aggregate transfer rate.
+    rate: bool,
     header_bar: usize,
     row_bar: bool,
     bytes: bool,
@@ -50,18 +52,25 @@ impl Layout {
         const HEADER_FIXED: usize = 4 + 2 + 2 + 36;
         const BYLINE_WIDTH: usize = " by @jdx".len();
         // The byline is the last thing the header gives up: it goes only when
-        // even a ten-cell bar would not fit beside it.
+        // even a ten-cell bar would not fit beside it. Below that the bar stays
+        // at ten — cells freed by a dropped byline or rate are not handed back,
+        // so a shrinking terminal never sees the bar grow — and the aggregate
+        // rate leaves the status once the ten cells no longer fit with it.
         let byline = columns >= HEADER_FIXED + BYLINE_WIDTH + MIN_HEADER_BAR_WIDTH;
+        let rate = columns >= HEADER_FIXED + MIN_HEADER_BAR_WIDTH;
         let version = columns >= HEADER_FIXED + BYLINE_WIDTH + HEADER_BAR_WIDTH + 1 + version_width;
-        let header_bar = columns
-            .saturating_sub(HEADER_FIXED + if byline { BYLINE_WIDTH } else { 0 })
-            .clamp(MIN_HEADER_BAR_WIDTH, HEADER_BAR_WIDTH);
+        let header_bar = if byline {
+            (columns - HEADER_FIXED - BYLINE_WIDTH).clamp(MIN_HEADER_BAR_WIDTH, HEADER_BAR_WIDTH)
+        } else {
+            MIN_HEADER_BAR_WIDTH
+        };
         // What a row has after its prefix: the phase, then the optional cells,
         // then the elapsed time and the spinner.
         let free = columns.saturating_sub(prefix_width);
         Self {
             version,
             byline,
+            rate,
             header_bar,
             row_bar: free >= 46,
             bytes: free >= 70,
@@ -203,7 +212,9 @@ fn refresh(state: &State, header: &Arc<ProgressJob>, rows: &Rows, now: Instant) 
     header.prop("byline", &byline_text(layout.byline));
     header.prop("bar", &state.bar_only(layout.header_bar));
     let mut status = state.count_label();
-    if let Some(rate) = state.aggregate_rate(now) {
+    if layout.rate
+        && let Some(rate) = state.aggregate_rate(now)
+    {
         status.push_str(&format!(" · {}/s", format_bytes(rate.round() as u64)));
     }
     let queued = state.queued_count();
@@ -489,6 +500,7 @@ mod tests {
             Layout {
                 version: true,
                 byline: true,
+                rate: true,
                 header_bar: HEADER_BAR_WIDTH,
                 row_bar: true,
                 bytes: true,
@@ -512,6 +524,16 @@ mod tests {
         assert!(!at(70).version && at(70).byline && at(70).header_bar == 18);
         assert!(!at(62).version && at(62).byline && at(62).header_bar == MIN_HEADER_BAR_WIDTH);
         assert!(!at(52).version && !at(52).byline && at(52).header_bar == MIN_HEADER_BAR_WIDTH);
+        // Below that the rate leaves the status too, so the ten-cell bar and
+        // the longest remaining status ("5/7 · 2 queued · 3.0s") fit in 40 —
+        // and the bar never grows back as the terminal shrinks.
+        assert!(at(54).rate && !at(52).rate);
+        assert_eq!(at(40).header_bar, MIN_HEADER_BAR_WIDTH);
+        let mut previous = HEADER_BAR_WIDTH;
+        for columns in (30..140).rev() {
+            assert!(at(columns).header_bar <= previous, "bar grew at {columns}");
+            previous = at(columns).header_bar;
+        }
     }
 
     #[test]

--- a/src/ui/tty_install_progress.rs
+++ b/src/ui/tty_install_progress.rs
@@ -1,0 +1,396 @@
+//! Live install progress for an interactive terminal.
+//!
+//! The live region is small on purpose: a header with the install-wide bar and
+//! one row per tool that is actually doing something. Finished tools leave the
+//! region as permanent lines above it — the same lines CI gets — so scrollback
+//! is the record and the screen never fills with rows that are done.
+//!
+//! Everything shown here comes from the shared [`State`]; clx is only asked to
+//! paint prop strings and animate a spinner.
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use clx::progress::{ProgressJob, ProgressJobBuilder, ProgressJobDoneBehavior, ProgressStatus};
+
+use super::install_progress::{InstallProgress, ToolProgress};
+use super::progress_report::{ProgressIcon, SingleReport};
+use super::style;
+use super::text_install_progress::{State, Tool, elapsed, filled_cells, first_line, format_bytes};
+use crate::cli::version::VERSION_PLAIN;
+
+/// Redraw cadence for elapsed times and rates. clx animates the spinner on its
+/// own; this only needs to keep the numbers from looking stuck.
+const REFRESH: Duration = Duration::from_millis(250);
+const HEADER_BAR_WIDTH: usize = 24;
+const ROW_BAR_WIDTH: usize = 10;
+/// Fine enough that a 24-cell bar never jumps more than one cell per update,
+/// and the terminal's OSC progress indicator moves in percent.
+const OSC_SCALE: usize = 10_000;
+
+/// Columns below which the artifact name, then the transfer detail, are
+/// dropped so the bar and the elapsed time keep their place.
+const ARTIFACT_MIN_COLUMNS: usize = 110;
+const DETAIL_MIN_COLUMNS: usize = 80;
+
+struct Rows {
+    /// One entry per tool, present while the tool has a row on screen.
+    jobs: Vec<Option<Arc<ProgressJob>>>,
+    /// Sub-progress rows (an embedded package manager's counter), keyed the same way.
+    children: Vec<Option<Arc<ProgressJob>>>,
+}
+
+pub(crate) struct TtyInstallProgress {
+    state: Arc<Mutex<State>>,
+    header: Arc<ProgressJob>,
+    rows: Arc<Mutex<Rows>>,
+    stop: mpsc::Sender<()>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl TtyInstallProgress {
+    pub(super) fn new(state: State) -> Self {
+        let count = state.tools.len();
+        let mise_text = format!("{}", style::emagenta("mise").bold());
+        let version_text = format!("{}", style::edim(&*VERSION_PLAIN));
+        let header = ProgressJobBuilder::new()
+            .body("{{ mise }} {{ version }}  {{ bar }}  {{ status }}")
+            .prop("mise", &mise_text)
+            .prop("version", &version_text)
+            .prop("bar", &state.bar_only(HEADER_BAR_WIDTH))
+            .prop("status", &format!("0/{count}"))
+            .progress_total(OSC_SCALE)
+            .progress_current(0)
+            // Finishing removes the header; the summary line above it is the
+            // record, and a second copy of the bar would only repeat it.
+            .on_done(ProgressJobDoneBehavior::Hide)
+            .start();
+        let rows = Arc::new(Mutex::new(Rows {
+            jobs: vec![None; count],
+            children: vec![None; count],
+        }));
+        let state = Arc::new(Mutex::new(state));
+        let (stop, rx) = mpsc::channel();
+        let thread = {
+            let state = state.clone();
+            let header = header.clone();
+            let rows = rows.clone();
+            thread::spawn(move || {
+                while rx.recv_timeout(REFRESH) == Err(mpsc::RecvTimeoutError::Timeout) {
+                    let state = state.lock().unwrap();
+                    let rows = rows.lock().unwrap();
+                    refresh(&state, &header, &rows, Instant::now());
+                }
+            })
+        };
+        Self {
+            state,
+            header,
+            rows,
+            stop,
+            thread: Some(thread),
+        }
+    }
+
+    fn stop(&mut self) {
+        let _ = self.stop.send(());
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+
+    fn row(&self, index: usize, tool: &Tool, status: ProgressStatus) -> Arc<ProgressJob> {
+        let mut rows = self.rows.lock().unwrap();
+        if let Some(job) = &rows.jobs[index] {
+            job.set_status(status);
+            return job.clone();
+        }
+        let job = self.header.add(
+            ProgressJobBuilder::new()
+                .body("{{ prefix }} {{ left | flex_fill }} {{ right }} {{ spinner(name=\"arc\") }}")
+                .prop("prefix", &tool.prefix)
+                .prop("left", "")
+                .prop("right", "")
+                .status(status)
+                .on_done(ProgressJobDoneBehavior::Hide)
+                .build(),
+        );
+        rows.jobs[index] = Some(job.clone());
+        job
+    }
+}
+
+/// Repaint every prop from the model. Cheap enough to run several times a
+/// second: it formats a handful of short strings and clx coalesces redraws.
+fn refresh(state: &State, header: &Arc<ProgressJob>, rows: &Rows, now: Instant) {
+    let columns = console::Term::stderr().size().1 as usize;
+    let (progress, _) = state.progress();
+    header.progress_current(((progress * OSC_SCALE as f64).round() as usize).min(OSC_SCALE));
+    header.prop("bar", &state.bar_only(HEADER_BAR_WIDTH));
+    let mut status = state.count_label();
+    if let Some(rate) = state.aggregate_rate(now) {
+        status.push_str(&format!(" · {}/s", format_bytes(rate.round() as u64)));
+    }
+    let queued = state.queued_count();
+    if queued > 0 {
+        status.push_str(&format!(" · {queued} queued"));
+    }
+    status.push_str(&format!(" · {}", elapsed(state.started, now)));
+    header.prop("status", &status);
+
+    let width = state.width();
+    for (index, tool) in state.tools.iter().enumerate() {
+        let Some(job) = rows.jobs.get(index).and_then(|j| j.as_ref()) else {
+            continue;
+        };
+        job.prop(
+            "prefix",
+            &console::pad_str(&tool.prefix, width, console::Alignment::Left, None).to_string(),
+        );
+        if let Some(waiting) = tool.waiting_message() {
+            job.prop("left", &style::edim(waiting).to_string());
+            job.prop("right", "");
+            continue;
+        }
+        let Some(started) = tool.started else {
+            continue;
+        };
+        let mut left = tool.message.clone();
+        let detail = tool.transfer_detail(now);
+        if !detail.is_empty() && columns >= DETAIL_MIN_COLUMNS {
+            left.push_str(&format!("  {detail}"));
+        }
+        job.prop("left", &left);
+        let mut right = String::new();
+        if !tool.weights.is_empty() {
+            let filled = filled_cells(tool.fraction, ROW_BAR_WIDTH, tool.outcome.is_some());
+            right.push_str(&format!(
+                "{}{}  ",
+                style::ecyan("█".repeat(filled)),
+                style::edim("░".repeat(ROW_BAR_WIDTH - filled))
+            ));
+        }
+        right.push_str(&elapsed(started, now));
+        if let Some(artifact) = &tool.artifact
+            && columns >= ARTIFACT_MIN_COLUMNS
+        {
+            right.push_str(&format!("  {}", style::edim(artifact)));
+        }
+        job.prop("right", &right);
+    }
+}
+
+impl InstallProgress for TtyInstallProgress {
+    fn start_tool(&self, key: &str) -> Option<Box<dyn ToolProgress>> {
+        let index = self.state.lock().unwrap().start_tool(key)?;
+        {
+            let state = self.state.lock().unwrap();
+            self.row(index, &state.tools[index], ProgressStatus::Running);
+        }
+        Some(Box::new(TtyToolProgress {
+            state: self.state.clone(),
+            header: self.header.clone(),
+            rows: self.rows.clone(),
+            index,
+        }))
+    }
+
+    fn set_waiting(&self, key: &str, dependencies: Vec<String>) {
+        let mut state = self.state.lock().unwrap();
+        state.set_waiting(key, dependencies);
+        if let Some(index) = state.index_of(key)
+            && state.tools[index].waiting_message().is_some()
+        {
+            // A held tool gets a row so the wait is visible, paused rather than
+            // spinning: nothing is happening to it yet.
+            self.row(index, &state.tools[index], ProgressStatus::Pending);
+        }
+    }
+
+    fn finish(&mut self, failures: Vec<(String, String)>) {
+        self.stop();
+        let mut state = self.state.lock().unwrap();
+        let now = Instant::now();
+        let lines = state.fail_unstarted(failures, now);
+        let mut rows = self.rows.lock().unwrap();
+        let Rows { jobs, children } = &mut *rows;
+        for job in jobs.iter_mut().chain(children.iter_mut()) {
+            if let Some(job) = job.take() {
+                job.remove();
+            }
+        }
+        for line in lines {
+            self.header.println(&line);
+        }
+        // One last repaint so the header the summary lands under reads 3/3
+        // with a full bar, not whatever the last tick happened to catch.
+        refresh(&state, &self.header, &rows, now);
+        let icon = if state.count(super::text_install_progress::Outcome::Failed) > 0 {
+            ProgressIcon::Error
+        } else {
+            ProgressIcon::Success
+        };
+        self.header
+            .println(&format!("{icon} {}", state.summary_text(now)));
+        self.header.progress_current(OSC_SCALE);
+        self.header.set_status(ProgressStatus::Done);
+    }
+}
+
+impl Drop for TtyInstallProgress {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct TtyToolProgress {
+    state: Arc<Mutex<State>>,
+    header: Arc<ProgressJob>,
+    rows: Arc<Mutex<Rows>>,
+    index: usize,
+}
+
+impl std::fmt::Debug for TtyToolProgress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TtyToolProgress")
+            .field("index", &self.index)
+            .finish()
+    }
+}
+
+impl TtyToolProgress {
+    fn with_tool(&self, f: impl FnOnce(&mut Tool)) {
+        f(&mut self.state.lock().unwrap().tools[self.index]);
+    }
+
+    fn job(&self) -> Option<Arc<ProgressJob>> {
+        self.rows.lock().unwrap().jobs[self.index].clone()
+    }
+
+    /// Sub-progress gets its own indented row under the tool, so a package
+    /// manager's count does not fight the tool's phase for the same cell.
+    fn sync_child(&self) {
+        let detail = {
+            let state = self.state.lock().unwrap();
+            let tool = &state.tools[self.index];
+            tool.transfer
+                .is_none()
+                .then(|| tool.detail.clone())
+                .flatten()
+        };
+        let mut rows = self.rows.lock().unwrap();
+        match (detail, rows.children[self.index].clone()) {
+            (Some(detail), Some(child)) => child.prop("detail", &detail),
+            (Some(detail), None) => {
+                if let Some(parent) = rows.jobs[self.index].clone() {
+                    let child = parent.add(
+                        ProgressJobBuilder::new()
+                            .body("  {{ arrow }} {{ detail }}")
+                            .prop("arrow", &style::edim("↳").to_string())
+                            .prop("detail", &detail)
+                            .on_done(ProgressJobDoneBehavior::Hide)
+                            .build(),
+                    );
+                    rows.children[self.index] = Some(child);
+                }
+            }
+            (None, Some(child)) => {
+                child.remove();
+                rows.children[self.index] = None;
+            }
+            (None, None) => {}
+        }
+    }
+}
+
+impl ToolProgress for TtyToolProgress {
+    fn set_prefix(&self, prefix: String) {
+        self.with_tool(|tool| tool.prefix = prefix.clone());
+        if let Some(job) = self.job() {
+            job.prop("prefix", &prefix);
+        }
+    }
+
+    fn complete(&self, error: Option<&str>) {
+        let line = {
+            let mut state = self.state.lock().unwrap();
+            let outcome = state.tools[self.index].outcome_for(error);
+            if let Some(error) = error {
+                state.tools[self.index].message = first_line(error);
+            }
+            state.finish_tool(self.index, outcome, Instant::now())
+        };
+        let Some(line) = line else {
+            return;
+        };
+        // The permanent line goes above the live region; the row leaves it.
+        let mut rows = self.rows.lock().unwrap();
+        if let Some(child) = rows.children[self.index].take() {
+            child.remove();
+        }
+        if let Some(job) = rows.jobs[self.index].take() {
+            job.remove();
+        }
+        drop(rows);
+        self.header.println(&line);
+    }
+
+    fn reporter(&self) -> Box<dyn SingleReport> {
+        Box::new(self.clone())
+    }
+}
+
+impl SingleReport for TtyToolProgress {
+    fn set_message(&self, message: String) {
+        self.with_tool(|tool| tool.apply_message(message));
+    }
+
+    fn set_detail(&self, detail: String) {
+        self.with_tool(|tool| tool.set_detail(detail));
+        self.sync_child();
+    }
+
+    fn println(&self, message: String) {
+        let prefix = self.state.lock().unwrap().tools[self.index].prefix.clone();
+        for line in message.lines() {
+            self.header.println(&format!("{prefix} {line}"));
+        }
+    }
+
+    fn start_operations(&self, count: usize) {
+        self.with_tool(|tool| tool.start_operations(&vec![1.0; count.max(1)]));
+    }
+
+    fn start_operations_weighted(&self, weights: &[f64]) {
+        self.with_tool(|tool| tool.start_operations(weights));
+    }
+
+    fn next_operation(&self) {
+        self.with_tool(|tool| tool.next_operation());
+        self.sync_child();
+    }
+
+    fn set_length(&self, length: u64) {
+        self.with_tool(|tool| tool.set_length(length));
+        self.sync_child();
+    }
+
+    fn set_position(&self, position: u64) {
+        self.with_tool(|tool| tool.set_position(position));
+    }
+
+    fn inc(&self, delta: u64) {
+        self.with_tool(|tool| tool.inc(delta));
+    }
+
+    fn abandon(&self) {
+        if let Some(job) = self.job() {
+            job.set_status(ProgressStatus::Hide);
+        }
+    }
+
+    fn finish_with_icon(&self, _message: String, icon: ProgressIcon) {
+        self.with_tool(|tool| tool.set_skipped(matches!(icon, ProgressIcon::Skipped)));
+    }
+}

--- a/src/ui/tty_install_progress.rs
+++ b/src/ui/tty_install_progress.rs
@@ -37,6 +37,7 @@ const OSC_SCALE: usize = 10_000;
 #[derive(Debug, PartialEq)]
 struct Layout {
     version: bool,
+    byline: bool,
     header_bar: usize,
     row_bar: bool,
     bytes: bool,
@@ -47,15 +48,20 @@ impl Layout {
     fn fit(columns: usize, prefix_width: usize, version_width: usize) -> Self {
         // `mise`, the gaps, and a status as long as "5/7 · 12.3 MB/s · 2 queued · 3.0s".
         const HEADER_FIXED: usize = 4 + 2 + 2 + 36;
-        let version = columns >= HEADER_FIXED + HEADER_BAR_WIDTH + 1 + version_width;
+        const BYLINE_WIDTH: usize = " by @jdx".len();
+        // The byline is the last thing the header gives up: it goes only when
+        // even a ten-cell bar would not fit beside it.
+        let byline = columns >= HEADER_FIXED + BYLINE_WIDTH + MIN_HEADER_BAR_WIDTH;
+        let version = columns >= HEADER_FIXED + BYLINE_WIDTH + HEADER_BAR_WIDTH + 1 + version_width;
         let header_bar = columns
-            .saturating_sub(HEADER_FIXED)
+            .saturating_sub(HEADER_FIXED + if byline { BYLINE_WIDTH } else { 0 })
             .clamp(MIN_HEADER_BAR_WIDTH, HEADER_BAR_WIDTH);
         // What a row has after its prefix: the phase, then the optional cells,
         // then the elapsed time and the spinner.
         let free = columns.saturating_sub(prefix_width);
         Self {
             version,
+            byline,
             header_bar,
             row_bar: free >= 46,
             bytes: free >= 70,
@@ -77,6 +83,7 @@ pub(crate) struct TtyInstallProgress {
     rows: Arc<Mutex<Rows>>,
     stop: mpsc::Sender<()>,
     thread: Option<JoinHandle<()>>,
+    finished: bool,
 }
 
 impl TtyInstallProgress {
@@ -90,9 +97,10 @@ impl TtyInstallProgress {
             console::measure_text_width(&VERSION_PLAIN),
         );
         let header = ProgressJobBuilder::new()
-            .body("{{ mise }}{{ version }}  {{ bar }}  {{ status }}")
+            .body("{{ mise }}{{ version }}{{ byline }}  {{ bar }}  {{ status }}")
             .prop("mise", &mise_text)
             .prop("version", &version_text(layout.version))
+            .prop("byline", &byline_text(layout.byline))
             .prop("bar", &state.bar_only(layout.header_bar))
             .prop("status", &format!("0/{count}"))
             .progress_total(OSC_SCALE)
@@ -125,6 +133,7 @@ impl TtyInstallProgress {
             rows,
             stop,
             thread: Some(thread),
+            finished: false,
         }
     }
 
@@ -170,6 +179,15 @@ fn version_text(shown: bool) -> String {
     }
 }
 
+/// `mise VERSION by @jdx`, as the header always read.
+fn byline_text(shown: bool) -> String {
+    if shown {
+        format!(" {}", style::edim("by @jdx"))
+    } else {
+        String::new()
+    }
+}
+
 /// Repaint every prop from the model. Cheap enough to run several times a
 /// second: it formats a handful of short strings and clx coalesces redraws.
 fn refresh(state: &State, header: &Arc<ProgressJob>, rows: &Rows, now: Instant) {
@@ -182,6 +200,7 @@ fn refresh(state: &State, header: &Arc<ProgressJob>, rows: &Rows, now: Instant) 
     let (progress, _) = state.progress();
     header.progress_current(((progress * OSC_SCALE as f64).round() as usize).min(OSC_SCALE));
     header.prop("version", &version_text(layout.version));
+    header.prop("byline", &byline_text(layout.byline));
     header.prop("bar", &state.bar_only(layout.header_bar));
     let mut status = state.count_label();
     if let Some(rate) = state.aggregate_rate(now) {
@@ -267,6 +286,7 @@ impl InstallProgress for TtyInstallProgress {
     }
 
     fn finish(&mut self, failures: Vec<(String, String)>) {
+        self.finished = true;
         self.stop();
         let mut state = self.state.lock().unwrap();
         let now = Instant::now();
@@ -298,6 +318,11 @@ impl InstallProgress for TtyInstallProgress {
 
 impl Drop for TtyInstallProgress {
     fn drop(&mut self) {
+        // A session dropped on an error path still closes its live region and
+        // leaves its summary; otherwise the header sits there under the error.
+        if !self.finished {
+            InstallProgress::finish(self, vec![]);
+        }
         self.stop();
     }
 }
@@ -463,6 +488,7 @@ mod tests {
             layout,
             Layout {
                 version: true,
+                byline: true,
                 header_bar: HEADER_BAR_WIDTH,
                 row_bar: true,
                 bytes: true,
@@ -479,14 +505,13 @@ mod tests {
         assert!(!Layout::fit(80, 12, 8).bytes);
         assert!(Layout::fit(80, 12, 8).row_bar);
         assert!(!Layout::fit(52, 12, 8).row_bar);
-        // The header drops the version before it shrinks the bar, and the
-        // bar never shrinks past ten cells.
-        assert!(Layout::fit(52, 12, 8).header_bar >= MIN_HEADER_BAR_WIDTH);
-        assert_eq!(Layout::fit(52, 12, 8).header_bar, MIN_HEADER_BAR_WIDTH);
-        assert!(!Layout::fit(52, 12, 8).version);
-        assert_eq!(Layout::fit(70, 12, 8).header_bar, HEADER_BAR_WIDTH);
-        assert!(!Layout::fit(70, 12, 8).version);
-        assert!(Layout::fit(78, 12, 8).version);
+        // The header drops the version first, then bar cells down to ten, and
+        // only then the byline.
+        let at = |columns| Layout::fit(columns, 12, 8);
+        assert!(at(90).version && at(90).byline && at(90).header_bar == HEADER_BAR_WIDTH);
+        assert!(!at(70).version && at(70).byline && at(70).header_bar == 18);
+        assert!(!at(62).version && at(62).byline && at(62).header_bar == MIN_HEADER_BAR_WIDTH);
+        assert!(!at(52).version && !at(52).byline && at(52).header_bar == MIN_HEADER_BAR_WIDTH);
     }
 
     #[test]

--- a/src/ui/tty_install_progress.rs
+++ b/src/ui/tty_install_progress.rs
@@ -351,6 +351,11 @@ impl SingleReport for TtyToolProgress {
         self.sync_child();
     }
 
+    fn set_items(&self, done: u64, total: u64) {
+        self.with_tool(|tool| tool.set_items(done, total));
+        self.sync_child();
+    }
+
     fn println(&self, message: String) {
         let prefix = self.state.lock().unwrap().tools[self.index].prefix.clone();
         for line in message.lines() {

--- a/src/ui/tty_install_progress.rs
+++ b/src/ui/tty_install_progress.rs
@@ -23,15 +23,46 @@ use crate::cli::version::VERSION_PLAIN;
 /// own; this only needs to keep the numbers from looking stuck.
 const REFRESH: Duration = Duration::from_millis(250);
 const HEADER_BAR_WIDTH: usize = 24;
+const MIN_HEADER_BAR_WIDTH: usize = 10;
 const ROW_BAR_WIDTH: usize = 10;
 /// Fine enough that a 24-cell bar never jumps more than one cell per update,
 /// and the terminal's OSC progress indicator moves in percent.
 const OSC_SCALE: usize = 10_000;
 
-/// Columns below which the artifact name, then the transfer detail, are
-/// dropped so the bar and the elapsed time keep their place.
-const ARTIFACT_MIN_COLUMNS: usize = 110;
-const DETAIL_MIN_COLUMNS: usize = 80;
+/// What fits on one line at this terminal width. Decided from the two widths
+/// that hold still during an install — the terminal and the prefix column — so
+/// a row does not gain and lose its bar as its message changes. Each cell goes
+/// in order of how much it says: the artifact name first, then the transfer
+/// figures, then the row bar; the header gives up its version, then bar cells.
+#[derive(Debug, PartialEq)]
+struct Layout {
+    version: bool,
+    header_bar: usize,
+    row_bar: bool,
+    bytes: bool,
+    artifact: bool,
+}
+
+impl Layout {
+    fn fit(columns: usize, prefix_width: usize, version_width: usize) -> Self {
+        // `mise`, the gaps, and a status as long as "5/7 · 12.3 MB/s · 2 queued · 3.0s".
+        const HEADER_FIXED: usize = 4 + 2 + 2 + 36;
+        let version = columns >= HEADER_FIXED + HEADER_BAR_WIDTH + 1 + version_width;
+        let header_bar = columns
+            .saturating_sub(HEADER_FIXED)
+            .clamp(MIN_HEADER_BAR_WIDTH, HEADER_BAR_WIDTH);
+        // What a row has after its prefix: the phase, then the optional cells,
+        // then the elapsed time and the spinner.
+        let free = columns.saturating_sub(prefix_width);
+        Self {
+            version,
+            header_bar,
+            row_bar: free >= 46,
+            bytes: free >= 70,
+            artifact: free >= 100,
+        }
+    }
+}
 
 struct Rows {
     /// One entry per tool, present while the tool has a row on screen.
@@ -52,12 +83,17 @@ impl TtyInstallProgress {
     pub(super) fn new(state: State) -> Self {
         let count = state.tools.len();
         let mise_text = format!("{}", style::emagenta("mise").bold());
-        let version_text = format!("{}", style::edim(&*VERSION_PLAIN));
+        // The first frame is drawn before the first refresh; it fits too.
+        let layout = Layout::fit(
+            columns(),
+            state.width(),
+            console::measure_text_width(&VERSION_PLAIN),
+        );
         let header = ProgressJobBuilder::new()
-            .body("{{ mise }} {{ version }}  {{ bar }}  {{ status }}")
+            .body("{{ mise }}{{ version }}  {{ bar }}  {{ status }}")
             .prop("mise", &mise_text)
-            .prop("version", &version_text)
-            .prop("bar", &state.bar_only(HEADER_BAR_WIDTH))
+            .prop("version", &version_text(layout.version))
+            .prop("bar", &state.bar_only(layout.header_bar))
             .prop("status", &format!("0/{count}"))
             .progress_total(OSC_SCALE)
             .progress_current(0)
@@ -120,13 +156,33 @@ impl TtyInstallProgress {
     }
 }
 
+fn columns() -> usize {
+    console::Term::stderr().size().1 as usize
+}
+
+/// The version with its separating space, or nothing: the header body has no
+/// gap of its own to leave behind when the version goes.
+fn version_text(shown: bool) -> String {
+    if shown {
+        format!(" {}", style::edim(&*VERSION_PLAIN))
+    } else {
+        String::new()
+    }
+}
+
 /// Repaint every prop from the model. Cheap enough to run several times a
 /// second: it formats a handful of short strings and clx coalesces redraws.
 fn refresh(state: &State, header: &Arc<ProgressJob>, rows: &Rows, now: Instant) {
-    let columns = console::Term::stderr().size().1 as usize;
+    let width = state.width();
+    let layout = Layout::fit(
+        columns(),
+        width,
+        console::measure_text_width(&VERSION_PLAIN),
+    );
     let (progress, _) = state.progress();
     header.progress_current(((progress * OSC_SCALE as f64).round() as usize).min(OSC_SCALE));
-    header.prop("bar", &state.bar_only(HEADER_BAR_WIDTH));
+    header.prop("version", &version_text(layout.version));
+    header.prop("bar", &state.bar_only(layout.header_bar));
     let mut status = state.count_label();
     if let Some(rate) = state.aggregate_rate(now) {
         status.push_str(&format!(" · {}/s", format_bytes(rate.round() as u64)));
@@ -138,7 +194,6 @@ fn refresh(state: &State, header: &Arc<ProgressJob>, rows: &Rows, now: Instant) 
     status.push_str(&format!(" · {}", elapsed(state.started, now)));
     header.prop("status", &status);
 
-    let width = state.width();
     for (index, tool) in state.tools.iter().enumerate() {
         let Some(job) = rows.jobs.get(index).and_then(|j| j.as_ref()) else {
             continue;
@@ -160,13 +215,13 @@ fn refresh(state: &State, header: &Arc<ProgressJob>, rows: &Rows, now: Instant) 
         let mut left = tool.message.clone();
         // Bytes only: detail and item counts have their own child row.
         if let Some(bytes) = tool.transfer_bytes(now)
-            && columns >= DETAIL_MIN_COLUMNS
+            && layout.bytes
         {
             left.push_str(&format!("  {bytes}"));
         }
         job.prop("left", &left);
         let mut right = String::new();
-        if !tool.weights.is_empty() {
+        if !tool.weights.is_empty() && layout.row_bar {
             let filled = filled_cells(tool.fraction, ROW_BAR_WIDTH, tool.outcome.is_some());
             right.push_str(&format!(
                 "{}{}  ",
@@ -176,7 +231,7 @@ fn refresh(state: &State, header: &Arc<ProgressJob>, rows: &Rows, now: Instant) 
         }
         right.push_str(&elapsed(started, now));
         if let Some(artifact) = &tool.artifact
-            && columns >= ARTIFACT_MIN_COLUMNS
+            && layout.artifact
         {
             right.push_str(&format!("  {}", style::edim(artifact)));
         }
@@ -215,7 +270,7 @@ impl InstallProgress for TtyInstallProgress {
         self.stop();
         let mut state = self.state.lock().unwrap();
         let now = Instant::now();
-        let lines = state.fail_unstarted(failures, now);
+        let lines = state.fail_unstarted(failures, now, Some(columns()));
         let mut rows = self.rows.lock().unwrap();
         let Rows { jobs, children } = &mut *rows;
         for job in jobs.iter_mut().chain(children.iter_mut()) {
@@ -275,14 +330,7 @@ impl TtyToolProgress {
     /// Sub-progress gets its own indented row under the tool, so a package
     /// manager's count does not fight the tool's phase for the same cell.
     fn sync_child(&self) {
-        let detail = {
-            let state = self.state.lock().unwrap();
-            let tool = &state.tools[self.index];
-            tool.transfer
-                .is_none()
-                .then(|| tool.detail.clone())
-                .flatten()
-        };
+        let detail = self.state.lock().unwrap().tools[self.index].child_detail(Instant::now());
         let mut rows = self.rows.lock().unwrap();
         match (detail, rows.children[self.index].clone()) {
             (Some(detail), Some(child)) => child.prop("detail", &detail),
@@ -323,7 +371,7 @@ impl ToolProgress for TtyToolProgress {
             if let Some(error) = error {
                 state.tools[self.index].message = first_line(error);
             }
-            state.finish_tool(self.index, outcome, Instant::now())
+            state.finish_tool(self.index, outcome, Instant::now(), Some(columns()))
         };
         let Some(line) = line else {
             return;
@@ -401,5 +449,50 @@ impl SingleReport for TtyToolProgress {
 
     fn finish_with_icon(&self, _message: String, icon: ProgressIcon) {
         self.with_tool(|tool| tool.set_skipped(matches!(icon, ProgressIcon::Skipped)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_wide_terminal_shows_everything() {
+        let layout = Layout::fit(140, 27, 8);
+        assert_eq!(
+            layout,
+            Layout {
+                version: true,
+                header_bar: HEADER_BAR_WIDTH,
+                row_bar: true,
+                bytes: true,
+                artifact: true,
+            }
+        );
+    }
+
+    #[test]
+    fn a_narrow_terminal_gives_up_the_cells_that_say_the_least_first() {
+        // The artifact goes first, then the transfer figures, then the row bar.
+        assert!(!Layout::fit(100, 12, 8).artifact);
+        assert!(Layout::fit(100, 12, 8).bytes);
+        assert!(!Layout::fit(80, 12, 8).bytes);
+        assert!(Layout::fit(80, 12, 8).row_bar);
+        assert!(!Layout::fit(52, 12, 8).row_bar);
+        // The header drops the version before it shrinks the bar, and the
+        // bar never shrinks past ten cells.
+        assert!(Layout::fit(52, 12, 8).header_bar >= MIN_HEADER_BAR_WIDTH);
+        assert_eq!(Layout::fit(52, 12, 8).header_bar, MIN_HEADER_BAR_WIDTH);
+        assert!(!Layout::fit(52, 12, 8).version);
+        assert_eq!(Layout::fit(70, 12, 8).header_bar, HEADER_BAR_WIDTH);
+        assert!(!Layout::fit(70, 12, 8).version);
+        assert!(Layout::fit(78, 12, 8).version);
+    }
+
+    #[test]
+    fn a_long_prefix_column_costs_the_rows_their_optional_cells() {
+        // The same terminal: a short prefix keeps the bytes, a long one loses them.
+        assert!(Layout::fit(90, 12, 8).bytes);
+        assert!(!Layout::fit(90, 27, 8).bytes);
     }
 }


### PR DESCRIPTION
#12902 added the append-only reporter for non-TTY output. This PR brings the interactive terminal up to the same information, from the same model.

## Before

```
mise 2026.9.1 by @jdx                                              [12/22]
node@24.20.0     download node-v24.20.0-linux-x64.tar.xz  42 MB 3s ████████░░░░ ◜
python@3.12.3    extract cpython-3.12.3+20240415-x86_64-unknown-linux-gnu-install_only.tar.gz ◝
hk@1.56.1        installed
gh@2.98.0        installed
... (18 more finished rows)
```

The header count was the only aggregate — no bar behind it (its `progress_total` only drove OSC). Rows carried raw phase text with the filename, so a long artifact name pushed the byte bar off a narrow terminal. Finished rows piled up (clx's default `Keep`), so on a 22-tool install the live work scrolled out of view. Rows never said how long a tool had been going, and the per-tool bar restarted for every operation — download to 100%, then checksum 0→100% again.

## After

```
  ✓ hk@1.56.1            1.5s  hk-v1.56.1-linux-x64.tar.xz
  ✓ gh@2.98.0            2.1s  gh_2.98.0_linux_amd64.tar.gz
  ✓ bun@1.4.0            0.3s · cached  bun-linux-x64.zip
mise 2026.9.1  ████████████░░░░░░░░░░░░  12/22 · 18.4 MB/s · 3 queued · 6.2s
node@24.20.0    downloading  42.1/78.3 MB · 12.4 MB/s       ██████░░░░  1.8s  node-v24.20.0-linux-x64.tar.xz ◜
python@3.12.3   extracting                                  █████████░  3.1s  cpython-3.12.3+….tar.gz ◝
npm:prettier    fetching                                    ████░░░░░░  1.0s ◞
  ↳ 32/48 pkgs · 4.2 MiB
markdownlint    waiting for node@24.20.0                                       ⏸
```

**One model, two renderers.** The `State`/`Tool` model from #12902 — weighted fractions, transfer rate, artifact, reuse — is now the only source of truth. Handler logic moved from the text reporter onto `Tool` (`apply_message`, `set_length`, …); the text and TTY renderers are thin. `InstallProgress`/`ToolProgress` traits let the scheduler not care which one it has. The two modes cannot drift apart because they read the same numbers.

**Finished tools become permanent lines, not live rows.** `job.println` writes above the live region and the row leaves it. The terminal shows the *same* `✓ hk@1.56.1  1.5s` lines CI does; the live region holds only the header and what's active. Scrollback is the record.

**Header carries the install-wide bar** — fractional, failures in red, whole-tool count, aggregate transfer rate, queued count, elapsed — and still drives the terminal's OSC progress indicator. It opens `mise VERSION by @jdx`, as the header always did; the append-only reporter's first line reads `mise by @jdx – installing 7 tools`.

**Rows: phase, detail, one bar, elapsed, artifact.** The row bar is the tool's weighted fraction, filled once across download → verify → extract instead of restarting per operation. Elapsed is per tool. The artifact is dimmed at the end so its length can't disturb the columns.

**"waiting for node@24.20.0."** The scheduler already knew a tool was held behind a dependency; it just had no row. `DepsGraph::dependencies_of` exposes what a queued tool is behind, the row is paused (⏸) rather than spinning, and the list drains as dependencies finish. Tools merely waiting for a job slot are a count in the header. The append-only reporter gets the same rows.

**Embedded npm installs drive the bar through aube's own phases.** The npm backend declares aube's bar weights (`0.15 / 0.80 / 0.05`) through `install_operation_weights`, so the plan — including the removal a forced reinstall puts in front — is set once by the install wrapper. `AubeProgress` walks through it: it reads the phase off each snapshot (resolving → fetching → linking → complete), advances an operation per change, and drops a snapshot from a phase already left rather than repainting the row with its counts. The package tally goes through a new `SingleReport::set_items(done, total)`, so it fills the bar as whole items with no size or rate attached. Before aube reports any phase it vets the package (typosquat, download-count and age gates) and resolves the requested version against the registry; that stretch is now labelled `checking package` instead of sitting on the wrapper's `installing`. Unit-tested with a recording reporter.

**Sub-progress gets a child row.** New `SingleReport::set_detail` carries secondary text that isn't a byte transfer — the npm path reports its phase as the message and `32/48 pkgs · 4.2 MiB` as detail. The TTY shows it as an indented `↳` row under the tool, and the row also carries a bare item tally when a backend drives the bar with counts but sends no detail; the parent row shows byte transfers only, so nothing is printed twice. The classic `ProgressReport` folds phase and detail back into its single status cell, and `VerboseReport` prints one line per change, so single-line reporters lose nothing.

**`prune`, `uninstall` and `upgrade`'s old versions use the same session.** They kept one `remove <path>` row per version in the live region — a prune of ~500 versions is what produced the megabytes of repeated rows in an agent terminal, and even a well-behaved terminal scrolled the active work away. Each finished removal is now one permanent `✓ tool@version  0.3s` line, the header reads `removing N tools`, the summary `removed N tools in …`, and `uninstall`/`remove <dir>` phases are normalized to `removing` (the path was what wrapped). `prune` asks its confirmations first, then removes, so a prompt never lands inside the live region. A removal row reads `removing` from the start (there is nothing to resolve), and a session dropped on an error path still closes with its summary, so the header never sits under the error. Dry runs keep their per-line report. The verbose operation counter is capped, so aube's `Complete` step no longer prints `[4/3]`. e2e-covered.

**The live region fits the terminal it is in.** A layout is decided from the two widths that hold still during an install — the terminal and the prefix column — so a row never gains and loses cells as its message changes. Cells go in order of how little they say: the artifact name first, then the transfer figures, then the row bar; the header gives up its version, then bar cells down to ten, then (below 62 columns) the byline and (below 54) the aggregate rate; the bar never grows back as the terminal shrinks. Completion lines drop the artifact when the full line would wrap (a wrapped record reads as two). At 52 columns a seven-tool install renders without a single wrapped line; at 120 everything is shown. The append-only reporter has no width to read (`COLUMNS` is not exported to pipes or CI), so it is narrow by construction instead.

**Append-only rows are narrow by construction.** A pipe or CI log has no width to detect (`COLUMNS` is a shell variable, almost never exported), so the snapshot rows are shaped to fit instead: fixed cells first — prefix, phase, elapsed — then the one variable cell, the transfer detail, unpadded and last. The artifact name is no longer repeated on every 3-second row (it wrapped mid-name in the GitHub log viewer); the completion line still records it once, in full, where it can be searched. `verify`/`verify size` phases are normalized like `download`/`extract`.

**Agent terminals get the append-only output.** The Claude Code terminal (and other AI-agent terminals) is a PTY that *records* frames instead of redrawing them: `isatty` says yes, but cursor-up and erase-line are logged, so an animated display becomes one copy of the whole live region per tick — a `mise prune` of ~500 versions produced megabytes of repeated rows. `CLAUDECODE=1` / `AI_AGENT` now select the same append-only reporter CI gets. e2e-covered.

**An install waiting on another mise's lock says so.** `lock_tool_version` already had a contention callback; the row now reads `waiting for install lock` only when actually contended, instead of sitting in "resolving". Unit-tested.

**A closing line.** `✓ installed 22 tools in 10.8s — 22 tools` (or `✗ 21 installed · 1 failed`), then the live region is gone.

`--verbose`, `--raw`, `--quiet` and `--dry-run` are unchanged; the classic per-tool `ProgressReport` remains for callers outside an install session.

## Tests

- Model tests in `text_install_progress.rs` cover the shared behavior (including the new waiting rows and non-transfer detail).
- `e2e/cli/test_install_tty_progress` drives `mise install` through a PTY with `CI` unset and a real window size: cursor controls prove a redraw, header bar and count present, phase and hook output visible, completion line and summary in the record, old `[cur/total]` header gone, `already installed` on re-run, a 50-column run with no line over 50 cells and a bar no wider than ten, an agent terminal (`CLAUDECODE=1`) getting the append-only output, `--verbose` unchanged.
- `e2e/cli/test_install_text_progress` covers the append-only reporter, including a removal session.
- Layout thresholds are unit-tested in `tty_install_progress.rs`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5-1; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, user-visible changes to install/uninstall/progress across many code paths, though behavior for `--verbose`/`--raw`/`--quiet` is preserved and coverage is extensive.
> 
> **Overview**
> Interactive installs now use a **shared progress model** with two renderers: a **live TTY region** (header bar, active rows, permanent completion lines in scrollback) and the existing **append-only** reporter for CI, captured stderr, and agent PTYs (`CLAUDECODE` / `AI_AGENT`).
> 
> The scheduler goes through **`InstallProgress` / `ToolProgress`**, surfaces **dependency waits** and **install-lock contention**, and reuses the same session for **`uninstall` / `prune` / upgrade removals** (one line per tool, no path spam). **NPM embedded installs** map aube phases to weighted operations via new **`set_detail` / `set_items`** on `SingleReport`.
> 
> E2E adds PTY install coverage and extends text-progress tests for uninstall output; layout and aube mapping have unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb0312ee2d28d4f0fb16ece79458d676b2379850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer interactive installation progress with live updates, dependency waiting states, transfer details, and improved narrow-terminal layouts.
  - Added consistent progress reporting for uninstalling, pruning, and removing older tool versions.
  - Added append-only progress output for CI and AI-agent terminals.

- **Bug Fixes**
  - Improved progress accuracy across installation phases, including package checks, item counts, completion status, and concurrent installations.
  - Prevented progress displays from overflowing narrow terminals or showing stale updates.

- **Tests**
  - Expanded end-to-end coverage for interactive, verbose, narrow-terminal, CI, uninstall, and removal progress scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->