### PR TITLE
perf(ci): speed up test workflow

### DIFF
--- a/.github/actions/fetch-token/action.yml
+++ b/.github/actions/fetch-token/action.yml
@@ -4,13 +4,41 @@ inputs:
   api-secret:
     description: "API secret for mise-versions"
     required: true
+  count:
+    description: "Number of tokens to fetch sequentially so the pool can rotate"
+    required: false
+    default: "1"
 outputs:
   token:
-    description: "The GitHub token"
+    description: "The GitHub token (first fetched token)"
     value: ${{ steps.fetch.outputs.token }}
   token-id:
-    description: "Token ID for rate-limit reporting"
+    description: "Token ID for rate-limit reporting (first fetched token)"
     value: ${{ steps.fetch.outputs.token_id }}
+  token_0:
+    description: "Fetched token 0"
+    value: ${{ steps.fetch.outputs.token_0 }}
+  token_1:
+    description: "Fetched token 1"
+    value: ${{ steps.fetch.outputs.token_1 }}
+  token_2:
+    description: "Fetched token 2"
+    value: ${{ steps.fetch.outputs.token_2 }}
+  token_3:
+    description: "Fetched token 3"
+    value: ${{ steps.fetch.outputs.token_3 }}
+  token_4:
+    description: "Fetched token 4"
+    value: ${{ steps.fetch.outputs.token_4 }}
+  token_5:
+    description: "Fetched token 5"
+    value: ${{ steps.fetch.outputs.token_5 }}
+  token_6:
+    description: "Fetched token 6"
+    value: ${{ steps.fetch.outputs.token_6 }}
+  token_7:
+    description: "Fetched token 7"
+    value: ${{ steps.fetch.outputs.token_7 }}
 runs:
   using: "composite"
   steps:
@@ -18,35 +46,54 @@ runs:
       shell: bash
       env:
         API_SECRET: ${{ inputs.api-secret }}
+        TOKEN_COUNT: ${{ inputs.count }}
       run: |
         if [ -z "$API_SECRET" ]; then
           echo "No API secret provided, skipping token fetch"
           exit 0
         fi
-        response=$(curl -sf -H "Authorization: Bearer $API_SECRET" \
-          "https://mise-versions.jdx.dev/api/token" || true)
-        if [ -z "$response" ]; then
-          exit 0
+        if ! [[ "$TOKEN_COUNT" =~ ^[1-8]$ ]]; then
+          echo "count must be an integer from 1 to 8"
+          exit 1
         fi
