### PR TITLE
feat(install): show resolver hosts and retry progress

### DIFF
--- a/e2e/cli/test_install_resolve_progress
+++ b/e2e/cli/test_install_resolve_progress
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+# Hold the version-list response until progress is visible. A progress line
+# printed after the lookup finishes cannot satisfy this test.
+export CI=0 MISE_COLOR=0 MISE_DEBUG=0 MISE_TRACE=0 MISE_LOG_LEVEL=info
+export MISE_FORCE_PROGRESS=0 MISE_HTTP_RETRIES=0
+
+python3 - <<'PY'
+import errno
+import fcntl
+import http.server
+import io
+import os
+from pathlib import Path
+import pty
+import re
+import select
+import struct
+import subprocess
+import tarfile
+import termios
+import threading
+import time
+
+archive = io.BytesIO()
+with tarfile.open(fileobj=archive, mode="w:gz") as tar:
+    content = b"#!/bin/sh\necho resolved\n"
+    entry = tarfile.TarInfo("bin/resolved")
+    entry.mode = 0o755
+    entry.size = len(content)
+    tar.addfile(entry, io.BytesIO(content))
+release = threading.Event()
+requested = threading.Event()
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path.startswith("/versions"):
+            requested.set()
+            if not release.wait(15):
+                self.send_error(504)
+                return
+            body = b"1.0.0\n2.0.0\n"
+        else:
+            body = archive.getvalue()
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+port = server.server_address[1]
+
+def run_case(name, args, tty=False):
+    release.clear()
+    requested.clear()
+    Path("mise.toml").write_text(f'''[tools."http:{name}"]
+version = "1"
+url = "http://127.0.0.1:{port}/tool-{{{{version}}}}.tar.gz"
+version_list_url = "http://127.0.0.1:{port}/versions-{name}"
+''')
+    env = dict(os.environ, MISE_CACHE_DIR=str(Path(f"cache-{name}").absolute()))
+    if tty:
+        master, slave = pty.openpty()
+        fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 160, 0, 0))
+        proc = subprocess.Popen(["mise", *args], stdout=subprocess.DEVNULL, stderr=slave, env=env)
+        os.close(slave)
+        fd = master
+    else:
+        proc = subprocess.Popen(["mise", *args], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=env)
+        fd = proc.stderr.fileno()
+    output = bytearray()
+    saw_wait = False
+    deadline = time.monotonic() + 30
+    try:
+        while time.monotonic() < deadline:
+            if not select.select([fd], [], [], 0.1)[0]:
+                continue
+            try:
+                chunk = os.read(fd, 65536)
+            except OSError as error:
+                if error.errno == errno.EIO:
+                    break
+                raise
+            if not chunk:
+                break
+            output.extend(chunk)
+            plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", output.decode(errors="replace"))
+            if "fetching from 127.0.0.1" in plain and requested.is_set():
+                assert "by @jdx" in plain, plain
+                assert "resolving" in plain, plain
+                assert "0/1" in plain, plain
+                saw_wait = True
+                release.set()
+        assert saw_wait, output.decode(errors="replace")
+        assert proc.wait(timeout=5) == 0, output.decode(errors="replace")
+    finally:
+        release.set()
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+        if tty:
+            os.close(master)
+        else:
+            proc.stderr.close()
+    plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", output.decode(errors="replace"))
+    assert "installed 1 tool" in plain, plain
+    return env
+
+try:
+    env = run_case("resolve-bare", ["install"])
+    # The early session closes satisfied requests without counting them as installs.
+    result = subprocess.run(["mise", "install"], env=env, capture_output=True, text=True, timeout=15)
+    assert result.returncode == 0, result.stderr
+    assert "1 already installed" in result.stderr, result.stderr
+    run_case("resolve-explicit", ["install", "http:resolve-explicit"])
+    run_case("resolve-tty", ["install"], tty=True)
+    run_case("resolve-upgrade", ["upgrade"])
+finally:
+    release.set()
+    server.shutdown()
+    server.server_close()
+PY

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -15,6 +15,10 @@ use crate::toolset::{
     InstallOptions, ResolveOptions, ToolRequest, ToolRequestSet, ToolSource, ToolVersionOptions,
     Toolset, ensure_compatible_install_requests, tool_env_vars,
 };
