### PR TITLE
fix(github): warn only once when oauth refresh is rejected

### DIFF
--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -573,7 +573,7 @@ fn lock_cache(path: &Path) -> Result<fslock::LockFile> {
 
 pub(crate) fn log_refresh_error(err: &eyre::Report) {
     if err.downcast_ref::<RefreshRejected>().is_some() {
-        warn!("{err}");
+        warn_once!("{err}");
     } else {
         debug!("failed to refresh GitHub OAuth token: {err:#}");
     }


### PR DESCRIPTION
A rejected GitHub OAuth refresh (for example `incorrect_client_credentials`) was logged on every GitHub request in the same command. Switch that path to `warn_once!` so the reauthorization message appears once.

*AI-assisted — Tool: opencode; model: xai/grok-4.6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change in an existing error path; no OAuth token, cache, or HTTP retry behavior is modified.
> 
> **Overview**
> When GitHub OAuth refresh fails with a **rejected** grant (e.g. bad credentials), `log_refresh_error` used `warn!`, so the reauthorization message could repeat on every GitHub API call in the same command (including the HTTP 401 refresh-retry path).
> 
> **`log_refresh_error`** now uses **`warn_once!`** for `RefreshRejected` errors so users see the guidance once; other refresh failures still go to **`debug!`** unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 207758bfed660993b1676d38ad06a372ad88c0a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated refresh-rejection warnings from being logged multiple times during the same process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->