### PR TITLE
feat(core): add rust mr_boxington tool option and use flag

### DIFF
--- a/docs/cli/use.md
+++ b/docs/cli/use.md
@@ -70,6 +70,9 @@ an activated shell on its next prompt, or immediately in `mise exec` commands.
 - **`--remove <TOOL>`** — Remove the tool(s) from config file
 - **`-h --help`** — Print help
 - **`--postinstall <COMMAND>`** — Command to run after installing this tool
+- **`--tool-option <KEY=VALUE>`** — Set an option for this tool (repeat for multiple options).
+  Values use inline tool-option types; unquoted text is treated as a string.
+  Place these flags before the tool they apply to.
 
 ## Examples
 
@@ -95,6 +98,12 @@ associate a different postinstall command with each tool
 
 ```
 mise use --postinstall "setup-a" tool-a --postinstall "setup-b" tool-b
+```
+
+enable a Rust tool option while installing Rust and mbx
+
+```
+mise use --tool-option mr_boxington=true rust mr-boxington
 ```
 
 set the current version of node to 20.x in ~/.config/mise/config.toml will write the precise version (e.g.: 20.0.0)

--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -90,27 +90,11 @@ can change which override rustup sees.
 
 ## Share Cargo builds with Mr Boxington
 
-[Mr Boxington](https://mr-boxington.jdx.dev/) (`mbx`) is a Rust build cache and scheduler that makes
-compiler work reusable across projects, worktrees, and CI. If you regularly wait for the same dependencies to
-compile in a fresh checkout, or watch several Cargo builds compete for your laptop's resources, mbx is built
-for that workflow.
-
-- **Reuse work across checkouts.** A matching compilation from one project or worktree can satisfy another.
-  New worktrees can start with a warm cache instead of rebuilding every shared dependency.
-- **Keep parallel builds under control.** Terminal builds, editor checks, and coding agents share a CPU and
-  memory budget when routed through mbx. Identical compilations running at the same time share the work too.
-- **Spend less disk on build artifacts.** One shared, self-pruning store reuses compiler outputs across
-  checkouts. Managed target directories can be collected after their checkouts disappear.
-- **Carry the cache into CI.** Share cached artifacts with teammates and CI runners through GitHub Actions,
-  S3, or a compatible cache server. Local use needs no server or daemon to manage.
-
-You keep using `cargo build`, `cargo test`, and `cargo clippy`; Cargo still plans the build, and mbx restores
-matching compiler outputs or runs the compiler when needed. The first build warms the cache, and later builds
-with matching inputs can reuse it.
-
-See mbx's [build-cache explanation](https://mr-boxington.jdx.dev/how-it-works),
-[benchmarks](https://mr-boxington.jdx.dev/benchmarks), and
-[GitHub Actions guide](https://mr-boxington.jdx.dev/github-action) for more.
+[Mr Boxington](https://mr-boxington.jdx.dev/) (`mbx`) is a Rust build cache and scheduler.
+It reuses matching compilations across projects, worktrees, and CI, so a fresh checkout can benefit from
+work you've already built. Parallel Cargo commands share a CPU and memory budget, and the cache prunes itself.
+You keep using ordinary Cargo commands; no cache server is needed for local use.
+See the [benchmarks](https://mr-boxington.jdx.dev/benchmarks) for examples.
 
 Enable the `mr_boxington` tool option and install mbx as a separate tool:
 

--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -95,32 +95,49 @@ self-pruning compilation cache. A crate compiled in one worktree can be reused i
 commands share a CPU and memory budget instead of oversubscribing the machine. It can also share cached artifacts
 with teammates and CI runners through a cache server, S3, or GitHub Actions.
 
-Install `mbx` and configure mise's [`cargo` command wrapper](/dev-tools/shims.html#command-wrappers) to use it:
+Enable the `mr_boxington` tool option and install mbx as a separate tool:
+
+```sh
+mise use --tool-option mr_boxington=true rust mr-boxington
+```
+
+This writes the equivalent of:
 
 ```toml [mise.toml]
 [tools]
-rust = "latest"
+rust = { version = "latest", mr_boxington = true }
 mr-boxington = "latest"
-
-[wrappers.cargo]
-command = "mbx"
-env = { MBX_CARGO_SHIM_MODE = "1" }
 ```
 
-Run `mise reshim` after adding the wrapper. Existing commands and mise tasks can keep invoking `cargo` normally:
+Cargo commands run through mbx in `mise exec`, tasks, activated shells, and
+mise shims. No `mbx setup` or postinstall hook is needed. mbx uses its normal
+mise version selection and lockfile entry, independently of Rust.
 
-```toml [mise.toml]
-[tasks.build]
-run = "cargo build"
+```sh
+mise exec -- cargo build
 ```
 
-Within the mise environment, the wrapper transparently routes those commands through `mbx`. This also avoids
-rewriting every task as `mbx build`, and keeps the same tasks usable if the wrapper is later removed.
+Editors and coding agents must invoke mise's Cargo shim or use `mise exec`.
+Direct calls to rustup's Cargo proxy or a toolchain's Cargo binary bypass mise.
+
+An explicit `[wrappers.cargo]` configuration takes precedence over this option.
+The [generic command wrapper configuration](/dev-tools/shims.html#command-wrappers)
+remains available when Rust is managed outside mise.
 
 ## Tool Options
 
 The following [tool-options](/dev-tools/#tool-options) are available for the `rust` backend—these
 go in `[tools]` in `mise.toml`.
+
+### `mr_boxington`
+
+Set `mr_boxington = true` to wrap Cargo with Mr Boxington. Defaults to `false`.
+Requires `mr-boxington` in the active tool configuration; merely having `mbx` on
+PATH is not sufficient. Keep its version in a separate `[tools]` entry.
+
+The option applies to the first platform-supported Rust version in the selected
+configuration. Set it to `false` in a project's Rust entry to disable an inherited
+opt-in. An explicitly configured Cargo wrapper is unaffected.
 
 ### `install_env`
 

--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -120,6 +120,7 @@ mise exec -- cargo build
 
 Editors and coding agents must invoke mise's Cargo shim or use `mise exec`.
 Direct calls to rustup's Cargo proxy or a toolchain's Cargo binary bypass mise.
+Safe mode ignores the opt-in from project-scoped Rust entries.
 
 An explicit `[wrappers.cargo]` configuration takes precedence over this option.
 The [generic command wrapper configuration](/dev-tools/shims.html#command-wrappers)

--- a/docs/lang/rust.md
+++ b/docs/lang/rust.md
@@ -90,10 +90,27 @@ can change which override rustup sees.
 
 ## Share Cargo builds with Mr Boxington
 
-[Mr Boxington](https://mr-boxington.jdx.dev/) (`mbx`) gives every checkout on a machine one shared,
-self-pruning compilation cache. A crate compiled in one worktree can be reused in another, and concurrent Cargo
-commands share a CPU and memory budget instead of oversubscribing the machine. It can also share cached artifacts
-with teammates and CI runners through a cache server, S3, or GitHub Actions.
+[Mr Boxington](https://mr-boxington.jdx.dev/) (`mbx`) is a Rust build cache and scheduler that makes
+compiler work reusable across projects, worktrees, and CI. If you regularly wait for the same dependencies to
+compile in a fresh checkout, or watch several Cargo builds compete for your laptop's resources, mbx is built
+for that workflow.
+
+- **Reuse work across checkouts.** A matching compilation from one project or worktree can satisfy another.
+  New worktrees can start with a warm cache instead of rebuilding every shared dependency.
+- **Keep parallel builds under control.** Terminal builds, editor checks, and coding agents share a CPU and
+  memory budget when routed through mbx. Identical compilations running at the same time share the work too.
+- **Spend less disk on build artifacts.** One shared, self-pruning store reuses compiler outputs across
+  checkouts. Managed target directories can be collected after their checkouts disappear.
+- **Carry the cache into CI.** Share cached artifacts with teammates and CI runners through GitHub Actions,
+  S3, or a compatible cache server. Local use needs no server or daemon to manage.
+
+You keep using `cargo build`, `cargo test`, and `cargo clippy`; Cargo still plans the build, and mbx restores
+matching compiler outputs or runs the compiler when needed. The first build warms the cache, and later builds
+with matching inputs can reuse it.
+
+See mbx's [build-cache explanation](https://mr-boxington.jdx.dev/how-it-works),
+[benchmarks](https://mr-boxington.jdx.dev/benchmarks), and
+[GitHub Actions guide](https://mr-boxington.jdx.dev/github-action) for more.
 
 Enable the `mr_boxington` tool option and install mbx as a separate tool:
 

--- a/e2e/cli/test_use_tool_option
+++ b/e2e/cli/test_use_tool_option
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+mise use --tool-option enabled=true --tool-option count=2 --tool-option label=hello dummy@1.0.0
+assert_contains "cat mise.toml" 'enabled = "true"'
+assert_contains "cat mise.toml" 'count = "2"'
+assert_contains "cat mise.toml" 'label = "hello"'
+
+mise use --tool-option enabled=false dummy@1.0.0 --tool-option label=second tiny@2.0.0
+assert "mise config get tools.dummy.enabled" "false"
+assert "mise config get tools.tiny.label" "second"
+assert_fail "mise config get tools.tiny.enabled"
+assert "mise config get tools.dummy.count" "2"
+
+mise use --tool-option 'items=["one", "two"]' --postinstall 'touch installed' 'dummy[inline=yes]@2.0.0'
+assert_contains "cat mise.toml" 'items = ["one", "two"]'
+assert "mise config get tools.dummy.inline" "yes"
+assert "test -f installed" ""
+
+assert_fail_contains "mise use --tool-option missing dummy 2>&1" "expects KEY=VALUE"
+assert_fail_contains "mise use --tool-option '=value' dummy 2>&1" "non-empty key"
+assert_fail_contains "mise use --tool-option enabled=true --tool-option enabled=false dummy 2>&1" "specified more than once"
+assert_fail_contains "mise use --tool-option enabled=true 'dummy[enabled=false]' 2>&1" "inline enabled option"
+assert_fail_contains "mise use --postinstall one --tool-option postinstall=two dummy 2>&1" "specified more than once"
+assert_fail_contains "mise use --tool-option enabled=true 2>&1" "TOOL@VERSION"
+
+mise use --dry-run --tool-option enabled=true dummy@3.0.0
+assert "mise config get tools.dummy.version" "2.0.0"
+
+mkdir legacy
+(
+  cd legacy
+  printf 'dummy 1.0.0\n' >.tool-versions
+  mise use --tool-option enabled=true dummy@1.0.0
+  assert_contains "cat mise.toml" 'enabled = "true"'
+  assert "cat .tool-versions" "dummy 1.0.0"
+  assert_fail_contains "mise use --path .tool-versions --tool-option enabled=true dummy 2>&1" "--tool-option requires a TOML config file"
+)

--- a/e2e/cli/test_use_tool_option
+++ b/e2e/cli/test_use_tool_option
@@ -5,6 +5,12 @@ assert_contains "cat mise.toml" 'enabled = "true"'
 assert_contains "cat mise.toml" 'count = "2"'
 assert_contains "cat mise.toml" 'label = "hello"'
 
+# Versionless updates also preserve options from the existing inline table.
+mise use --tool-option label=updated dummy
+assert "mise config get tools.dummy.count" "2"
+assert "mise config get tools.dummy.enabled" "true"
+assert "mise config get tools.dummy.label" "updated"
+
 mise use --tool-option enabled=false dummy@1.0.0 --tool-option label=second tiny@2.0.0
 assert "mise config get tools.dummy.enabled" "false"
 assert "mise config get tools.tiny.label" "second"

--- a/e2e/core/test_rust_mr_boxington
+++ b/e2e/core/test_rust_mr_boxington
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+unset MISE_CARGO_HOME MISE_RUSTUP_HOME
+export MISE_OFFLINE=1
+
+CONFIG_CARGO_HOME="$PWD/config-cargo"
+CONFIG_RUSTUP_HOME="$PWD/config-rustup"
+mkdir -p "$CONFIG_CARGO_HOME/bin" "$CONFIG_RUSTUP_HOME"
+touch "$CONFIG_RUSTUP_HOME/settings.toml"
+
+cat >"$CONFIG_CARGO_HOME/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+echo "cargo:$RUSTUP_TOOLCHAIN:$*"
+EOF
+
+cat >"$CONFIG_CARGO_HOME/bin/rustc" <<'EOF'
+#!/usr/bin/env bash
+echo "rustc ${RUSTUP_TOOLCHAIN:-unknown}"
+EOF
+
+cat >"$CONFIG_CARGO_HOME/bin/rustup" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "$*" >>"$CARGO_HOME/rustup.log"
+
+case "$1 $2" in
+	"show profile")
+		echo minimal
+		;;
+	"component list")
+		echo rustfmt
+		;;
+	"toolchain install")
+		mkdir -p "$RUSTUP_HOME/toolchains/$3"
+		;;
+	"toolchain uninstall")
+		;;
+	*)
+		echo "unexpected rustup args: $*" >&2
+		exit 1
+		;;
+esac
+EOF
+
+chmod +x "$CONFIG_CARGO_HOME/bin/cargo" "$CONFIG_CARGO_HOME/bin/rustc" "$CONFIG_CARGO_HOME/bin/rustup"
+
+mkdir -p "$PWD/mbx/bin"
+cat >"$PWD/mbx/bin/mbx" <<'EOF'
+#!/usr/bin/env bash
+printf 'mbx:%s\n' "$MBX_CARGO_SHIM_MODE"
+exec cargo "$@"
+EOF
+chmod +x "$PWD/mbx/bin/mbx"
+
+cat >mise.toml <<EOF
+[env]
+MISE_CARGO_HOME = "$CONFIG_CARGO_HOME"
+MISE_RUSTUP_HOME = "$CONFIG_RUSTUP_HOME"
+[tools]
+rust = { version = "1.81.0", components = ["rustfmt"] }
+[tasks.check]
+run = "cargo check"
+[tasks.unwrapped]
+tools = { rust = { version = "1.81.0", mr_boxington = false } }
+run = "cargo check"
+EOF
+
+mise use --tool-option mr_boxington=true rust@1.81.0 "mr-boxington@path:$PWD/mbx"
+assert "mise config get tools.rust.mr_boxington" "true"
+assert_contains "cat mise.toml" 'mr_boxington = true'
+assert "mise exec -- cargo check" "mbx:1
+cargo:1.81.0:check"
+assert "mise run check 2>/dev/null" "mbx:1
+cargo:1.81.0:check"
+assert_contains "mise hook-env -s bash --force" "$MISE_DATA_DIR/command-wrappers/bin"
+assert "'$MISE_DATA_DIR/shims/cargo' check" "mbx:1
+cargo:1.81.0:check"
+(
+  eval "$(mise activate bash --shims)"
+  assert "cargo check" "mbx:1
+cargo:1.81.0:check"
+)
+
+assert "mise exec 'rust[mr_boxington=false]@1.81.0' -- cargo check" "cargo:1.81.0:check"
+assert "mise run unwrapped 2>/dev/null" "cargo:1.81.0:check"
+
+# Safe mode ignores project-provided wrapping.
+assert "MISE_CARGO_HOME='$CONFIG_CARGO_HOME' MISE_RUSTUP_HOME='$CONFIG_RUSTUP_HOME' MISE_SAFE=1 mise exec -- cargo check" "cargo:1.81.0:check"
+
+# Project overrides turn off a global/parent default.
+mkdir child
+(
+  cd child
+  printf '[tools]\nrust = { version = "1.81.0", mr_boxington = false }\n' >mise.toml
+  assert "mise exec -- cargo check" "cargo:1.81.0:check"
+  assert "'$MISE_DATA_DIR/shims/cargo' check" "cargo:1.81.0:check"
+  printf '[tools]\nrust = "1.81.0"\n' >mise.toml
+  assert "mise exec -- cargo check" "cargo:1.81.0:check"
+)
+
+# Explicit wrappers take precedence.
+cat >>mise.toml <<'EOF'
+[wrappers.cargo]
+command = "echo"
+args = ["custom"]
+EOF
+assert "mise exec -- cargo check" "custom check"
+
+# Missing dependencies produce actionable errors, not accidental PATH fallbacks.
+cat >mise.toml <<EOF
+[env]
+MISE_CARGO_HOME = "$CONFIG_CARGO_HOME"
+MISE_RUSTUP_HOME = "$CONFIG_RUSTUP_HOME"
+[tools]
+rust = { version = "1.81.0", mr_boxington = true }
+EOF
+assert_fail_contains "mise exec -- cargo check 2>&1" "requires mr-boxington in [tools]"
+cat >>mise.toml <<'EOF'
+[wrappers.cargo]
+command = "echo"
+args = ["custom"]
+EOF
+assert "mise exec -- cargo check" "custom check"
+
+: >mise.toml
+mise reshim
+assert_fail "test -e '$MISE_DATA_DIR/command-wrappers/bin/cargo'"

--- a/e2e/core/test_rust_mr_boxington
+++ b/e2e/core/test_rust_mr_boxington
@@ -4,6 +4,7 @@ set -euo pipefail
 
 unset MISE_CARGO_HOME MISE_RUSTUP_HOME
 export MISE_OFFLINE=1
+export MISE_ENV_CACHE=1
 
 CONFIG_CARGO_HOME="$PWD/config-cargo"
 CONFIG_RUSTUP_HOME="$PWD/config-rustup"
@@ -114,6 +115,8 @@ EOF
 assert "mise run wrapped 2>/dev/null" "mbx:1
 cargo:1.81.0:check"
 assert "mise run check 2>/dev/null" "cargo:1.81.0:check"
+assert "mise run wrapped 2>/dev/null" "mbx:1
+cargo:1.81.0:check"
 mise reshim
 assert "mise exec 'rust[mr_boxington=true]@1.81.0' -- cargo check" "mbx:1
 cargo:1.81.0:check"

--- a/e2e/core/test_rust_mr_boxington
+++ b/e2e/core/test_rust_mr_boxington
@@ -71,6 +71,7 @@ EOF
 mise use --tool-option mr_boxington=true rust@1.81.0 "mr-boxington@path:$PWD/mbx"
 assert "mise config get tools.rust.mr_boxington" "true"
 assert_contains "cat mise.toml" 'mr_boxington = true'
+assert_contains "cat mise.toml" 'components = ["rustfmt"]'
 assert "mise exec -- cargo check" "mbx:1
 cargo:1.81.0:check"
 assert "mise run check 2>/dev/null" "mbx:1
@@ -100,6 +101,22 @@ mkdir child
   printf '[tools]\nrust = "1.81.0"\n' >mise.toml
   assert "mise exec -- cargo check" "cargo:1.81.0:check"
 )
+
+# Task and exec opt-ins work without a previously generated wrapper.
+mise use --tool-option mr_boxington=false rust@1.81.0
+mise reshim
+assert_fail "test -e '$MISE_DATA_DIR/command-wrappers/bin/cargo'"
+cat >>mise.toml <<'EOF'
+[tasks.wrapped]
+tools = { rust = { version = "1.81.0", mr_boxington = true } }
+run = "cargo check"
+EOF
+assert "mise run wrapped 2>/dev/null" "mbx:1
+cargo:1.81.0:check"
+assert "mise run check 2>/dev/null" "cargo:1.81.0:check"
+mise reshim
+assert "mise exec 'rust[mr_boxington=true]@1.81.0' -- cargo check" "mbx:1
+cargo:1.81.0:check"
 
 # Explicit wrappers take precedence.
 cat >>mise.toml <<'EOF'

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -7703,6 +7703,11 @@ Print help
 .TP
 \fB\-\-postinstall\fR \fI<COMMAND>\fR
 Command to run after installing this tool
+.TP
+\fB\-\-tool\-option\fR \fI<KEY=VALUE>\fR
+Set an option for this tool (repeat for multiple options).
+Values use inline tool\-option types; unquoted text is treated as a string.
+Place these flags before the tool they apply to.
 \fBArguments:\fR
 .PP
 .TP
@@ -7739,6 +7744,12 @@ associate a different postinstall command with each tool
 .PP
 .RS 4
 mise use \-\-postinstall "setup\-a" tool\-a \-\-postinstall "setup\-b" tool\-b
+.RE
+.PP
+enable a Rust tool option while installing Rust and mbx
+.PP
+.RS 4
+mise use \-\-tool\-option mr_boxington=true rust mr\-boxington
 .RE
 .PP
 set the current version of node to 20.x in ~/.config/mise/config.toml will write the precise version (e.g.: 20.0.0)

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -5272,6 +5272,13 @@ https://mise.jdx.dev/configuration/settings.html#lockfile
         flag --postinstall help="Command to run after installing this tool" {
             arg <COMMAND>
         }
+        flag --tool-option help=#"""
+Set an option for this tool (repeat for multiple options).
+Values use inline tool-option types; unquoted text is treated as a string.
+Place these flags before the tool they apply to.
+"""# var=#true {
+            arg "<KEY=VALUE>"
+        }
         arg <TOOL@VERSION> help="Tool to add to config file" help_long=#"""
 Tool to add to config file
 
@@ -5287,6 +5294,7 @@ Tool options can be set with this syntax:
     example "mise use node@20" help="set the current version of node to 20.x in the selected project config will write the fuzzy version (e.g.: 20)"
     example "mise use --postinstall \"mbx setup --defaults\" mr-boxington" help="run a command after installing a tool"
     example "mise use --postinstall \"setup-a\" tool-a --postinstall \"setup-b\" tool-b" help="associate a different postinstall command with each tool"
+    example "mise use --tool-option mr_boxington=true rust mr-boxington" help="enable a Rust tool option while installing Rust and mbx"
     example "mise use -g --pin node@20" help="set the current version of node to 20.x in ~/.config/mise/config.toml will write the precise version (e.g.: 20.0.0)"
     example "mise use --env local node@20" help="writes mise.local.toml (preserving .mise.local.toml if it already exists)"
     example "mise use --env staging node@20" help="writes mise.staging.toml (loaded with MISE_ENV=staging)"

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -281,6 +281,8 @@ impl Exec {
             );
         }
 
+        crate::shims::ensure_command_wrapper_shims(&config, &ts)?;
+
         let (mut env, env_remove) = measure!("env_with_path", {
             ts.env_with_path_and_removals(&config).await?
         });

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -264,23 +264,6 @@ impl Exec {
             ts.notify_missing_versions(missing);
         });
 
-        // Environment-derived wrappers must follow the effective runtime tool
-        // requests rather than re-reading only the project defaults.
-        if !self.tool.is_empty() {
-            config = config.with_tool_request_set(
-                ts.versions
-                    .iter()
-                    .map(|(backend, versions)| {
-                        (
-                            backend.clone(),
-                            versions.requests.clone(),
-                            versions.source.clone(),
-                        )
-                    })
-                    .collect(),
-            );
-        }
-
         crate::shims::ensure_command_wrapper_shims(&config, &ts)?;
 
         let (mut env, env_remove) = measure!("env_with_path", {

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -264,10 +264,37 @@ impl Exec {
             ts.notify_missing_versions(missing);
         });
 
+        // Environment-derived wrappers must follow the effective runtime tool
+        // requests rather than re-reading only the project defaults.
+        if !self.tool.is_empty() {
+            config = config.with_tool_request_set(
+                ts.versions
+                    .iter()
+                    .map(|(backend, versions)| {
+                        (
+                            backend.clone(),
+                            versions.requests.clone(),
+                            versions.source.clone(),
+                        )
+                    })
+                    .collect(),
+            );
+        }
+
         let (mut env, env_remove) = measure!("env_with_path", {
             ts.env_with_path_and_removals(&config).await?
         });
         env.extend(wrapper_env);
+        if !self.tool.is_empty() {
+            // A dispatched shim reloads config in a new process. Preserve both
+            // enclosing task overrides and these explicit exec overrides.
+            let mut tools = crate::shims::task_tool_args_from_env()?;
+            tools.retain(|tool| !self.tool.iter().any(|explicit| explicit.ba == tool.ba));
+            tools.extend(self.tool.iter().cloned());
+            if let Some(value) = crate::shims::task_tool_args_env(&tools)? {
+                env.insert(crate::shims::TASK_TOOL_ARGS_ENV.into(), value);
+            }
+        }
         if strip_dispatch_dirs && let Some(path) = env.get_mut(&*env::PATH_KEY) {
             *path = crate::file::strip_dispatch_dirs_from_path(path);
         }

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -57,6 +57,10 @@ use crate::{config, env, exit, file};
         help = r###"associate a different postinstall command with each tool"###
     ),
     example(
+        r###"mise use --tool-option mr_boxington=true rust mr-boxington"###,
+        help = r###"enable a Rust tool option while installing Rust and mbx"###
+    ),
+    example(
         r###"mise use -g --pin node@20"###,
         help = r###"set the current version of node to 20.x in ~/.config/mise/config.toml will write the precise version (e.g.: 20.0.0)"###
     ),
@@ -153,6 +157,12 @@ struct UseTool {
     #[usage(long, value_name = "COMMAND")]
     postinstall: Option<String>,
 
+    /// Set an option for this tool (repeat for multiple options).
+    /// Values use inline tool-option types; unquoted text is treated as a string.
+    /// Place these flags before the tool they apply to.
+    #[usage(long, value_name = "KEY=VALUE", verbatim_doc_comment)]
+    tool_option: Vec<String>,
+
     /// Tool to add to config file
     ///
     /// e.g.: node@20, cargo:ripgrep@latest, npm:prettier@3
@@ -165,6 +175,63 @@ struct UseTool {
     tool: ToolArg,
 }
 
+impl UseTool {
+    fn has_options(&self) -> bool {
+        self.postinstall.is_some() || !self.tool_option.is_empty()
+    }
+
+    fn request_options(&self) -> Result<ToolVersionOptions> {
+        let mut options = ToolVersionOptions::default();
+        let mut entries = Vec::new();
+        if let Some(command) = &self.postinstall {
+            entries.push((
+                "postinstall".to_string(),
+                toml::Value::String(command.clone()),
+                "--postinstall",
+            ));
+        }
+        for option in &self.tool_option {
+            let (key, value) = option
+                .split_once('=')
+                .ok_or_else(|| eyre!("--tool-option expects KEY=VALUE: {option}"))?;
+            let key = key.trim();
+            if key.is_empty() {
+                bail!("--tool-option requires a non-empty key");
+            }
+            let value = toml::from_str::<toml::Table>(&format!("value = {value}"))
+                .ok()
+                .filter(|table| table.len() == 1)
+                .and_then(|mut table| table.remove("value"))
+                .unwrap_or_else(|| toml::Value::String(value.to_string()));
+            entries.push((key.to_string(), value, "--tool-option"));
+        }
+        let mut seen = std::collections::HashSet::new();
+        for (key, value, flag) in entries {
+            if !seen.insert(key.clone()) {
+                bail!(
+                    "tool option {key:?} was specified more than once for {}",
+                    self.tool
+                );
+            }
+            if self
+                .tool
+                .ba
+                .explicit_opts()
+                .is_some_and(|options| options.contains_key(&key))
+            {
+                bail!(
+                    "cannot combine {flag} with an inline {key} option for {}",
+                    self.tool
+                );
+            }
+            options
+                .insert_option(key, value)
+                .map_err(|error| eyre!(error))?;
+        }
+        Ok(options)
+    }
+}
+
 impl Use {
     pub(super) fn is_dry_run(&self) -> bool {
         self.dry_run || self.dry_run_code
@@ -174,6 +241,7 @@ impl Use {
         if self.tools.is_empty() && self.remove.is_empty() {
             self.tools = vec![UseTool {
                 postinstall: None,
+                tool_option: Vec::new(),
                 tool: self.tool_selector()?,
             }];
         }
@@ -199,6 +267,14 @@ impl Use {
         {
             bail!("--postinstall requires a TOML config file");
         }
+        if self
+            .tools
+            .iter()
+            .any(|target| !target.tool_option.is_empty())
+            && !matches!(cf.source(), ToolSource::MiseToml(_))
+        {
+            bail!("--tool-option requires a TOML config file");
+        }
         let pin = self.pin || !self.fuzzy && (Settings::get().pin || Settings::get().asdf_compat);
         let mut resolve_options = ResolveOptions {
             latest_versions: false,
@@ -216,27 +292,7 @@ impl Use {
             .tools
             .iter()
             .map(|target| {
-                if target.postinstall.is_some()
-                    && target
-                        .tool
-                        .ba
-                        .explicit_opts()
-                        .is_some_and(|options| options.contains_key("postinstall"))
-                {
-                    bail!(
-                        "cannot combine --postinstall with an inline postinstall option for {}",
-                        target.tool
-                    );
-                }
-                let mut request_options = ToolVersionOptions::default();
-                if let Some(command) = &target.postinstall {
-                    request_options
-                        .insert_option(
-                            "postinstall".to_string(),
-                            toml::Value::String(command.clone()),
-                        )
-                        .map_err(|error| eyre!(error))?;
-                }
+                let request_options = target.request_options()?;
                 match target.tool.tvr.clone() {
                     Some(tvr) => {
                         if tvr.version() == "latest" && !Settings::get().locked {
@@ -246,7 +302,7 @@ impl Use {
                             resolve_options.use_locked_version = false;
                         }
                         let mut tvr = tvr;
-                        if target.postinstall.is_some() {
+                        if target.has_options() {
                             tvr.set_options(request_options);
                         }
                         Ok(tvr)
@@ -348,7 +404,7 @@ impl Use {
 
     async fn get_config_file(&self) -> Result<Arc<dyn ConfigFile>> {
         let cwd = env::current_dir()?;
-        let has_postinstall = self.tools.iter().any(|target| target.postinstall.is_some());
+        let has_options = self.tools.iter().any(UseTool::has_options);
         let explicit_file = self.path.as_ref().is_some_and(|path| !path.is_dir());
         let opts = ConfigPathOptions {
             global: self.global,
@@ -359,7 +415,7 @@ impl Use {
             prevent_home_local: true, // When in HOME, use global config
         };
         let mut path = resolve_target_config_path(opts)?;
-        if has_postinstall && !explicit_file && path.extension().is_none_or(|ext| ext != "toml") {
+        if has_options && !explicit_file && path.extension().is_none_or(|ext| ext != "toml") {
             // Tool-level options cannot be represented in .tool-versions or idiomatic
             // version files. Keep the selected directory, but write the hook to its
             // default TOML config rather than unexpectedly selecting a TOML file above it.

--- a/src/config/command_wrapper.rs
+++ b/src/config/command_wrapper.rs
@@ -42,3 +42,57 @@ impl CommandWrapper {
         }
     }
 }
+
+/// Rust's opt-in wrapper shares the same dispatch path as explicit wrappers.
+/// Inspect effective requests so project, platform, and runtime selection apply.
+pub(crate) fn add_rust_wrapper<'a>(
+    wrappers: &mut IndexMap<String, CommandWrapper>,
+    tools: impl IntoIterator<Item = &'a crate::toolset::ToolRequest>,
+) -> eyre::Result<()> {
+    use crate::backend::options::BackendOptions;
+    use crate::cli::args::BackendArg;
+
+    if wrappers
+        .keys()
+        .any(|name| crate::shims::command_names_eq(name, "cargo"))
+    {
+        return Ok(());
+    }
+    let tools: Vec<_> = tools
+        .into_iter()
+        .filter(|tool| tool.is_os_supported())
+        .collect();
+    let enabled = tools
+        .iter()
+        .find(|tool| tool.ba().full() == "core:rust")
+        .is_some_and(|rust| {
+            // Match explicit wrappers: safe mode cannot activate project commands.
+            let safe = !crate::config::Settings::safe_mode()
+                || rust
+                    .source()
+                    .path()
+                    .is_none_or(crate::config::is_global_config);
+            safe && BackendOptions::new(&rust.options()).bool("mr_boxington")
+        });
+    if !enabled {
+        return Ok(());
+    }
+    let mbx = BackendArg::from("mr-boxington");
+    if !tools
+        .iter()
+        .any(|tool| tool.ba().short == mbx.short || tool.ba().full() == mbx.full())
+    {
+        eyre::bail!(
+            "rust's mr_boxington option requires mr-boxington in [tools]; add `mr-boxington = \"latest\"`"
+        );
+    }
+    wrappers.insert(
+        "cargo".into(),
+        CommandWrapper::Detailed(CommandWrapperOptions {
+            command: "mbx".into(),
+            args: Vec::new(),
+            env: [("MBX_CARGO_SHIM_MODE".into(), "1".into())].into(),
+        }),
+    );
+    Ok(())
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1378,17 +1378,12 @@ impl Config {
                 watch_files: cached.watch_files.clone(),
                 has_uncacheable: false,
             };
-            // Wrapper activation can depend on runtime Rust options, which are
-            // not part of the non-tool environment cache key.
+            // Keep only explicit wrappers in the non-tool environment. Tool-derived
+            // wrappers are selected later, after sourced env and tool templates resolve.
             env_results
                 .env_paths
                 .retain(|path| path != &*dirs::COMMAND_WRAPPERS);
-            if !load_command_wrappers(
-                &self.config_files,
-                self.get_tool_request_set().await?.tools.values().flatten(),
-            )?
-            .is_empty()
-            {
+            if !load_command_wrappers(&self.config_files, std::iter::empty())?.is_empty() {
                 env_results
                     .env_paths
                     .insert(0, dirs::COMMAND_WRAPPERS.clone());
@@ -1436,12 +1431,7 @@ impl Config {
             },
         )
         .await?;
-        if !load_command_wrappers(
-            &self.config_files,
-            self.get_tool_request_set().await?.tools.values().flatten(),
-        )?
-        .is_empty()
-        {
+        if !load_command_wrappers(&self.config_files, std::iter::empty())?.is_empty() {
             env_results
                 .env_paths
                 .insert(0, dirs::COMMAND_WRAPPERS.clone());

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1378,8 +1378,16 @@ impl Config {
                 watch_files: cached.watch_files.clone(),
                 has_uncacheable: false,
             };
-            if !load_command_wrappers(&self.config_files)?.is_empty()
-                && !env_results.env_paths.contains(&*dirs::COMMAND_WRAPPERS)
+            // Wrapper activation can depend on runtime Rust options, which are
+            // not part of the non-tool environment cache key.
+            env_results
+                .env_paths
+                .retain(|path| path != &*dirs::COMMAND_WRAPPERS);
+            if !load_command_wrappers(
+                &self.config_files,
+                self.get_tool_request_set().await?.tools.values().flatten(),
+            )?
+            .is_empty()
             {
                 env_results
                     .env_paths
@@ -1428,7 +1436,12 @@ impl Config {
             },
         )
         .await?;
-        if !load_command_wrappers(&self.config_files)?.is_empty() {
+        if !load_command_wrappers(
+            &self.config_files,
+            self.get_tool_request_set().await?.tools.values().flatten(),
+        )?
+        .is_empty()
+        {
             env_results
                 .env_paths
                 .insert(0, dirs::COMMAND_WRAPPERS.clone());
@@ -3123,8 +3136,9 @@ fn load_shell_aliases(config_files: &ConfigMap) -> Result<EnvWithSources> {
 }
 
 /// Load command wrappers from global through project scope.
-pub(crate) fn load_command_wrappers(
+pub(crate) fn load_command_wrappers<'a>(
     config_files: &ConfigMap,
+    tools: impl IntoIterator<Item = &'a crate::toolset::ToolRequest>,
 ) -> Result<IndexMap<String, CommandWrapper>> {
     let mut wrappers = IndexMap::new();
     let safe_mode = Settings::safe_mode();
@@ -3139,6 +3153,7 @@ pub(crate) fn load_command_wrappers(
             wrappers.insert(name, wrapper);
         }
     }
+    command_wrapper::add_rust_wrapper(&mut wrappers, tools)?;
     Ok(wrappers)
 }
 

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -1004,6 +1004,27 @@ fn is_legacy_windows_cmd_shim(contents: &[u8]) -> bool {
     )
 }
 
+/// Create wrappers needed by a runtime toolset without removing another task's wrappers.
+pub(crate) fn ensure_command_wrapper_shims(config: &Config, ts: &Toolset) -> Result<()> {
+    let wrappers = load_command_wrappers(
+        &config.config_files,
+        ts.versions.values().flat_map(|versions| &versions.requests),
+    )?;
+    validate_wrapper_names(wrappers.keys())?;
+    if wrappers.is_empty() {
+        return Ok(());
+    }
+    let mise_bin = mise_bin_for_shims().absolutize()?.into_owned();
+    let shims = wrappers
+        .keys()
+        .flat_map(|name| platform_shim_names(&mise_bin, name))
+        .collect();
+    if let Some(error) = write_bootstrap_shims(&mise_bin, &dirs::COMMAND_WRAPPERS, &shims)? {
+        return Err(error);
+    }
+    Ok(())
+}
+
 fn sync_command_wrapper_shims(
     config: &Config,
     ts: &Toolset,

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -65,7 +65,7 @@ pub(crate) fn task_tool_args_env(tools: &[ToolArg]) -> Result<Option<String>> {
     }
 }
 
-fn task_tool_args_from_env() -> Result<Vec<ToolArg>> {
+pub(crate) fn task_tool_args_from_env() -> Result<Vec<ToolArg>> {
     let Ok(serialized) = env::var(TASK_TOOL_ARGS_ENV) else {
         return Ok(vec![]);
     };
@@ -218,7 +218,10 @@ async fn which_shim(
         .with_resolve_options(resolve_options)
         .build(config)
         .await?;
-    let wrappers = load_command_wrappers(&config.config_files)?;
+    let wrappers = load_command_wrappers(
+        &config.config_files,
+        ts.versions.values().flat_map(|versions| &versions.requests),
+    )?;
     validate_wrapper_names(wrappers.keys())?;
     let wrapper = if cfg!(macos) {
         wrappers
@@ -626,7 +629,7 @@ pub(crate) async fn reshim_for(
     )?;
 
     if matches!(requested_scope, ShimScope::User | ShimScope::Both) {
-        sync_command_wrapper_shims(config, &mise_bin, full_rebuild)?;
+        sync_command_wrapper_shims(config, ts, &mise_bin, full_rebuild)?;
     }
 
     Ok(())
@@ -1001,8 +1004,16 @@ fn is_legacy_windows_cmd_shim(contents: &[u8]) -> bool {
     )
 }
 
-fn sync_command_wrapper_shims(config: &Config, mise_bin: &Path, force: bool) -> Result<()> {
-    let wrappers = load_command_wrappers(&config.config_files)?;
+fn sync_command_wrapper_shims(
+    config: &Config,
+    ts: &Toolset,
+    mise_bin: &Path,
+    force: bool,
+) -> Result<()> {
+    let wrappers = load_command_wrappers(
+        &config.config_files,
+        ts.versions.values().flat_map(|versions| &versions.requests),
+    )?;
     validate_wrapper_names(wrappers.keys())?;
     if wrappers.is_empty() {
         if cfg!(windows) {
@@ -1044,7 +1055,7 @@ fn sync_command_wrapper_shims(config: &Config, mise_bin: &Path, force: bool) -> 
     Ok(())
 }
 
-fn command_names_eq(a: &str, b: &str) -> bool {
+pub(crate) fn command_names_eq(a: &str, b: &str) -> bool {
     if cfg!(macos) {
         a.to_lowercase() == b.to_lowercase()
     } else {

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -2095,20 +2095,6 @@ impl TaskExecutor {
             ts_build_start.elapsed().as_millis()
         );
 
-        // Wrapper activation must follow this task's effective requests, including opt-ins.
-        let config = &config.with_tool_request_set(
-            toolset
-                .versions
-                .iter()
-                .map(|(backend, versions)| {
-                    (
-                        backend.clone(),
-                        versions.requests.clone(),
-                        versions.source.clone(),
-                    )
-                })
-                .collect(),
-        );
         crate::shims::ensure_command_wrapper_shims(config, &toolset)?;
 
         let env_render_start = std::time::Instant::now();

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -2095,6 +2095,22 @@ impl TaskExecutor {
             ts_build_start.elapsed().as_millis()
         );
 
+        // Wrapper activation must follow this task's effective requests, including opt-ins.
+        let config = &config.with_tool_request_set(
+            toolset
+                .versions
+                .iter()
+                .map(|(backend, versions)| {
+                    (
+                        backend.clone(),
+                        versions.requests.clone(),
+                        versions.source.clone(),
+                    )
+                })
+                .collect(),
+        );
+        crate::shims::ensure_command_wrapper_shims(config, &toolset)?;
+
         let env_render_start = std::time::Instant::now();
         // extra_vars contains resolved vars from the task's config hierarchy.
         let (mut env, task_env, extra_vars, mut env_remove) = if let Some(task_cf) = task_cf {

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -630,7 +630,7 @@ fn normalize_backend_option_value(key: &str, value: toml::Value) -> toml::Value 
 }
 
 fn preserves_backend_option_type(key: &str) -> bool {
-    matches!(key, "allow_builds")
+    matches!(key, "allow_builds" | "mr_boxington")
 }
 
 /// `pub(crate)` so callers that only want to know whether a value would resolve can ask the same

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -390,12 +390,18 @@ impl Toolset {
             })
             .collect();
 
-        // Collect tool versions
+        // Runtime options can change tool environments and wrapper activation without
+        // changing versions, so include them in the cache identity.
         let tool_versions: Vec<(String, String)> = self
             .list_current_versions()
             .into_iter()
-            .map(|(b, tv)| (b.id().to_string(), tv.version.clone()))
-            .collect();
+            .map(|(b, tv)| {
+                Ok((
+                    b.id().to_string(),
+                    serde_json::to_string(&(tv.version.clone(), tv.request.options()))?,
+                ))
+            })
+            .collect::<Result<_>>()?;
 
         // Get settings hash
         let settings_hash = compute_settings_hash();

--- a/src/toolset/toolset_paths.rs
+++ b/src/toolset/toolset_paths.rs
@@ -118,7 +118,8 @@ impl Toolset {
         paths.extend(self.list_paths(config).await);
 
         // 6. env_results.env_paths (from load_post_env like _.path directives) - these go at the front
-        let paths = env_results.env_paths.into_iter().chain(paths).collect();
+        let mut paths = env_results.env_paths.into_iter().chain(paths).collect();
+        self.apply_command_wrapper_paths(config, &mut paths)?;
         Ok(paths)
     }
 
@@ -137,6 +138,7 @@ impl Toolset {
         // env_results.env_paths must come FIRST for highest precedence
         let mut user_paths = env_results.env_paths;
         user_paths.extend(config.path_dirs().await?.clone());
+        self.apply_command_wrapper_paths(config, &mut user_paths)?;
 
         // Tool paths start empty
         let mut tool_paths = Vec::new();
@@ -153,5 +155,19 @@ impl Toolset {
         tool_paths.extend(self.list_paths(config).await);
 
         Ok((user_paths, tool_paths))
+    }
+    /// Select wrappers after tool templates and runtime options have been resolved.
+    fn apply_command_wrapper_paths(&self, config: &Config, paths: &mut Vec<PathBuf>) -> Result<()> {
+        paths.retain(|path| path != &*crate::dirs::COMMAND_WRAPPERS);
+        let wrappers = crate::config::load_command_wrappers(
+            &config.config_files,
+            self.versions
+                .values()
+                .flat_map(|versions| &versions.requests),
+        )?;
+        if !wrappers.is_empty() {
+            paths.insert(0, crate::dirs::COMMAND_WRAPPERS.clone());
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
Rust users currently need to configure a Cargo command wrapper separately to use Mr Boxington. Add `mr_boxington = true` to the Rust tool entry and a scoped `mise use --tool-option KEY=VALUE` flag, making setup a single command:

```sh
mise use --tool-option mr_boxington=true rust mr-boxington
```

The Rust option supplies the existing Cargo wrapper automatically while keeping mbx independently versioned and locked. Explicit Cargo wrappers take precedence; missing mbx configuration produces an actionable error. Project, task, and explicit exec overrides are respected, and project wrapping is ignored in safe mode. Cargo must still resolve through mise.

`--tool-option` is repeatable and applies to the following tool, like `--postinstall`. It preserves existing options, accepts the normal option value types, rejects duplicate/inline conflicts, and selects a TOML config when necessary. Includes generated CLI documentation and a Rust setup guide.

Validation:
- `mise run lint-fix`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- 28 tool-option unit tests
- E2E suites for Rust/mbx integration, scoped tool options, existing postinstall behavior, command wrappers, and exec recursion with and without shims
- Generated usage/completions; CLI reference tests pass

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Cargo is resolved on PATH and in shims for Rust projects, with new runtime wrapper logic in exec/tasks; mistakes could break builds or bypass intended wrappers, though explicit wrappers and safe mode limits are preserved.
> 
> **Overview**
> Adds **`mise use --tool-option KEY=VALUE`** (repeatable, scoped to the next tool like `--postinstall`) so tool entries can be written with inline options from the CLI. Values follow normal TOML option typing; duplicates, inline conflicts, and non-TOML targets are rejected, and option-bearing `use` calls steer writes to a default `mise.toml` when needed.
> 
> Rust gains **`mr_boxington = true`**, which auto-installs the existing **Cargo → mbx** command wrapper when `mr-boxington` is also in `[tools]`, without a manual `[wrappers.cargo]` block. Wrapper selection now depends on the **resolved toolset** (project/task/exec overrides, safe mode for project opt-ins, explicit wrappers still win). **PATH** and shim generation were adjusted so tool-derived wrappers apply after env resolution; **exec** and **tasks** ensure wrapper shims exist at runtime and preserve explicit exec tool overrides in the shim dispatch env. Env caching includes tool options so wrapper changes invalidate correctly.
> 
> Docs and generated CLI help cover the new flag and the updated Mr Boxington setup flow; e2e tests cover `--tool-option` validation and mbx routing across exec, tasks, shims, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e04c5c96e67e1024ffc6c6f0d31662539e74cba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added repeatable `--tool-option KEY=VALUE` support to `mise use` for per-tool configuration.
  - Rust Cargo commands can route through Mr Boxington during executions, tasks, activated shells, and shims.
  - Existing Cargo wrappers and project-level settings take precedence where applicable.

- **Bug Fixes**
  - Improved consistency of tool options, explicit tool selections, command wrappers, and environments.

- **Documentation**
  - Updated CLI and Rust documentation with setup requirements, behavior details, and examples.

- **Tests**
  - Added coverage for validation, overrides, dry runs, missing tools, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->