-        token=$(echo "$response" | jq -r '.token')
-        echo "::add-mask::$token"
-        # Validate token looks like a GitHub token (starts with gh and has reasonable length)
-        if ! [[ "$token" =~ ^gh[a-z]_[A-Za-z0-9_]+$ ]] || [ ${#token} -lt 20 ]; then
-          echo "Invalid or missing token in response, skipping"
-          exit 0
-        fi
-        # Validate both the token and its usable core budget. GitHub returns 200
-        # from /rate_limit even when the token is already exhausted.
-        rate_limit=$(curl -sf -H "Authorization: Bearer $token" \
-          "https://api.github.com/rate_limit" || true)
-        if [ -z "$rate_limit" ]; then
-          echo "Token failed GitHub API validation, skipping"
-          exit 0
-        fi
-        remaining=$(echo "$rate_limit" | jq -r '.resources.core.remaining // 0')
-        if ! [[ "$remaining" =~ ^[0-9]+$ ]] || [ "$remaining" -le 1 ]; then
-          echo "Token has no usable GitHub core rate limit remaining, skipping"
-          exit 0
-        fi
-        echo "token=$token" >> "$GITHUB_OUTPUT"
-        echo "token_id=$(echo "$response" | jq -r '.token_id')" >> "$GITHUB_OUTPUT"
+
+        fetch_one() {
+          local i="$1"
+          local response token rate_limit remaining token_id
+          response=$(curl -sf -H "Authorization: Bearer $API_SECRET" \
+            "https://mise-versions.jdx.dev/api/token" || true)
+          if [ -z "$response" ]; then
+            return 0
+          fi
+          token=$(echo "$response" | jq -r '.token')
+          echo "::add-mask::$token"
+          # Validate token looks like a GitHub token (starts with gh and has reasonable length)
+          if ! [[ "$token" =~ ^gh[a-z]_[A-Za-z0-9_]+$ ]] || [ ${#token} -lt 20 ]; then
+            echo "Invalid or missing token in response, skipping"
+            return 0
+          fi
+          # Validate both the token and its usable core budget. GitHub returns 200
+          # from /rate_limit even when the token is already exhausted.
+          rate_limit=$(curl -sf -H "Authorization: Bearer $token" \
+            "https://api.github.com/rate_limit" || true)
+          if [ -z "$rate_limit" ]; then
+            echo "Token failed GitHub API validation, skipping"
+            return 0
+          fi
+          remaining=$(echo "$rate_limit" | jq -r '.resources.core.remaining // 0')
+          if ! [[ "$remaining" =~ ^[0-9]+$ ]] || [ "$remaining" -le 1 ]; then
+            echo "Token has no usable GitHub core rate limit remaining, skipping"
+            return 0
+          fi
+          token_id=$(echo "$response" | jq -r '.token_id')
+          echo "token_$i=$token" >> "$GITHUB_OUTPUT"
+          if [ "$i" -eq 0 ]; then
+            echo "token=$token" >> "$GITHUB_OUTPUT"
+            echo "token_id=$token_id" >> "$GITHUB_OUTPUT"
+          fi
+        }
+
+        # Fetch sequentially so the pool can rotate its cursor between requests.
+        for i in $(seq 0 $((TOKEN_COUNT - 1))); do
+          fetch_one "$i"
+        done

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -20,6 +20,8 @@ concurrency:
 env:
   MBX_DISABLE: "1"
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
   MISE_TRUSTED_CONFIG_PATHS: ${{ github.workspace }}
   MISE_EXPERIMENTAL: 1
   MISE_LOCKFILE: 1
@@ -38,8 +40,10 @@ jobs:
       full-ci: ${{ steps.classify.outputs.full-ci }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: github.event_name == 'pull_request'
         with:
           fetch-depth: 0
+          filter: blob:none
       - name: Classify changes
         id: classify
         env:
@@ -77,8 +81,8 @@ jobs:
           cargo build --all-features --ignore-rust-version
           echo "$PWD/target/debug" >> "$GITHUB_PATH"
       - run: mise -v
-      # Downstream jobs only execute this binary, so keep full debug symbols in
-      # the build job while transferring a much smaller stripped copy.
+      # Downstream jobs only execute this binary. Compile with line tables
+      # (CARGO_PROFILE_DEV_DEBUG) and strip the uploaded copy further.
       - name: Prepare mise artifact
         run: |
           install -Dm755 target/debug/mise target/ci-artifacts/mise
@@ -224,67 +228,28 @@ jobs:
     # The release PR runs the full suite against the packaged release tarball.
     # Keep that stronger signal instead of also testing the debug artifact.
     if: ${{ needs.classify-changes.outputs.full-ci == 'true' && (github.event_name != 'pull_request' || github.head_ref != 'release' || github.base_ref != 'main') }}
-    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=cache' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-large;overrides.cache-tag=cache' }}
     needs: [build-ubuntu, classify-changes]
     timeout-minutes: 125
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-      # Fetch sequentially so the pool can rotate its cursor between requests.
-      # Each token is also rejected by the action when its core budget is empty.
-      - name: Fetch token 0
-        id: token_0
+      - name: Fetch tokens
+        id: tokens
         uses: ./.github/actions/fetch-token
         with:
           api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 1
-        id: token_1
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 2
-        id: token_2
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 3
-        id: token_3
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 4
-        id: token_4
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 5
-        id: token_5
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 6
-        id: token_6
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - name: Fetch token 7
-        id: token_7
-        uses: ./.github/actions/fetch-token
-        with:
-          api-secret: ${{ secrets.MISE_VERSIONS_API_SECRET }}
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: mise-ubuntu-latest
-          path: target/debug
-      - run: echo "$PWD/target/debug" >> "$GITHUB_PATH" && chmod +x target/debug/mise
+          count: "8"
       - parallel:
-          - uses: ./.github/actions/mise-tools
+          - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+            with:
+              name: mise-ubuntu-latest
+              path: target/debug
           - name: Pull e2e Docker image
             run: docker pull ghcr.io/jdx/mise:e2e
-      # Each test gets isolated host directories and an ephemeral container.
-      # Run four branches on a standard runner; each branch handles two
-      # token-isolated tranches sequentially, capped at eight containers total.
+      - run: echo "$PWD/target/debug" >> "$GITHUB_PATH" && chmod +x target/debug/mise
+      # Tests run in ephemeral containers and do not need host mise tools.
+      # Four branches on a large runner; each handles two token-isolated
+      # tranches sequentially, capped at eight containers total.
       - parallel:
           - name: Test tranches 0 and 4
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
@@ -295,8 +260,8 @@ jobs:
               TEST_TRANCHE_COUNT: 8
               TRANCHE_A: 0
               TRANCHE_B: 4
-              TOKEN_A: ${{ steps.token_0.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              TOKEN_B: ${{ steps.token_4.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_A: ${{ steps.tokens.outputs.token_0 || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_B: ${{ steps.tokens.outputs.token_4 || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: &e2e-retry
               timeout_minutes: 30
               retry_wait_seconds: 30
@@ -315,8 +280,8 @@ jobs:
               TEST_TRANCHE_COUNT: 8
               TRANCHE_A: 1
               TRANCHE_B: 5
-              TOKEN_A: ${{ steps.token_1.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              TOKEN_B: ${{ steps.token_5.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_A: ${{ steps.tokens.outputs.token_1 || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_B: ${{ steps.tokens.outputs.token_5 || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: *e2e-retry
           - name: Test tranches 2 and 6
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
@@ -327,8 +292,8 @@ jobs:
               TEST_TRANCHE_COUNT: 8
               TRANCHE_A: 2
               TRANCHE_B: 6
-              TOKEN_A: ${{ steps.token_2.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              TOKEN_B: ${{ steps.token_6.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_A: ${{ steps.tokens.outputs.token_2 || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_B: ${{ steps.tokens.outputs.token_6 || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: *e2e-retry
           - name: Test tranches 3 and 7
             uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
@@ -339,8 +304,8 @@ jobs:
               TEST_TRANCHE_COUNT: 8
               TRANCHE_A: 3
               TRANCHE_B: 7
-              TOKEN_A: ${{ steps.token_3.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
-              TOKEN_B: ${{ steps.token_7.outputs.token || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_A: ${{ steps.tokens.outputs.token_3 || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
+              TOKEN_B: ${{ steps.tokens.outputs.token_7 || secrets.MISE_GH_TOKEN || secrets.GITHUB_TOKEN }}
             with: *e2e-retry
 
   bootstrap-linux-host:


### PR DESCRIPTION
Recent test runs spend ~18m trusted / ~28m untrusted, with e2e and Windows unit on the critical path. This trims compile time and e2e setup without adding jobs.

- Compile CI binaries with `line-tables-only` debuginfo and `CARGO_INCREMENTAL=0`
- Run trusted e2e on the large Namespace runner
- Fetch the eight pooled tokens in one sequential step
- Skip host `mise-tools` for Linux e2e (tests run in containers) and overlap artifact download with the image pull
- Classify docs-only PRs with a treeless clone, and skip the clone on non-PR runs

Windows unit on `windows-latest` is still the other wall-clock limiter.

*AI-assisted — Tool: opencode; model: xai/grok-4.6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow and action changes; fetch-token remains backward compatible with default count 1 for other callers.
> 
> **Overview**
> **CI compile and e2e setup are tuned to cut wall-clock time** without adding jobs.
> 
> Workflow-wide Cargo settings set `CARGO_INCREMENTAL=0` and `CARGO_PROFILE_DEV_DEBUG=line-tables-only` so debug builds are faster while the uploaded `mise` artifact is still stripped. The **classify-changes** job only checks out on pull requests, uses a treeless clone (`filter: blob:none`), and skips checkout entirely on non-PR events.
> 
> The **fetch-token** composite action gains an optional `count` (1–8) and emits `token_0`…`token_7` by fetching from the pool **sequentially** in one step; legacy `token` / `token-id` still reflect the first fetch. **e2e** calls it once with `count: "8"` instead of eight separate steps, runs trusted jobs on the **large** Namespace profile, drops host **mise-tools**, and overlaps artifact download with the e2e Docker image pull. Tranche env vars now read `steps.tokens.outputs.token_N`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7feb4eb2d7f2dd1591091ae96628457c88727287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The token-fetching workflow can now retrieve up to eight tokens in a single operation, while preserving access to the first token through existing outputs.

- **Tests**
  - End-to-end testing now uses consolidated token handling and improved parallel processing.
  - Build and checkout settings have been optimized to reduce unnecessary artifacts and improve CI efficiency.
  - Linux end-to-end jobs use larger runners and no longer require host-level tool installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->