### PR TITLE
feat(ruby): support bundler ruby file: in Gemfile

### DIFF
--- a/docs/lang/ruby.md
+++ b/docs/lang/ruby.md
@@ -188,7 +188,8 @@ ruby = { version = "latest", install_env = { RUBY_CONFIGURE_OPTS = "--disable-in
 
 mise uses a `mise.toml` or `.tool-versions` file for auto-switching between software versions.
 However, it can also read the ruby-specific version files `.ruby-version` and `Gemfile`
-(if it specifies a ruby version).
+(if it specifies a ruby version). A Gemfile may pin ruby with `ruby "3.3.6"` or Bundler's
+`ruby file: ".ruby-version"` (the path is resolved next to the Gemfile).
 
 Create a `.ruby-version` file for the current version of ruby:
 

--- a/e2e/core/test_ruby_from_gemfile
+++ b/e2e/core/test_ruby_from_gemfile
@@ -9,3 +9,16 @@ ruby "3.3.6"
 EOF
 
 assert "mise current ruby" "3.3.6"
+
+# Bundler `ruby file:` should follow a sibling version file, including when
+# `.ruby-version` itself is not treated as an idiomatic config file.
+mise settings add idiomatic_version_file_disable_files ruby:.ruby-version
+cat >.ruby-version <<EOF
+3.3.6
+EOF
+cat >Gemfile <<EOF
+source "https://rubygems.org"
+ruby file: ".ruby-version"
+EOF
+
+assert "mise current ruby" "3.3.6"

--- a/src/config/config_file/idiomatic_version/mod.rs
+++ b/src/config/config_file/idiomatic_version/mod.rs
@@ -6,7 +6,9 @@ use crate::backend::BackendList;
 use crate::cli::args::{BackendArg, BackendResolution};
 use crate::config::config_file::ConfigFile;
 use crate::file;
+use crate::plugins;
 use crate::toolset::{ToolRequest, ToolRequestSet, ToolSource};
+use crate::watch_files::WatchFile;
 
 pub(crate) mod package_json;
 
@@ -157,6 +159,18 @@ impl ConfigFile for IdiomaticVersionFile {
 
     fn to_tool_request_set(&self) -> Result<ToolRequestSet> {
         Ok(self.tools.clone())
+    }
+
+    fn watch_files(&self) -> Result<Vec<WatchFile>> {
+        Ok(plugins::core::gemfile_watch_patterns(&self.path)
+            .into_iter()
+            .map(|pattern| WatchFile {
+                patterns: vec![pattern],
+                run: None,
+                shell: None,
+                task: None,
+            })
+            .collect())
     }
 }
 

--- a/src/plugins/core/mod.rs
+++ b/src/plugins/core/mod.rs
@@ -25,6 +25,10 @@ pub(crate) mod python;
 #[cfg_attr(windows, path = "ruby_windows.rs")]
 mod ruby;
 mod ruby_common;
+
+pub(crate) fn gemfile_watch_patterns(path: &std::path::Path) -> Vec<String> {
+    ruby_common::gemfile_watch_patterns(path)
+}
 mod rust;
 mod swift;
 mod zig;

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -1030,7 +1030,7 @@ impl Backend for RubyPlugin {
 
     async fn _parse_idiomatic_file(&self, path: &Path) -> Result<Vec<String>> {
         let v = match path.file_name() {
-            Some(name) if name == "Gemfile" => parse_gemfile(&file::read_to_string(path)?),
+            Some(name) if name == "Gemfile" => super::ruby_common::parse_gemfile(path)?,
             _ => {
                 // .ruby-version
                 let body = normalize_idiomatic_contents(&file::read_to_string(path)?);
@@ -1218,34 +1218,6 @@ impl Backend for RubyPlugin {
     }
 }
 
-fn parse_gemfile(body: &str) -> String {
-    let v = body
-        .lines()
-        .find(|line| line.trim().starts_with("ruby "))
-        .unwrap_or_default()
-        .trim()
-        .split('#')
-        .next()
-        .unwrap_or_default()
-        .replace("engine:", ":engine =>")
-        .replace("engine_version:", ":engine_version =>");
-    let v = regex!(r#".*:engine *=> *['"](?<engine>[^'"]*).*:engine_version *=> *['"](?<engine_version>[^'"]*).*"#).replace_all(&v, "${engine_version}__ENGINE__${engine}").to_string();
-    let v = regex!(r#".*:engine_version *=> *['"](?<engine_version>[^'"]*).*:engine *=> *['"](?<engine>[^'"]*).*"#).replace_all(&v, "${engine_version}__ENGINE__${engine}").to_string();
-    let v = regex!(r#" *ruby *['"]([^'"]*).*"#)
-        .replace_all(&v, "$1")
-        .to_string();
-    let v = regex!(r#"^[^0-9]"#).replace_all(&v, "").to_string();
-    let v = regex!(r#"(.*)__ENGINE__(.*)"#)
-        .replace_all(&v, "$2-$1")
-        .to_string();
-    // make sure it's a version string like "3.0.0", "3.4.10", "ruby-3.0.0",
-    // or "jruby-9.4.12.0" (optional engine prefix, one or more numeric segments)
-    if !regex!(r"^(\w+-)?\d+(\.\d+)*$").is_match(&v) {
-        return "".to_string();
-    }
-    v
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1253,7 +1225,6 @@ mod tests {
     use crate::platform::Platform;
     use crate::toolset::ToolSource;
     use confique::Layer;
-    use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     static TEST_SETTINGS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -1388,60 +1359,6 @@ mod tests {
         assert_eq!(RubyPlugin::tag_to_version("3_3_0"), None); // Missing 'v' prefix
         assert_eq!(RubyPlugin::tag_to_version("v3_3"), None); // Missing patch version
         assert_eq!(RubyPlugin::tag_to_version("jruby-9.4.0"), None); // Different format
-    }
-
-    #[test]
-    fn test_parse_gemfile() {
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            ruby '2.7.2'
-        "#}),
-            "2.7.2"
-        );
-        // Each numeric segment may be more than one digit (e.g. 3.4.10, 4.0.6)
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            ruby "3.4.10"
-        "#}),
-            "3.4.10"
-        );
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            ruby "4.0.6"
-        "#}),
-            "4.0.6"
-        );
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            ruby '1.9.3', engine: 'jruby', engine_version: "1.6.7"
-        "#}),
-            "jruby-1.6.7"
-        );
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            ruby '1.9.3', :engine => 'jruby', :engine_version => '1.6.7'
-        "#}),
-            "jruby-1.6.7"
-        );
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            ruby '1.9.3', :engine_version => '1.6.7', :engine => 'jruby'
-        "#}),
-            "jruby-1.6.7"
-        );
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            ruby "3.3.0", engine: "jruby", engine_version: "9.4.12.0"
-        "#}),
-            "jruby-9.4.12.0"
-        );
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            source "https://rubygems.org"
-            ruby File.read(File.expand_path(".ruby-version", __dir__)).strip
-        "#}),
-            ""
-        );
     }
 
     #[test]

--- a/src/plugins/core/ruby_common.rs
+++ b/src/plugins/core/ruby_common.rs
@@ -215,6 +215,10 @@ fn is_safe_relative_ruby_file(filename: &str) -> bool {
         })
 }
 
+fn is_gemfile_path(path: &Path) -> bool {
+    path.file_name().is_some_and(|name| name == "Gemfile")
+}
+
 /// Relative paths from a Gemfile `ruby file:` option, for hook-env watches.
 pub(crate) fn gemfile_watch_patterns(gemfile_path: &Path) -> Vec<String> {
     if gemfile_path
@@ -227,7 +231,9 @@ pub(crate) fn gemfile_watch_patterns(gemfile_path: &Path) -> Vec<String> {
         return vec![];
     };
     match gemfile_ruby_directive(&body).and_then(|line| ruby_file_option(&line)) {
-        Some(filename) if is_safe_relative_ruby_file(&filename) && filename != "Gemfile" => {
+        Some(filename)
+            if is_safe_relative_ruby_file(&filename) && !is_gemfile_path(Path::new(&filename)) =>
+        {
             vec![filename]
         }
         _ => vec![],
@@ -239,7 +245,7 @@ fn read_ruby_file_option(gemfile_path: &Path, filename: &str) -> Option<String> 
         return None;
     }
     let path = gemfile_path.parent()?.join(filename);
-    if path.file_name().is_some_and(|name| name == "Gemfile") {
+    if is_gemfile_path(&path) {
         return None;
     }
     let version = parse_bundler_ruby_version_file(&file::read_to_string(&path).ok()?);
@@ -473,5 +479,29 @@ mod tests {
             vec![".ruby-version".to_string()]
         );
         assert!(gemfile_watch_patterns(&dir.path().join(".ruby-version")).is_empty());
+    }
+
+    #[test]
+    fn gemfile_watch_patterns_skip_self_and_nested_gemfile() {
+        let dir = tempfile::tempdir().unwrap();
+        let gemfile = dir.path().join("Gemfile");
+        file::write(&gemfile, "ruby file: \"./Gemfile\"\n").unwrap();
+        assert!(gemfile_watch_patterns(&gemfile).is_empty());
+
+        file::write(&gemfile, "ruby file: \"nested/Gemfile\"\n").unwrap();
+        assert!(gemfile_watch_patterns(&gemfile).is_empty());
+    }
+
+    #[test]
+    fn parse_gemfile_file_option_rejects_self_and_nested_gemfile() {
+        let dir = tempfile::tempdir().unwrap();
+        let gemfile = dir.path().join("Gemfile");
+        file::write(&gemfile, "ruby file: \"./Gemfile\"\n").unwrap();
+        assert_eq!(parse_gemfile(&gemfile).unwrap(), "");
+
+        file::create_dir_all(dir.path().join("nested")).unwrap();
+        file::write(dir.path().join("nested/Gemfile"), "ruby \"3.3.6\"\n").unwrap();
+        file::write(&gemfile, "ruby file: \"nested/Gemfile\"\n").unwrap();
+        assert_eq!(parse_gemfile(&gemfile).unwrap(), "");
     }
 }

--- a/src/plugins/core/ruby_common.rs
+++ b/src/plugins/core/ruby_common.rs
@@ -130,20 +130,17 @@ pub(super) fn parse_gemfile(path: &Path) -> Result<String> {
 }
 
 fn parse_gemfile_contents(body: &str, gemfile_path: Option<&Path>) -> String {
-    let line = body
-        .lines()
-        .find(|line| line.trim().starts_with("ruby "))
-        .unwrap_or_default()
-        .trim()
-        .split('#')
-        .next()
-        .unwrap_or_default()
-        .to_string();
-    if let Some(filename) = ruby_file_option(&line) {
-        return gemfile_path
-            .and_then(|path| read_ruby_file_option(path, &filename))
-            .unwrap_or_default();
-    }
+    let line = gemfile_ruby_directive(body).unwrap_or_default();
+    let line = if let Some(filename) = ruby_file_option(&line) {
+        let Some(file_version) =
+            gemfile_path.and_then(|path| read_ruby_file_option(path, &filename))
+        else {
+            return String::new();
+        };
+        rewrite_ruby_line_with_file_version(&line, &file_version)
+    } else {
+        line
+    };
     let v = line
         .replace("engine:", ":engine =>")
         .replace("engine_version:", ":engine_version =>");
@@ -162,25 +159,86 @@ fn parse_gemfile_contents(body: &str, gemfile_path: Option<&Path>) -> String {
     v
 }
 
+fn gemfile_ruby_directive(body: &str) -> Option<String> {
+    body.lines()
+        .find(|line| line.trim().starts_with("ruby "))
+        .map(|line| strip_ruby_line_comment(line.trim()).to_string())
+}
+
+/// Drop a `#` comment unless it sits inside quotes (`file: ".ruby-version#ci"`).
+fn strip_ruby_line_comment(line: &str) -> &str {
+    let mut in_single = false;
+    let mut in_double = false;
+    for (i, c) in line.char_indices() {
+        match c {
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            '#' if !in_single && !in_double => return line[..i].trim_end(),
+            _ => {}
+        }
+    }
+    line
+}
+
 fn ruby_file_option(line: &str) -> Option<String> {
     regex!(r#"(?:^|\s)(?:file\s*:|:file\s*=>)\s*['"]([^'"]+)['"]"#)
         .captures(line)
         .map(|caps| caps[1].to_string())
 }
 
-fn read_ruby_file_option(gemfile_path: &Path, filename: &str) -> Option<String> {
+fn rewrite_ruby_line_with_file_version(line: &str, version: &str) -> String {
+    let stripped = regex!(r#"(?:,\s*)?(?:file\s*:|:file\s*=>)\s*['"][^'"]+['"]"#)
+        .replace(line, "")
+        .to_string();
+    let rest = stripped
+        .trim()
+        .strip_prefix("ruby")
+        .unwrap_or(stripped.trim())
+        .trim_start()
+        .trim_start_matches(',')
+        .trim();
+    if rest.is_empty() {
+        format!("ruby \"{version}\"")
+    } else {
+        format!("ruby \"{version}\", {rest}")
+    }
+}
+
+fn is_safe_relative_ruby_file(filename: &str) -> bool {
     let rel = Path::new(filename);
-    if filename.is_empty()
-        || rel.components().any(|c| {
+    !filename.is_empty()
+        && !rel.components().any(|c| {
             matches!(
                 c,
                 Component::ParentDir | Component::Prefix(_) | Component::RootDir
             )
         })
+}
+
+/// Relative paths from a Gemfile `ruby file:` option, for hook-env watches.
+pub(crate) fn gemfile_watch_patterns(gemfile_path: &Path) -> Vec<String> {
+    if gemfile_path
+        .file_name()
+        .is_none_or(|name| name != "Gemfile")
     {
+        return vec![];
+    }
+    let Ok(body) = file::read_to_string(gemfile_path) else {
+        return vec![];
+    };
+    match gemfile_ruby_directive(&body).and_then(|line| ruby_file_option(&line)) {
+        Some(filename) if is_safe_relative_ruby_file(&filename) && filename != "Gemfile" => {
+            vec![filename]
+        }
+        _ => vec![],
+    }
+}
+
+fn read_ruby_file_option(gemfile_path: &Path, filename: &str) -> Option<String> {
+    if !is_safe_relative_ruby_file(filename) {
         return None;
     }
-    let path = gemfile_path.parent()?.join(rel);
+    let path = gemfile_path.parent()?.join(filename);
     if path.file_name().is_some_and(|name| name == "Gemfile") {
         return None;
     }
@@ -197,7 +255,9 @@ fn read_ruby_file_option(gemfile_path: &Path, filename: &str) -> Option<String> 
 fn parse_bundler_ruby_version_file(body: &str) -> String {
     let normalized = normalize_idiomatic_contents(body);
     for line in normalized.lines() {
-        if let Some(version) = capture_bundler_ruby_line(line.trim()) {
+        if let Some(version) = capture_bundler_ruby_line(line.trim())
+            && is_ruby_version_string(&version)
+        {
             return version;
         }
     }
@@ -212,8 +272,12 @@ fn parse_bundler_ruby_version_file(body: &str) -> String {
 }
 
 fn capture_bundler_ruby_line(line: &str) -> Option<String> {
+    // `ruby-3.2.2` is a version; `ruby-build 2024.1.1` is a different tool.
+    if let Some(caps) = regex!(r"^ruby-(\d[\w.]*)$").captures(line) {
+        return Some(caps[1].to_string());
+    }
     let caps =
-        regex!(r#"^ruby[\s-]*(?:=\s*)?(?:"([^"]+)"|'([^']+)'|([^\s#"']+))"#).captures(line)?;
+        regex!(r#"^ruby(?:\s*=\s*|\s+)(?:"([^"]+)"|'([^']+)'|([^\s#"']+))"#).captures(line)?;
     Some(
         caps.get(1)
             .or_else(|| caps.get(2))
@@ -362,5 +426,52 @@ mod tests {
 
         file::write(&gemfile, "ruby file: \".ruby-version\"\n").unwrap();
         assert_eq!(parse_gemfile(&gemfile).unwrap(), "");
+    }
+
+    #[test]
+    fn parse_gemfile_file_option_applies_engine_options() {
+        let dir = tempfile::tempdir().unwrap();
+        let gemfile = dir.path().join("Gemfile");
+        file::write(dir.path().join(".ruby-version"), "1.9.3\n").unwrap();
+        file::write(
+            &gemfile,
+            "ruby file: \".ruby-version\", engine: \"jruby\", engine_version: \"1.6.7\"\n",
+        )
+        .unwrap();
+        assert_eq!(parse_gemfile(&gemfile).unwrap(), "jruby-1.6.7");
+    }
+
+    #[test]
+    fn parse_gemfile_file_option_skips_hyphenated_tools() {
+        let dir = tempfile::tempdir().unwrap();
+        let gemfile = dir.path().join("Gemfile");
+        file::write(
+            dir.path().join(".tool-versions"),
+            "ruby-build 2024.1.1\nruby 3.3.6\n",
+        )
+        .unwrap();
+        file::write(&gemfile, "ruby file: \".tool-versions\"\n").unwrap();
+        assert_eq!(parse_gemfile(&gemfile).unwrap(), "3.3.6");
+    }
+
+    #[test]
+    fn parse_gemfile_file_option_keeps_hash_in_quoted_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let gemfile = dir.path().join("Gemfile");
+        file::write(dir.path().join(".ruby-version#ci"), "3.3.6\n").unwrap();
+        file::write(&gemfile, "ruby file: \".ruby-version#ci\" # comment\n").unwrap();
+        assert_eq!(parse_gemfile(&gemfile).unwrap(), "3.3.6");
+    }
+
+    #[test]
+    fn gemfile_watch_patterns_include_referenced_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let gemfile = dir.path().join("Gemfile");
+        file::write(&gemfile, "ruby file: \".ruby-version\"\n").unwrap();
+        assert_eq!(
+            gemfile_watch_patterns(&gemfile),
+            vec![".ruby-version".to_string()]
+        );
+        assert!(gemfile_watch_patterns(&dir.path().join(".ruby-version")).is_empty());
     }
 }

--- a/src/plugins/core/ruby_common.rs
+++ b/src/plugins/core/ruby_common.rs
@@ -1,6 +1,11 @@
+use std::path::{Component, Path};
+
+use crate::backend::normalize_idiomatic_contents;
+use crate::file;
 use crate::github;
 use crate::lockfile::PlatformInfo;
 use eyre::Result;
+use xx::regex;
 
 const RUBYINSTALLER_REPO: &str = "oneclick/rubyinstaller2";
 
@@ -112,9 +117,122 @@ pub(super) async fn resolve_rubyinstaller_lock_info(version: &str) -> Result<Pla
     })
 }
 
+/// Parse a Bundler `Gemfile` for a ruby version request.
+///
+/// Supports `ruby "3.3.6"`, engine options, and Bundler's
+/// `ruby file: ".ruby-version"` (also `:file =>`). The referenced file is
+/// resolved relative to the Gemfile and must stay in that directory.
+pub(super) fn parse_gemfile(path: &Path) -> Result<String> {
+    Ok(parse_gemfile_contents(
+        &file::read_to_string(path)?,
+        Some(path),
+    ))
+}
+
+fn parse_gemfile_contents(body: &str, gemfile_path: Option<&Path>) -> String {
+    let line = body
+        .lines()
+        .find(|line| line.trim().starts_with("ruby "))
+        .unwrap_or_default()
+        .trim()
+        .split('#')
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    if let Some(filename) = ruby_file_option(&line) {
+        return gemfile_path
+            .and_then(|path| read_ruby_file_option(path, &filename))
+            .unwrap_or_default();
+    }
+    let v = line
+        .replace("engine:", ":engine =>")
+        .replace("engine_version:", ":engine_version =>");
+    let v = regex!(r#".*:engine *=> *['"](?<engine>[^'"]*).*:engine_version *=> *['"](?<engine_version>[^'"]*).*"#).replace_all(&v, "${engine_version}__ENGINE__${engine}").to_string();
+    let v = regex!(r#".*:engine_version *=> *['"](?<engine_version>[^'"]*).*:engine *=> *['"](?<engine>[^'"]*).*"#).replace_all(&v, "${engine_version}__ENGINE__${engine}").to_string();
+    let v = regex!(r#" *ruby *['"]([^'"]*).*"#)
+        .replace_all(&v, "$1")
+        .to_string();
+    let v = regex!(r#"^[^0-9]"#).replace_all(&v, "").to_string();
+    let v = regex!(r#"(.*)__ENGINE__(.*)"#)
+        .replace_all(&v, "$2-$1")
+        .to_string();
+    if !is_ruby_version_string(&v) {
+        return String::new();
+    }
+    v
+}
+
+fn ruby_file_option(line: &str) -> Option<String> {
+    regex!(r#"(?:^|\s)(?:file\s*:|:file\s*=>)\s*['"]([^'"]+)['"]"#)
+        .captures(line)
+        .map(|caps| caps[1].to_string())
+}
+
+fn read_ruby_file_option(gemfile_path: &Path, filename: &str) -> Option<String> {
+    let rel = Path::new(filename);
+    if filename.is_empty()
+        || rel.components().any(|c| {
+            matches!(
+                c,
+                Component::ParentDir | Component::Prefix(_) | Component::RootDir
+            )
+        })
+    {
+        return None;
+    }
+    let path = gemfile_path.parent()?.join(rel);
+    if path.file_name().is_some_and(|name| name == "Gemfile") {
+        return None;
+    }
+    let version = parse_bundler_ruby_version_file(&file::read_to_string(&path).ok()?);
+    if is_ruby_version_string(&version) {
+        Some(version)
+    } else {
+        None
+    }
+}
+
+/// Bundler `normalize_ruby_file`: `ruby-3.2.2`, `ruby 3.2.2`, `ruby = "3.2.2"`,
+/// or a single-line `.ruby-version` body.
+fn parse_bundler_ruby_version_file(body: &str) -> String {
+    let normalized = normalize_idiomatic_contents(body);
+    for line in normalized.lines() {
+        if let Some(version) = capture_bundler_ruby_line(line.trim()) {
+            return version;
+        }
+    }
+    if normalized.trim().lines().nth(1).is_some() {
+        return String::new();
+    }
+    normalized
+        .trim()
+        .trim_start_matches("ruby-")
+        .trim_start_matches('v')
+        .to_string()
+}
+
+fn capture_bundler_ruby_line(line: &str) -> Option<String> {
+    let caps =
+        regex!(r#"^ruby[\s-]*(?:=\s*)?(?:"([^"]+)"|'([^']+)'|([^\s#"']+))"#).captures(line)?;
+    Some(
+        caps.get(1)
+            .or_else(|| caps.get(2))
+            .or_else(|| caps.get(3))?
+            .as_str()
+            .to_string(),
+    )
+}
+
+fn is_ruby_version_string(version: &str) -> bool {
+    // optional engine prefix, one or more numeric segments: "3.0.0", "3.4.10",
+    // "ruby-3.0.0", "jruby-9.4.12.0"
+    regex!(r"^(\w+-)?\d+(\.\d+)*$").is_match(version)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::file;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -151,5 +269,98 @@ mod tests {
         assert!(is_mri_version("3.4.4"));
         assert!(!is_mri_version("jruby-9.4.0.0"));
         assert!(!is_mri_version("truffleruby-24.1.1"));
+    }
+
+    #[test]
+    fn parse_gemfile_literals() {
+        assert_eq!(parse_gemfile_contents("ruby '2.7.2'\n", None), "2.7.2");
+        assert_eq!(parse_gemfile_contents("ruby \"3.4.10\"\n", None), "3.4.10");
+        assert_eq!(parse_gemfile_contents("ruby \"4.0.6\"\n", None), "4.0.6");
+        assert_eq!(
+            parse_gemfile_contents(
+                "ruby '1.9.3', engine: 'jruby', engine_version: \"1.6.7\"\n",
+                None
+            ),
+            "jruby-1.6.7"
+        );
+        assert_eq!(
+            parse_gemfile_contents(
+                "ruby '1.9.3', :engine => 'jruby', :engine_version => '1.6.7'\n",
+                None
+            ),
+            "jruby-1.6.7"
+        );
+        assert_eq!(
+            parse_gemfile_contents(
+                "ruby '1.9.3', :engine_version => '1.6.7', :engine => 'jruby'\n",
+                None
+            ),
+            "jruby-1.6.7"
+        );
+        assert_eq!(
+            parse_gemfile_contents(
+                "ruby \"3.3.0\", engine: \"jruby\", engine_version: \"9.4.12.0\"\n",
+                None
+            ),
+            "jruby-9.4.12.0"
+        );
+        assert_eq!(
+            parse_gemfile_contents(
+                "source \"https://rubygems.org\"\nruby File.read(File.expand_path(\".ruby-version\", __dir__)).strip\n",
+                None
+            ),
+            ""
+        );
+    }
+
+    #[test]
+    fn parse_gemfile_file_option_reads_ruby_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let gemfile = dir.path().join("Gemfile");
+        file::write(dir.path().join(".ruby-version"), "3.3.6\n").unwrap();
+        file::write(
+            &gemfile,
+            "source \"https://rubygems.org\"\nruby file: \".ruby-version\"\n",
+        )
+        .unwrap();
+        assert_eq!(parse_gemfile(&gemfile).unwrap(), "3.3.6");
+    }
+
+    #[test]
+    fn parse_gemfile_file_option_accepts_hash_rocket_and_single_quotes() {
+        let dir = tempfile::tempdir().unwrap();
+        let gemfile = dir.path().join("Gemfile");
+        file::write(dir.path().join(".ruby-version"), "ruby-3.4.10\n").unwrap();
+        file::write(&gemfile, "ruby :file => '.ruby-version'\n").unwrap();
+        assert_eq!(parse_gemfile(&gemfile).unwrap(), "3.4.10");
+    }
+
+    #[test]
+    fn parse_gemfile_file_option_reads_tool_versions_and_mise_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        file::write(
+            dir.path().join(".tool-versions"),
+            "nodejs 20\nruby 3.3.6 # comment\n",
+        )
+        .unwrap();
+        file::write(dir.path().join("mise.toml"), "[tools]\nruby = \"4.0.6\"\n").unwrap();
+
+        let gemfile = dir.path().join("Gemfile");
+        file::write(&gemfile, "ruby file: \".tool-versions\"\n").unwrap();
+        assert_eq!(parse_gemfile(&gemfile).unwrap(), "3.3.6");
+
+        file::write(&gemfile, "ruby file: \"mise.toml\"\n").unwrap();
+        assert_eq!(parse_gemfile(&gemfile).unwrap(), "4.0.6");
+    }
+
+    #[test]
+    fn parse_gemfile_file_option_rejects_parent_dir_and_missing_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let gemfile = dir.path().join("Gemfile");
+        file::write(&gemfile, "ruby file: \"../.ruby-version\"\n").unwrap();
+        assert_eq!(parse_gemfile(&gemfile).unwrap(), "");
+
+        file::write(&gemfile, "ruby file: \".ruby-version\"\n").unwrap();
+        assert_eq!(parse_gemfile(&gemfile).unwrap(), "");
     }
 }

--- a/src/plugins/core/ruby_windows.rs
+++ b/src/plugins/core/ruby_windows.rs
@@ -204,7 +204,7 @@ impl Backend for RubyPlugin {
 
     async fn _parse_idiomatic_file(&self, path: &Path) -> Result<Vec<String>> {
         let v = match path.file_name() {
-            Some(name) if name == "Gemfile" => parse_gemfile(&file::read_to_string(path)?),
+            Some(name) if name == "Gemfile" => super::ruby_common::parse_gemfile(path)?,
             _ => {
                 // .ruby-version
                 let body = normalize_idiomatic_contents(&file::read_to_string(path)?);
@@ -259,33 +259,6 @@ impl Backend for RubyPlugin {
     }
 }
 
-fn parse_gemfile(body: &str) -> String {
-    let v = body
-        .lines()
-        .find(|line| line.trim().starts_with("ruby "))
-        .unwrap_or_default()
-        .trim()
-        .split('#')
-        .next()
-        .unwrap_or_default()
-        .replace("engine:", ":engine =>")
-        .replace("engine_version:", ":engine_version =>");
-    let v = regex!(r#".*:engine *=> *['"](?<engine>[^'"]*).*:engine_version *=> *['"](?<engine_version>[^'"]*).*"#).replace_all(&v, "${engine_version}__ENGINE__${engine}").to_string();
-    let v = regex!(r#".*:engine_version *=> *['"](?<engine_version>[^'"]*).*:engine *=> *['"](?<engine>[^'"]*).*"#).replace_all(&v, "${engine_version}__ENGINE__${engine}").to_string();
-    let v = regex!(r#" *ruby *['"]([^'"]*).*"#)
-        .replace_all(&v, "$1")
-        .to_string();
-    let v = regex!(r#"^[^0-9]"#).replace_all(&v, "").to_string();
-    let v = regex!(r#"(.*)__ENGINE__(.*)"#)
-        .replace_all(&v, "$2-$1")
-        .to_string();
-    // make sure it's like "ruby-3.0.0" or "3.0.0"
-    if !regex!(r"^(\w+-)?([0-9])(\.[0-9])*$").is_match(&v) {
-        return "".to_string();
-    }
-    v
-}
-
 /// The archive a lockfile already pins for this platform, as `(url, filename)`.
 /// `None` when nothing is locked or the URL yields no filename, in which case
 /// the caller resolves the archive itself.
@@ -298,7 +271,6 @@ fn locked_archive(locked_url: Option<&str>) -> Option<(String, String)> {
 #[cfg(test)]
 mod tests {
     use crate::config::Config;
-    use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -347,41 +319,6 @@ mod tests {
                 .unwrap()
                 .is_empty(),
             "versions for truffleruby+graalvm-24 should not be empty"
-        );
-    }
-
-    #[test]
-    fn test_parse_gemfile() {
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            ruby '2.7.2'
-        "#}),
-            "2.7.2"
-        );
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            ruby '1.9.3', engine: 'jruby', engine_version: "1.6.7"
-        "#}),
-            "jruby-1.6.7"
-        );
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            ruby '1.9.3', :engine => 'jruby', :engine_version => '1.6.7'
-        "#}),
-            "jruby-1.6.7"
-        );
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            ruby '1.9.3', :engine_version => '1.6.7', :engine => 'jruby'
-        "#}),
-            "jruby-1.6.7"
-        );
-        assert_eq!(
-            parse_gemfile(indoc! {r#"
-            source "https://rubygems.org"
-            ruby File.read(File.expand_path(".ruby-version", __dir__)).strip
-        "#}),
-            ""
         );
     }
 }


### PR DESCRIPTION
## Summary

When ruby idiomatic version files are enabled, mise reads `Gemfile` for a ruby version. It already understood `ruby "3.3.6"` and engine options, but not Bundler's `ruby file: ".ruby-version"`. That form is common (see #12913) and was ignored, so the Gemfile contributed no version.

This follows Bundler's relative-path rules:

- `ruby file: ".ruby-version"` / `ruby file: '.ruby-version'` / `ruby :file => ".ruby-version"`
- The path is resolved next to the Gemfile
- The referenced file may be a plain `.ruby-version`, a `.tool-versions` `ruby …` line, or a `mise.toml` `ruby = "…"` assignment
- Absolute paths, `..`, and pointing at another `Gemfile` are ignored

`ruby File.read(...)` is still not supported.

Fixes the user-facing gap from https://github.com/jdx/mise/discussions/12913.

## Test plan

- [x] Unit tests for literals, `file:`, hash rocket, `.tool-versions` / `mise.toml` bodies, missing files, and parent-dir rejection
- [x] `mise run test:e2e e2e/core/test_ruby_from_gemfile` (literal + `source` + `ruby file: ".ruby-version"`)

*AI-assisted — Tool: Grok Build; model: xAI/Grok 4.6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Ruby idiomatic version parsing and file watches; existing literal Gemfile behavior is preserved with added path-safety checks.
> 
> **Overview**
> Adds support for **Bundler’s `ruby file:`** form when mise reads Ruby from a `Gemfile`, so projects that pin Ruby via a sibling file (e.g. `.ruby-version`) resolve the version correctly instead of contributing nothing.
> 
> Parsing is **centralized in `ruby_common`**: `ruby file:`, `:file =>`, and literal `ruby "…"` / engine options still work; referenced paths are resolved next to the Gemfile and can read `.ruby-version`, `.tool-versions` (`ruby` line), or `mise.toml`. **Unsafe paths** (`..`, absolute, or another `Gemfile`) are rejected; dynamic `ruby File.read(...)` remains unsupported.
> 
> **Idiomatic `Gemfile` configs** now register **watch patterns** for the referenced version file so hook-env can react when that file changes. Docs and e2e cover `ruby file: ".ruby-version"` even when `.ruby-version` is not an idiomatic file on its own.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6937ec188516dd903588eb207e1a86a346b694a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ruby versions can now be detected from a Gemfile using Bundler’s `ruby file:` syntax.
  * Referenced `.ruby-version`, `.tool-versions`, or `mise.toml` files are supported.
  * Ruby engine and engine version declarations in Gemfiles are recognized.
  * Referenced files are resolved relative to the Gemfile, with unsafe paths rejected.
  * Changes to referenced version files are monitored for updates.

* **Documentation**
  * Added guidance and examples for pinning Ruby versions through Gemfiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->