+use crate::ui::install_progress::install_progress;
+use crate::ui::multi_progress_report::MultiProgressReport;
+use crate::ui::progress_report::ProgressIcon;
+use crate::ui::resolve_progress;
 use crate::{config, env, exit, hooks};
 use eyre::Result;
 use itertools::Itertools;
@@ -560,22 +564,58 @@ impl Install {
             // This will error with a proper message like "tool not found in mise tool registry"
             ba.backend()?;
         }
+        let opts = self.install_opts()?;
+        let install_candidates = install_candidates
+            .into_iter()
+            .filter(|tr| self.include_lazy || tr.options().lazy != Some(true))
+            .collect_vec();
+        let mut progress = (!opts.raw && !opts.dry_run)
+            .then(|| {
+                install_progress(
+                    &MultiProgressReport::get(),
+                    install_candidates
+                        .iter()
+                        .map(|tr| (tr.to_string(), tr.to_string())),
+                )
+            })
+            .flatten();
         let requests = measure!("fetching install runtimes", {
             if self.force {
                 install_candidates
             } else {
-                trs.missing_tools_for_install(&install_config)
-                    .await
-                    .into_iter()
-                    .cloned()
-                    .collect_vec()
+                let mut missing = vec![];
+                for tr in install_candidates {
+                    let reporter = progress
+                        .as_ref()
+                        .and_then(|p| p.start_tool(&tr.to_string()));
+                    let satisfied = resolve_progress::scope(
+                        reporter.as_ref().map(|p| p.reporter()),
+                        tr.is_install_satisfied(&install_config),
+                    )
+                    .await;
+                    if satisfied {
+                        if let Some(reporter) = reporter {
+                            reporter.finish_with_icon(
+                                "already installed".into(),
+                                ProgressIcon::Skipped,
+                            );
+                            reporter.complete(None);
+                        }
+                    } else {
+                        if let Some(progress) = &progress {
+                            progress.queue_tool(&tr.to_string());
+                        }
+                        missing.push(tr);
+                    }
+                }
+                missing
             }
-        })
-        .into_iter()
-        .filter(|request| self.include_lazy || request.options().lazy != Some(true))
-        .collect_vec();
+        });
         let has_work = !requests.is_empty();
         let (versions, install_error) = if requests.is_empty() {
+            if let Some(mut progress) = progress.take() {
+                progress.finish(vec![]);
+            }
             measure!("run_postinstall_hook", {
                 info!("all tools are installed");
                 // Nothing was installed, but postinstall still runs (idempotent
@@ -610,8 +650,13 @@ impl Install {
             let mut ts = Toolset::from(trs.clone());
             measure!("install_all_versions", {
                 split_install_result(
-                    ts.install_all_versions(&mut install_config, requests, &self.install_opts()?)
-                        .await,
+                    ts.install_all_versions_with_progress(
+                        &mut install_config,
+                        requests,
+                        &opts,
+                        progress,
+                    )
+                    .await,
                 )
             })
         };

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -195,6 +195,7 @@ impl Upgrade {
             crate::lockfile::migrate_monorepo_lockfiles(&config, false)?;
         }
         let ts = ToolsetBuilder::new()
+            .with_resolution_progress(!self.is_dry_run() && !self.raw)
             .with_args(&self.tool)
             .with_scope(self.scope())
             .build(&config)
@@ -225,7 +226,14 @@ impl Upgrade {
             None
         };
         let mut outdated = ts
-            .list_outdated_versions_filtered(&config, self.bump, &opts, filter_tools, exclude_tools)
+            .list_outdated_versions_with_progress(
+                &config,
+                self.bump,
+                &opts,
+                filter_tools,
+                exclude_tools,
+                !self.is_dry_run() && !self.raw,
+            )
             .await;
         self.warn_if_newer_versions_hidden_by_minimum_release_age(
             &config,

--- a/src/http.rs
+++ b/src/http.rs
@@ -1286,6 +1286,7 @@ impl Client {
         options: SendOnceOptions,
     ) -> Result<Response> {
         let original_url = url.clone();
+        crate::ui::resolve_progress::fetching(&url);
         #[cfg(unix)]
         if matches!(url.host_str(), Some("github.com" | "api.github.com"))
             && let Some(socket) = std::env::var_os("MISE_GITHUB_RELAY_SOCKET")
@@ -1300,6 +1301,7 @@ impl Client {
             return options.check_response(response);
         }
         apply_url_replacements(&mut url);
+        crate::ui::resolve_progress::fetching(&url);
         let host_key = http_host_key(&url);
         if Settings::get().prefer_offline()
             && let Some(host) = &host_key
@@ -2108,6 +2110,7 @@ where
                     err,
                     delay
                 );
+                crate::ui::resolve_progress::retrying(url, attempt + 1, delay);
                 tokio::time::sleep(delay).await;
                 attempt += 1;
             }
@@ -3294,8 +3297,27 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         let url: Url = format!("http://127.0.0.1:{port}/").parse().unwrap();
         let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
 
-        let resp = client.get_async(url).await.unwrap();
+        let reporter = crate::ui::resolve_progress::tests::RecordingReport::default();
+        let resp = crate::ui::resolve_progress::scope(
+            Some(Box::new(reporter.clone())),
+            client.get_async(url),
+        )
+        .await
+        .unwrap();
 
+        let messages = reporter.0.lock().unwrap();
+        assert!(
+            messages
+                .first()
+                .unwrap()
+                .contains("fetching from 127.0.0.1")
+        );
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.contains("retrying 127.0.0.1 (attempt 2"))
+        );
+        assert!(messages.last().unwrap().contains("fetching from 127.0.0.1"));
         assert!(resp.status().is_success());
         // Two connections: the aborted one, then the retry that succeeded.
         assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 2);

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -30,6 +30,7 @@ pub(crate) struct ToolsetBuilder {
     scope: ConfigScope,
     default_to_latest: bool,
     resolve_options: ResolveOptions,
+    resolution_progress: bool,
     config_files: Option<ConfigMap>,
 }
 
@@ -50,6 +51,11 @@ impl ToolsetBuilder {
 
     pub(crate) fn with_scope(mut self, scope: ConfigScope) -> Self {
         self.scope = scope;
+        self
+    }
+
+    pub(crate) fn with_resolution_progress(mut self, enabled: bool) -> Self {
+        self.resolution_progress = enabled;
         self
     }
 
@@ -79,7 +85,7 @@ impl ToolsetBuilder {
         });
         measure!("toolset_builder::build::resolve", {
             if let Err(err) = toolset
-                .resolve_with_opts(config, &self.resolve_options)
+                .resolve_with_progress(config, &self.resolve_options, self.resolution_progress)
                 .await
             {
                 if Error::is_argument_err(&err) || Error::is_required_channel_resolution_err(&err) {

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -133,26 +133,61 @@ impl Toolset {
         config: &Arc<Config>,
         opts: &ResolveOptions,
     ) -> eyre::Result<()> {
+        self.resolve_with_progress(config, opts, false).await
+    }
+
+    pub(crate) async fn resolve_with_progress(
+        &mut self,
+        config: &Arc<Config>,
+        opts: &ResolveOptions,
+        show_progress: bool,
+    ) -> eyre::Result<()> {
+        let mut progress = show_progress
+            .then(|| {
+                crate::ui::install_progress::resolution_progress(
+                    self.versions
+                        .keys()
+                        .map(|ba| (ba.short.clone(), ba.short.clone())),
+                )
+            })
+            .flatten();
         self.list_missing_plugins();
         let versions = self
             .versions
             .clone()
             .into_iter()
-            .map(|(ba, tvl)| (config.clone(), ba, tvl.clone(), opts.clone()))
+            .map(|(ba, tvl)| {
+                let reporter = progress.as_ref().and_then(|p| p.start_tool(&ba.short));
+                (config.clone(), ba, tvl, opts.clone(), reporter)
+            })
             .collect::<Vec<_>>();
-        let tvls = parallel::parallel(versions, |(config, ba, mut tvl, opts)| async move {
-            if let Err(err) = tvl.resolve(&config, &opts).await {
-                if Error::is_required_channel_resolution_err(&err) {
-                    return Err(err);
+        let tvls = parallel::parallel(
+            versions,
+            |(config, ba, mut tvl, opts, reporter)| async move {
+                let result = crate::ui::resolve_progress::scope(
+                    reporter.as_ref().map(|p| p.reporter()),
+                    tvl.resolve(&config, &opts),
+                )
+                .await;
+                if let Some(reporter) = reporter {
+                    reporter.complete(result.as_ref().err().map(|e| e.to_string()).as_deref());
                 }
-                // warn_once: a command may resolve the same toolset more than
-                // once, and repeating an identical failure adds no information.
-                warn_once!("Failed to resolve tool version list for {ba}: {err}");
-            }
-            Ok((ba, tvl))
-        })
+                if let Err(err) = result {
+                    if Error::is_required_channel_resolution_err(&err) {
+                        return Err(err);
+                    }
+                    // warn_once: a command may resolve the same toolset more than
+                    // once, and repeating an identical failure adds no information.
+                    warn_once!("Failed to resolve tool version list for {ba}: {err}");
+                }
+                Ok((ba, tvl))
+            },
+        )
         .await?;
         self.versions = tvls.into_iter().collect();
+        if let Some(progress) = progress.as_mut() {
+            progress.finish(vec![]);
+        }
         Ok(())
     }
 
@@ -374,6 +409,26 @@ impl Toolset {
         filter_tools: Option<&[crate::cli::args::ToolArg]>,
         exclude_tools: Option<&[crate::cli::args::ToolArg]>,
     ) -> Vec<OutdatedInfo> {
+        self.list_outdated_versions_with_progress(
+            config,
+            bump,
+            opts,
+            filter_tools,
+            exclude_tools,
+            false,
+        )
+        .await
+    }
+
+    pub(crate) async fn list_outdated_versions_with_progress(
+        &self,
+        config: &Arc<Config>,
+        bump: bool,
+        opts: &ResolveOptions,
+        filter_tools: Option<&[crate::cli::args::ToolArg]>,
+        exclude_tools: Option<&[crate::cli::args::ToolArg]>,
+        show_progress: bool,
+    ) -> Vec<OutdatedInfo> {
         let list_versions = if opts.inactive {
             match self.list_all_versions(config).await {
                 Ok(v) => v,
@@ -404,43 +459,80 @@ impl Toolset {
             })
             .map(|(t, tv)| (config.clone(), t, tv, bump, opts.clone()))
             .collect::<Vec<_>>();
-        let outdated = parallel::parallel(versions, |(config, t, tv, bump, opts)| async move {
-            let mut outdated = HashSet::new();
-            match t.outdated_info(&config, &tv, bump, &opts).await {
-                Ok(Some(oi)) => {
-                    outdated.insert(oi);
+        let mut progress = show_progress
+            .then(|| {
+                crate::ui::install_progress::resolution_progress(
+                    versions
+                        .iter()
+                        .map(|(_, _, tv, _, _)| (tv.to_string(), tv.to_string())),
+                )
+            })
+            .flatten();
+        let versions = versions
+            .into_iter()
+            .map(|args| {
+                let reporter = progress
+                    .as_ref()
+                    .and_then(|p| p.start_tool(&args.2.to_string()));
+                (args, reporter)
+            })
+            .collect();
+        let outdated = parallel::parallel(
+            versions,
+            |((config, t, tv, bump, opts), reporter)| async move {
+                let mut error = None;
+                let result = crate::ui::resolve_progress::scope(
+                    reporter.as_ref().map(|p| p.reporter()),
+                    async {
+                        let mut outdated = HashSet::new();
+                        match t.outdated_info(&config, &tv, bump, &opts).await {
+                            Ok(Some(oi)) => {
+                                outdated.insert(oi);
+                            }
+                            Ok(None) => {}
+                            Err(e) => {
+                                error = Some(e.to_string());
+                                warn!("Error getting outdated info for {tv}: {e:#}");
+                            }
+                        }
+                        if let Some(symlink_path) = t.symlink_path(&tv)
+                            && !is_runtime_symlink(&symlink_path)
+                        {
+                            trace!("skipping symlinked version {tv}");
+                            // do not consider symlinked versions to be outdated
+                            return Ok(outdated);
+                        }
+                        if t.uses_custom_outdated_info() {
+                            return Ok(outdated);
+                        }
+                        match OutdatedInfo::resolve(&config, tv.clone(), bump, &opts).await {
+                            Ok(Some(oi)) => {
+                                outdated.insert(oi);
+                            }
+                            Ok(None) => {}
+                            Err(e) => {
+                                error = Some(e.to_string());
+                                warn!("Error creating OutdatedInfo for {tv}: {e:#}");
+                            }
+                        }
+                        Ok(outdated)
+                    },
+                )
+                .await;
+                if let Some(reporter) = reporter {
+                    reporter.complete(error.as_deref());
                 }
-                Ok(None) => {}
-                Err(e) => {
-                    warn!("Error getting outdated info for {tv}: {e:#}");
-                }
-            }
-            if let Some(symlink_path) = t.symlink_path(&tv)
-                && !is_runtime_symlink(&symlink_path)
-            {
-                trace!("skipping symlinked version {tv}");
-                // do not consider symlinked versions to be outdated
-                return Ok(outdated);
-            }
-            if t.uses_custom_outdated_info() {
-                return Ok(outdated);
-            }
-            match OutdatedInfo::resolve(&config, tv.clone(), bump, &opts).await {
-                Ok(Some(oi)) => {
-                    outdated.insert(oi);
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    warn!("Error creating OutdatedInfo for {tv}: {e:#}");
-                }
-            }
-            Ok(outdated)
-        })
+                result
+            },
+        )
         .await
         .unwrap_or_else(|e| {
             warn!("Error in parallel outdated version check: {e:#}");
             vec![]
         });
+        if let Some(progress) = progress.as_mut() {
+            progress.finish(vec![]);
+        }
         outdated.into_iter().flatten().collect()
     }
 

--- a/src/toolset/tool_request_set.rs
+++ b/src/toolset/tool_request_set.rs
@@ -47,20 +47,6 @@ impl ToolRequestSet {
     //         .collect()
     // }
 
-    /// Lists requests whose complete backend-managed install state is unsatisfied.
-    pub(crate) async fn missing_tools_for_install(
-        &self,
-        config: &Arc<Config>,
-    ) -> Vec<&ToolRequest> {
-        let mut tools = vec![];
-        for tr in self.tools.values().flatten() {
-            if tr.is_os_supported() && !tr.is_install_satisfied(config).await {
-                tools.push(tr);
-            }
-        }
-        tools
-    }
-
     pub(crate) fn list_tools(&self) -> Vec<&Arc<BackendArg>> {
         self.tools.keys().collect()
     }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -255,8 +255,19 @@ impl Toolset {
     pub async fn install_all_versions(
         &mut self,
         config: &mut Arc<Config>,
+        versions: Vec<ToolRequest>,
+        opts: &InstallOptions,
+    ) -> Result<Vec<ToolVersion>> {
+        self.install_all_versions_with_progress(config, versions, opts, None)
+            .await
+    }
+
+    pub(crate) async fn install_all_versions_with_progress(
+        &mut self,
+        config: &mut Arc<Config>,
         mut versions: Vec<ToolRequest>,
         opts: &InstallOptions,
+        progress: Option<Box<dyn InstallProgress>>,
     ) -> Result<Vec<ToolVersion>> {
         if versions.is_empty() {
             // Configured plugins are still installed when no tools need work
@@ -280,14 +291,16 @@ impl Toolset {
         } else {
             opts.reason.clone()
         };
-        let mut install_progress = (!opts.raw && !opts.dry_run)
-            .then(|| {
-                install_progress(
-                    &mpr,
-                    versions.iter().map(|tr| (tool_key(tr), tr.to_string())),
-                )
-            })
-            .flatten();
+        let mut install_progress = progress.or_else(|| {
+            (!opts.raw && !opts.dry_run)
+                .then(|| {
+                    install_progress(
+                        &mpr,
+                        versions.iter().map(|tr| (tool_key(tr), tr.to_string())),
+                    )
+                })
+                .flatten()
+        });
         if install_progress.is_none() {
             mpr.init_footer(opts.dry_run, &footer_reason, versions.len());
         }
@@ -706,7 +719,11 @@ impl Toolset {
         if should_refresh_remote_versions(tr, &pre_resolve_backend, &resolve_options) {
             resolve_options.refresh_remote_versions = true;
         }
-        let mut tv = tr.resolve(config, &resolve_options).await?;
+        let mut tv = crate::ui::resolve_progress::scope(
+            tool_progress.map(|p| p.reporter()),
+            tr.resolve(config, &resolve_options),
+        )
+        .await?;
         let backend = tv.backend()?;
         backend::ensure_backend_enabled(&backend.get_type())?;
         if let Some(dir) = &opts.install_dir {

--- a/src/ui/install_progress.rs
+++ b/src/ui/install_progress.rs
@@ -31,6 +31,9 @@ pub(crate) trait InstallProgress: Send + Sync {
     /// panicking in the scheduler.
     fn start_tool(&self, key: &str) -> Option<Box<dyn ToolProgress>>;
 
+    /// Resolution found work to do; release the lookup row back to the scheduler.
+    fn queue_tool(&self, key: &str);
+
     /// A tool the scheduler is holding until these dependencies finish.
     fn set_waiting(&self, key: &str, dependencies: Vec<String>);
 
@@ -46,6 +49,13 @@ pub(crate) fn install_progress(
     tools: impl Iterator<Item = (String, String)>,
 ) -> Option<Box<dyn InstallProgress>> {
     progress_for(mpr, Action::Install, tools)
+}
+
+/// A separate lookup phase, used before upgrade knows which tools need work.
+pub(crate) fn resolution_progress(
+    tools: impl Iterator<Item = (String, String)>,
+) -> Option<Box<dyn InstallProgress>> {
+    progress_for(&MultiProgressReport::get(), Action::Resolve, tools)
 }
 
 /// The same session for `prune`, `uninstall` and `upgrade`'s old versions.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod install_progress;
 pub(crate) mod multi_progress_report;
 pub(crate) mod progress_report;
 pub(crate) mod prompt;
+pub(crate) mod resolve_progress;
 pub(crate) mod style;
 pub(crate) mod table;
 pub(crate) mod text_install_progress;

--- a/src/ui/resolve_progress.rs
+++ b/src/ui/resolve_progress.rs
@@ -1,0 +1,127 @@
+//! Network status belongs to the resolver future, not a thread or a global
+//! current tool. The scope ends before installation, so artifact downloads
+//! cannot overwrite install phases. Spawned resolver jobs enter their own scope.
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::progress_report::SingleReport;
+
+tokio::task_local! {
+    static REPORTER: Option<Arc<dyn SingleReport>>;
+}
+
+pub(crate) async fn scope<T>(
+    reporter: Option<Box<dyn SingleReport>>,
+    future: impl Future<Output = T>,
+) -> T {
+    let reporter = reporter.map(Arc::from);
+    REPORTER.scope(reporter, future).await
+}
+
+/// Only the hostname is displayed: URLs can contain credentials, signed query
+/// strings, and private repository paths. This describes the request, not its
+/// DNS/TCP/TLS phase (which reqwest does not expose here).
+pub(crate) fn fetching(url: &url::Url) {
+    update(|| {
+        format!(
+            "resolving · fetching from {}",
+            url.host_str().unwrap_or("remote")
+        )
+    });
+}
+
+pub(crate) fn retrying(url: &url::Url, attempt: usize, delay: Duration) {
+    update(|| {
+        format!(
+            "resolving · retrying {} (attempt {}, {:.1}s backoff)",
+            url.host_str().unwrap_or("remote"),
+            attempt,
+            delay.as_secs_f64(),
+        )
+    });
+}
+
+fn update(message: impl FnOnce() -> String) {
+    let _ = REPORTER.try_with(|reporter| {
+        if let Some(reporter) = reporter {
+            reporter.set_message(message());
+        }
+    });
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Clone, Debug, Default)]
+    pub(crate) struct RecordingReport(pub(crate) Arc<Mutex<Vec<String>>>);
+
+    impl SingleReport for RecordingReport {
+        fn set_message(&self, message: String) {
+            self.0.lock().unwrap().push(message);
+        }
+    }
+
+    #[tokio::test]
+    async fn interleaved_resolvers_keep_their_hosts_and_hide_url_secrets() {
+        let first = RecordingReport::default();
+        let second = RecordingReport::default();
+        let a = url::Url::parse("https://user:secret@one.example/private?token=secret").unwrap();
+        let b = url::Url::parse("https://two.example/versions").unwrap();
+        let barrier = tokio::sync::Barrier::new(2);
+        tokio::join!(
+            scope(Some(Box::new(first.clone())), async {
+                fetching(&a);
+                barrier.wait().await;
+                retrying(&a, 2, Duration::from_secs(1));
+            }),
+            scope(Some(Box::new(second.clone())), async {
+                fetching(&b);
+                barrier.wait().await;
+                fetching(&b);
+            }),
+        );
+        assert_eq!(
+            *first.0.lock().unwrap(),
+            vec![
+                "resolving · fetching from one.example",
+                "resolving · retrying one.example (attempt 2, 1.0s backoff)",
+            ]
+        );
+        assert_eq!(
+            *second.0.lock().unwrap(),
+            vec![
+                "resolving · fetching from two.example",
+                "resolving · fetching from two.example",
+            ]
+        );
+        // An artifact request after resolution cannot alter a completed lookup.
+        fetching(&a);
+        assert_eq!(first.0.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn cancellation_restores_the_enclosing_scope() {
+        let outer = RecordingReport::default();
+        let inner = RecordingReport::default();
+        let url = url::Url::parse("https://example.com/versions").unwrap();
+        scope(Some(Box::new(outer.clone())), async {
+            let lookup = scope(Some(Box::new(inner.clone())), async {
+                fetching(&url);
+                std::future::pending::<()>().await;
+            });
+            // Poll once and then drop the pending lookup, as a timeout would.
+            let mut lookup = Box::pin(lookup);
+            assert!(futures_util::poll!(&mut lookup).is_pending());
+            drop(lookup);
+            fetching(&url);
+        })
+        .await;
+        assert_eq!(inner.0.lock().unwrap().len(), 1);
+        assert_eq!(outer.0.lock().unwrap().len(), 1);
+        fetching(&url);
+        assert_eq!(outer.0.lock().unwrap().len(), 1);
+    }
+}

--- a/src/ui/text_install_progress.rs
+++ b/src/ui/text_install_progress.rs
@@ -405,6 +405,7 @@ fn format_bytes_in(bytes: u64, total: u64) -> String {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Action {
     Install,
+    Resolve,
     Remove,
 }
 
@@ -412,6 +413,7 @@ impl Action {
     pub(super) fn present(self) -> &'static str {
         match self {
             Action::Install => "installing",
+            Action::Resolve => "resolving",
             Action::Remove => "removing",
         }
     }
@@ -419,6 +421,7 @@ impl Action {
     pub(super) fn past(self) -> &'static str {
         match self {
             Action::Install => "installed",
+            Action::Resolve => "resolved",
             Action::Remove => "removed",
         }
     }
@@ -482,10 +485,17 @@ impl State {
         tool.started = Some(Instant::now());
         // A removal has nothing to resolve; its one phase is the verb itself.
         tool.message = match self.action {
-            Action::Install => "resolving".into(),
+            Action::Install | Action::Resolve => "resolving".into(),
             Action::Remove => "removing".into(),
         };
         Some(index)
+    }
+
+    pub(super) fn queue_tool(&mut self, key: &str) {
+        if let Some(index) = self.index_of(key) {
+            self.tools[index].started = None;
+            self.tools[index].message = "waiting to install".into();
+        }
     }
 
     pub(super) fn set_waiting(&mut self, key: &str, dependencies: Vec<String>) {
@@ -789,6 +799,10 @@ impl InstallProgress for TextInstallProgress {
         }))
     }
 
+    fn queue_tool(&self, key: &str) {
+        self.state.lock().unwrap().queue_tool(key);
+    }
+
     fn set_waiting(&self, key: &str, dependencies: Vec<String>) {
         self.state.lock().unwrap().set_waiting(key, dependencies);
     }
@@ -943,6 +957,22 @@ mod tests {
             started,
             resumed_at: 0,
         }
+    }
+
+    #[test]
+    fn resolved_request_returns_to_dependency_queue() {
+        let mut state = State::new([("node@22".into(), "node@22".into())].into_iter());
+        state.start_tool("node@22");
+        state.queue_tool("node@22");
+        state.set_waiting("node@22", vec!["dependency".into()]);
+        assert_eq!(
+            state.tools[0].waiting_message().as_deref(),
+            Some("waiting for dependency")
+        );
+        assert_eq!(state.complete_count(), 0);
+        state.start_tool("node@22");
+        assert!(state.tools[0].waiting_message().is_none());
+        assert_eq!(state.tools[0].message, "resolving");
     }
 
     #[test]

--- a/src/ui/tty_install_progress.rs
+++ b/src/ui/tty_install_progress.rs
@@ -284,6 +284,14 @@ impl InstallProgress for TtyInstallProgress {
         }))
     }
 
+    fn queue_tool(&self, key: &str) {
+        let mut state = self.state.lock().unwrap();
+        state.queue_tool(key);
+        if let Some(index) = state.index_of(key) {
+            self.row(index, &state.tools[index], ProgressStatus::Pending);
+        }
+    }
+
     fn set_waiting(&self, key: &str, dependencies: Vec<String>) {
         let mut state = self.state.lock().unwrap();
         state.set_waiting(key, dependencies);


### PR DESCRIPTION
A slow version-list fetch can leave `mise install` silent before its install session begins. Start the bare-install session before checking installed versions, then carry it into the scheduler. Requests already satisfied finish as already installed; requests needing work return to the dependency queue and acquire their resolved label during installation. `mise upgrade` gets a separate resolving phase while discovering updates.

Resolver-scoped HTTP status shows messages such as `resolving · fetching from nodejs.org` and retry attempt/backoff details. Async scopes keep parallel tools' status separate and end before artifact installation. Only hostnames are displayed, without URL credentials, paths, or query strings. Plugin subprocesses and clients outside mise's shared HTTP client retain generic resolving status; this does not identify the DNS/TCP/TLS phase or change timeouts, retries, caches, or scheduling.

Follow-up to #12906. Started from its final commit `fb0312ee2`, then rebased onto `main` after it merged. The merge and original base had identical trees, and the rebase preserved this change's tested tree.

## Validation

- 33 focused unit tests passed across both renderers, resolver-scope isolation/cancellation, and a real HTTP retry.
- Three e2e tests passed: `test_install_resolve_progress`, `test_install_text_progress`, and `test_install_tty_progress`. The new local server withholds its version list until the waiting host is visible, covering bare install, explicit install, upgrade, and a real PTY; it also checks already-installed completion.
- Scoped `hk run fix --safe --files0-from … --format json` passed: formatting, shellcheck, shfmt, and `cargo check --all-features`.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` passed.

A broader `ui::`-only unit invocation had 48 passes and four failures in untouched tests: `test_multi_progress_report` calls `backend::list` before its registry is initialized (`src/backend/mod.rs:510`), and three `progress_report` tests then encounter the poisoned mutex. The focused tests above avoid that initialization-order failure.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install/upgrade orchestration and HTTP reporting paths used during resolution, but behavior for retries, caches, and scheduling is intended to stay the same aside from UX.
> 
> **Overview**
> **`mise install` and `mise upgrade` now surface resolver activity** instead of staying quiet while version lists are fetched. A new `resolve_progress` layer uses async task-local scopes so parallel tools get separate status lines (hostname only—no credentials or paths) such as `resolving · fetching from …` and retry attempt/backoff text wired from the shared HTTP client.
> 
> **Install flow changes:** the multi-tool progress session starts *before* the “already installed?” pass. Each candidate runs satisfaction checks inside a resolver scope; satisfied tools finish as **already installed**, while tools that need work are **`queue_tool`**’d back into the install scheduler and reuse the same session via `install_all_versions_with_progress`. **`mise upgrade`** enables a dedicated **resolving** phase while building the toolset and listing outdated versions (`ToolsetBuilder::with_resolution_progress`, `list_outdated_versions_with_progress`).
> 
> Progress renderers gain an `Action::Resolve` and `queue_tool`; `missing_tools_for_install` is removed in favor of the inline install loop. An e2e script delays a local version-list response until resolver output is visible (bare install, explicit install, TTY, upgrade, and re-run “already installed”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d484913af0b09dc281be8999cee6e869e6756967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added progress indicators while installing and upgrading tools, including resolution status and per-tool completion.
  - Added network activity messages showing when sources are being fetched and retried.
  - Progress reporting is supported in both standard terminal and TTY displays.

- **Bug Fixes**
  - Progress output now accurately reflects tools waiting for installation and resolution results.

- **Tests**
  - Added end-to-end coverage for installation and upgrade progress output, including terminal and retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->