### PR TITLE
fix(shim): resolve mise-shim.exe through a symlinked mise.exe on Windows

### DIFF
--- a/e2e-win/shim_source_symlink.Tests.ps1
+++ b/e2e-win/shim_source_symlink.Tests.ps1
@@ -1,0 +1,79 @@
+Describe 'exe shim source lookup through a symlinked mise' {
+    # Single-link layout: the PATH-visible mise.exe is a symlink while mise-shim.exe
+    # ships only beside the real binary. The lookup used to check only beside the
+    # link and on PATH, so "exe" shim mode silently fell back to "file" mode.
+
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        $script:OriginalPath = $env:PATH
+        $script:OriginalDataDir = [Environment]::GetEnvironmentVariable('MISE_DATA_DIR', 'Process')
+        $script:OriginalConfigFile = [Environment]::GetEnvironmentVariable('MISE_CONFIG_FILE', 'Process')
+        $script:OriginalTrustedConfigPaths = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $script:OriginalShimMode = [Environment]::GetEnvironmentVariable('MISE_WINDOWS_SHIM_MODE', 'Process')
+
+        # The single-link layout: real/bin/{mise.exe, mise-shim.exe} plus links/mise.exe -> real/bin/mise.exe
+        $script:RealBin = Join-Path $TestDrive 'real\bin'
+        $script:Links = Join-Path $TestDrive 'links'
+        New-Item -ItemType Directory -Path $script:RealBin -Force | Out-Null
+        New-Item -ItemType Directory -Path $script:Links -Force | Out-Null
+        $miseOnPath = (Get-Command -Type Application mise -All | Select-Object -First 1).Source
+        Copy-Item $miseOnPath (Join-Path $script:RealBin 'mise.exe')
+        Copy-Item (Join-Path (Split-Path $miseOnPath) 'mise-shim.exe') (Join-Path $script:RealBin 'mise-shim.exe')
+        $script:LinkedMise = Join-Path $script:Links 'mise.exe'
+        New-Item -ItemType SymbolicLink -Path $script:LinkedMise -Target (Join-Path $script:RealBin 'mise.exe') | Out-Null
+
+        # Strip PATH of any directory that can reach a mise-shim.exe and prepend the
+        # links directory: the linked mise is now the only mise on PATH.
+        $stripped = ($env:PATH -split ';' | Where-Object {
+            $_ -and -not (Test-Path -LiteralPath (Join-Path $_ 'mise-shim.exe'))
+        }) -join ';'
+        $env:PATH = "$($script:Links);$stripped"
+
+        # Isolated data dir and config; the lazy bin stages a jq shim without installing it.
+        $env:MISE_DATA_DIR = Join-Path $TestDrive 'data'
+        $env:MISE_CONFIG_FILE = Join-Path $TestDrive 'mise.toml'
+        $env:MISE_TRUSTED_CONFIG_PATHS = $TestDrive
+        Set-Location $TestDrive
+        @'
+[tools]
+jq = { version = "1.7.1", lazy = true, lazy_bins = ["jq.exe"] }
+'@ | Out-File -FilePath $env:MISE_CONFIG_FILE -Encoding utf8NoBOM
+
+        $env:MISE_WINDOWS_SHIM_MODE = 'exe'
+        & $script:LinkedMise reshim --force
+        $script:ReshimExit = $LASTEXITCODE
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        $env:PATH = $script:OriginalPath
+        foreach ($saved in @(
+            @{ Name = 'MISE_DATA_DIR'; Value = $script:OriginalDataDir },
+            @{ Name = 'MISE_CONFIG_FILE'; Value = $script:OriginalConfigFile },
+            @{ Name = 'MISE_TRUSTED_CONFIG_PATHS'; Value = $script:OriginalTrustedConfigPaths },
+            @{ Name = 'MISE_WINDOWS_SHIM_MODE'; Value = $script:OriginalShimMode }
+        )) {
+            if ($null -eq $saved.Value) {
+                Remove-Item -Path "Env:\$($saved.Name)" -ErrorAction SilentlyContinue
+            } else {
+                [Environment]::SetEnvironmentVariable($saved.Name, $saved.Value, 'Process')
+            }
+        }
+    }
+
+    It 'reshim succeeds with the symlinked mise as the only mise on PATH' {
+        $script:ReshimExit | Should -Be 0
+    }
+
+    It 'writes native exe shims from the mise-shim.exe beside the real binary' {
+        # Before the fix this was jq.cmd + an extension-less script (the "file" fallback).
+        $shim = Join-Path $env:MISE_DATA_DIR 'shims\jq.exe'
+        Test-Path $shim -PathType Leaf | Should -BeTrue
+        (Get-FileHash $shim).Hash | Should -Be (Get-FileHash (Join-Path $script:RealBin 'mise-shim.exe')).Hash
+    }
+
+    It 'does not leave file-mode shims behind' {
+        Test-Path (Join-Path $env:MISE_DATA_DIR 'shims\jq.cmd') | Should -BeFalse
+        Test-Path (Join-Path $env:MISE_DATA_DIR 'shims\jq') | Should -BeFalse
+    }
+}

--- a/e2e-win/shim_source_symlink.Tests.ps1
+++ b/e2e-win/shim_source_symlink.Tests.ps1
@@ -20,7 +20,27 @@ Describe 'exe shim source lookup through a symlinked mise' {
         Copy-Item $miseOnPath (Join-Path $script:RealBin 'mise.exe')
         Copy-Item (Join-Path (Split-Path $miseOnPath) 'mise-shim.exe') (Join-Path $script:RealBin 'mise-shim.exe')
         $script:LinkedMise = Join-Path $script:Links 'mise.exe'
-        New-Item -ItemType SymbolicLink -Path $script:LinkedMise -Target (Join-Path $script:RealBin 'mise.exe') | Out-Null
+        # Hosts without Developer Mode / elevation cannot create file symlinks;
+        # record that so the tests can skip instead of failing the whole suite.
+        $script:SymlinkUnavailable = $false
+        try {
+            New-Item -ItemType SymbolicLink -Path $script:LinkedMise -Target (Join-Path $script:RealBin 'mise.exe') -ErrorAction Stop | Out-Null
+        } catch {
+            # Only "this host refuses file symlinks" failures may skip: a missing
+            # privilege (no Developer Mode/elevation) surfaces as
+            # UnauthorizedAccessException/PermissionDenied and a filesystem without
+            # symlink support as InvalidOperationException/InvalidOperation (see
+            # FileSystemProvider.NewItemPrivate). Anything else is a fixture or
+            # path defect and must fail the run, not silently skip the coverage.
+            $hostRefusesSymlinks = ($_.Exception -is [System.UnauthorizedAccessException] -and
+                    $_.CategoryInfo.Category -eq 'PermissionDenied') -or
+                ($_.Exception -is [System.InvalidOperationException] -and
+                    $_.CategoryInfo.Category -eq 'InvalidOperation')
+            if (-not $hostRefusesSymlinks) {
+                throw
+            }
+            $script:SymlinkUnavailable = $true
+        }
 
         # Strip PATH of any directory that can reach a mise-shim.exe and prepend the
         # links directory: the linked mise is now the only mise on PATH.
@@ -40,8 +60,10 @@ jq = { version = "1.7.1", lazy = true, lazy_bins = ["jq.exe"] }
 '@ | Out-File -FilePath $env:MISE_CONFIG_FILE -Encoding utf8NoBOM
 
         $env:MISE_WINDOWS_SHIM_MODE = 'exe'
-        & $script:LinkedMise reshim --force
-        $script:ReshimExit = $LASTEXITCODE
+        if (-not $script:SymlinkUnavailable) {
+            & $script:LinkedMise reshim --force
+            $script:ReshimExit = $LASTEXITCODE
+        }
     }
 
     AfterAll {
@@ -62,10 +84,18 @@ jq = { version = "1.7.1", lazy = true, lazy_bins = ["jq.exe"] }
     }
 
     It 'reshim succeeds with the symlinked mise as the only mise on PATH' {
+        if ($script:SymlinkUnavailable) {
+            Set-ItResult -Skipped -Because 'this host cannot create file symlinks (enable Developer Mode or run elevated)'
+            return
+        }
         $script:ReshimExit | Should -Be 0
     }
 
     It 'writes native exe shims from the mise-shim.exe beside the real binary' {
+        if ($script:SymlinkUnavailable) {
+            Set-ItResult -Skipped -Because 'this host cannot create file symlinks (enable Developer Mode or run elevated)'
+            return
+        }
         # Before the fix this was jq.cmd + an extension-less script (the "file" fallback).
         $shim = Join-Path $env:MISE_DATA_DIR 'shims\jq.exe'
         Test-Path $shim -PathType Leaf | Should -BeTrue
@@ -73,6 +103,10 @@ jq = { version = "1.7.1", lazy = true, lazy_bins = ["jq.exe"] }
     }
 
     It 'does not leave file-mode shims behind' {
+        if ($script:SymlinkUnavailable) {
+            Set-ItResult -Skipped -Because 'this host cannot create file symlinks (enable Developer Mode or run elevated)'
+            return
+        }
         Test-Path (Join-Path $env:MISE_DATA_DIR 'shims\jq.cmd') | Should -BeFalse
         Test-Path (Join-Path $env:MISE_DATA_DIR 'shims\jq') | Should -BeFalse
     }

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -1215,14 +1215,17 @@ fn old_shim_path(path: &Path) -> PathBuf {
     path.with_file_name(name)
 }
 
-/// Find the `mise-shim.exe` that ships beside `mise_bin`, if there is one.
+/// Find the `mise-shim.exe` that ships beside the real `mise_bin` — following
+/// symlinks/junctions — if there is one.
 ///
 /// Not `#[cfg(windows)]`, unlike the shim code around it: `mise generate task-stubs
 /// --windows-launcher=exe` asks the same question, and on a host where the answer is always `None`
 /// that is the honest answer to report rather than a compile error to route around.
 pub(crate) fn find_mise_shim_bin(mise_bin: &Path) -> Option<PathBuf> {
-    // Look next to the mise binary first
-    if let Some(parent) = mise_bin.parent() {
+    // mise-shim.exe ships beside the real mise.exe, which may sit behind a
+    // symlink or junction (dunce avoids the `\\?\` verbatim prefix)
+    let real_bin = dunce::canonicalize(mise_bin).unwrap_or_else(|_| mise_bin.to_path_buf());
+    if let Some(parent) = real_bin.parent() {
         let candidate = parent.join("mise-shim.exe");
         if candidate.is_file() {
             return Some(candidate);
@@ -2734,5 +2737,129 @@ mod tests {
             "2026.5.16",
             "symlink"
         ));
+    }
+
+    /// Create a file symlink, or return `false` when the platform refuses
+    /// (Windows without the symlink privilege) so the caller can skip itself.
+    fn try_symlink_file(target: &Path, link: &Path) -> bool {
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(target, link).is_ok()
+        }
+        #[cfg(windows)]
+        {
+            match std::os::windows::fs::symlink_file(target, link) {
+                Ok(()) => true,
+                Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => false,
+                Err(err) => panic!("failed to create file symlink: {err}"),
+            }
+        }
+    }
+
+    /// A single-link mise layout: the PATH-visible `mise.exe` is a link, and
+    /// `mise-shim.exe` ships only beside the real binary. Returns the linked
+    /// mise and the real shim, or `None` when symlinks cannot be created on
+    /// this host.
+    fn single_link_layout(temp: &Path) -> Option<(PathBuf, PathBuf)> {
+        let real_dir = temp.join("real").join("bin");
+        let links_dir = temp.join("links");
+        fs::create_dir_all(&real_dir).unwrap();
+        fs::create_dir_all(&links_dir).unwrap();
+        let real_mise = real_dir.join("mise.exe");
+        fs::write(&real_mise, "mise").unwrap();
+        let real_shim = real_dir.join("mise-shim.exe");
+        fs::write(&real_shim, "mise-shim").unwrap();
+        let linked_mise = links_dir.join("mise.exe");
+        if !try_symlink_file(&real_mise, &linked_mise) {
+            return None;
+        }
+        Some((linked_mise, real_shim))
+    }
+
+    #[test]
+    fn find_mise_shim_bin_finds_the_shim_beside_the_binary() {
+        let temp = tempfile::tempdir().unwrap();
+        let bin = temp.path().join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        fs::write(bin.join("mise.exe"), "mise").unwrap();
+        let shim = bin.join("mise-shim.exe");
+        fs::write(&shim, "mise-shim").unwrap();
+
+        let found = find_mise_shim_bin(&bin.join("mise.exe")).expect("shim beside the binary");
+        assert_eq!(
+            dunce::canonicalize(&found).unwrap(),
+            dunce::canonicalize(&shim).unwrap()
+        );
+    }
+
+    #[test]
+    fn find_mise_shim_bin_follows_a_symlinked_mise_bin() {
+        let temp = tempfile::tempdir().unwrap();
+        let Some((linked_mise, real_shim)) = single_link_layout(temp.path()) else {
+            return;
+        };
+
+        // Regression: the old lookup checked only beside the link and on PATH.
+        let found = find_mise_shim_bin(&linked_mise).expect("shim beside the real binary");
+        assert_eq!(
+            dunce::canonicalize(&found).unwrap(),
+            dunce::canonicalize(&real_shim).unwrap()
+        );
+    }
+
+    #[test]
+    fn find_mise_shim_bin_follows_chained_symlinks() {
+        let temp = tempfile::tempdir().unwrap();
+        let Some((linked_mise, real_shim)) = single_link_layout(temp.path()) else {
+            return;
+        };
+        let redirect_dir = temp.path().join("redirect");
+        fs::create_dir_all(&redirect_dir).unwrap();
+        let redirected = redirect_dir.join("mise.exe");
+        if !try_symlink_file(&linked_mise, &redirected) {
+            return;
+        }
+
+        let found = find_mise_shim_bin(&redirected).expect("shim through two links");
+        assert_eq!(
+            dunce::canonicalize(&found).unwrap(),
+            dunce::canonicalize(&real_shim).unwrap()
+        );
+    }
+
+    #[test]
+    fn find_mise_shim_bin_prefers_the_shim_beside_the_real_binary() {
+        let temp = tempfile::tempdir().unwrap();
+        let Some((linked_mise, real_shim)) = single_link_layout(temp.path()) else {
+            return;
+        };
+        let beside_link = temp.path().join("links").join("mise-shim.exe");
+        fs::write(&beside_link, "another shim").unwrap();
+
+        let found = find_mise_shim_bin(&linked_mise).expect("a shim beside the real binary");
+        assert_eq!(
+            dunce::canonicalize(&found).unwrap(),
+            dunce::canonicalize(&real_shim).unwrap()
+        );
+        assert_ne!(
+            dunce::canonicalize(&found).unwrap(),
+            dunce::canonicalize(&beside_link).unwrap()
+        );
+    }
+
+    #[test]
+    fn find_mise_shim_bin_returns_none_when_no_shim_exists() {
+        let temp = tempfile::tempdir().unwrap();
+        let bin = temp.path().join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        let mise = bin.join("mise.exe");
+        fs::write(&mise, "mise").unwrap();
+
+        // A mise-shim.exe on PATH happens in dev environments that build it, so
+        // the assertion is scoped to what this test controls.
+        let found = find_mise_shim_bin(&mise);
+        if file::which("mise-shim.exe").is_none() {
+            assert_eq!(found, None);
+        }
     }
 }

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -2740,19 +2740,31 @@ mod tests {
     }
 
     /// Create a file symlink, or return `false` when the platform refuses
-    /// (Windows without the symlink privilege) so the caller can skip itself.
+    /// (e.g. Windows without the symlink privilege) so the caller can skip
+    /// itself. Any other failure panics: swallowing it would silently turn the
+    /// new coverage into a no-op.
     fn try_symlink_file(target: &Path, link: &Path) -> bool {
-        #[cfg(unix)]
-        {
-            std::os::unix::fs::symlink(target, link).is_ok()
-        }
-        #[cfg(windows)]
-        {
-            match std::os::windows::fs::symlink_file(target, link) {
-                Ok(()) => true,
-                Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => false,
-                Err(err) => panic!("failed to create file symlink: {err}"),
+        let result = {
+            #[cfg(unix)]
+            {
+                std::os::unix::fs::symlink(target, link)
             }
+            #[cfg(windows)]
+            {
+                std::os::windows::fs::symlink_file(target, link)
+            }
+        };
+        match result {
+            Ok(()) => true,
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::Unsupported
+                ) =>
+            {
+                false
+            }
+            Err(err) => panic!("failed to create file symlink: {err}"),
         }
     }
 
@@ -2856,9 +2868,14 @@ mod tests {
         fs::write(&mise, "mise").unwrap();
 
         // A mise-shim.exe on PATH happens in dev environments that build it, so
-        // the assertion is scoped to what this test controls.
+        // the assertion is scoped to what this test controls. `file::which` on
+        // Windows matches the extension only, so filter to existing files the
+        // same way the resolver does before deciding to skip.
         let found = find_mise_shim_bin(&mise);
-        if file::which("mise-shim.exe").is_none() {
+        if file::which("mise-shim.exe")
+            .filter(|p| p.is_file())
+            .is_none()
+        {
             assert_eq!(found, None);
         }
     }


### PR DESCRIPTION
# fix(shim): resolve mise-shim.exe through a symlinked mise.exe on Windows

## Problem

On Windows, `find_mise_shim_bin` located the `mise-shim.exe` source by looking only beside the invoked `mise.exe`, then falling back to PATH.

When mise.exe is invoked through a symlink or junction (e.g. a hand-made link in a PATH bin directory), `mise-shim.exe` — which ships beside the *real* mise.exe in the release archives — is found by neither lookup, and `"exe"` shim mode silently falls back to `"file"` mode, with no warning.

Repro before the fix:

```powershell
New-Item -ItemType SymbolicLink -Path C:\bin\mise.exe -Target <path to the real mise.exe>
$env:MISE_WINDOWS_SHIM_MODE = 'exe'
mise reshim --force   # writes jq.cmd + an extension-less jq instead of a native jq.exe
```

## Fix

Resolve the link with `dunce::canonicalize` (resolves symlinks/junctions without the `\\?\` verbatim prefix; on failure the invoked path is used as-is) and look beside the real binary: the release archives are the authority for where mise-shim.exe lives. PATH remains the fallback.

```rust
pub(crate) fn find_mise_shim_bin(mise_bin: &Path) -> Option<PathBuf> {
    // mise-shim.exe ships beside the real mise.exe, which may sit behind a
    // symlink or junction (dunce avoids the `\\?\` verbatim prefix)
    let real_bin = dunce::canonicalize(mise_bin).unwrap_or_else(|_| mise_bin.to_path_buf());
    if let Some(parent) = real_bin.parent() {
        let candidate = parent.join("mise-shim.exe");
        if candidate.is_file() {
            return Some(candidate);
        }
    }
    // Fall back to searching PATH
    file::which("mise-shim.exe").filter(|p| p.is_file())
}
```

The lookup order becomes **beside the real binary > PATH**. The resolve costs about one `stat` (measured ~23 µs, and it runs once per command rather than once per shim), so overhead is imperceptible.

## Coverage

Unit tests in `src/shims.rs` (run on all platforms; they skip themselves only where the host refuses to create symlinks — missing privilege or an unsupported filesystem — and panic on any other fixture failure instead of silently skipping):

| test | scenario |
|---|---|
| `find_mise_shim_bin_finds_the_shim_beside_the_binary` | baseline: shim beside the binary |
| `find_mise_shim_bin_follows_a_symlinked_mise_bin` | single-link layout: the PATH-visible mise.exe is a link, the shim ships only beside the real binary |
| `find_mise_shim_bin_follows_chained_symlinks` | link-to-link chains resolve |
| `find_mise_shim_bin_prefers_the_shim_beside_the_real_binary` | when both sides have a shim, the real binary's is returned |
| `find_mise_shim_bin_returns_none_when_no_shim_exists` | `None` when no shim exists |

`e2e-win/shim_source_symlink.Tests.ps1` reproduces the single-link layout end to end: it stages `real/bin/{mise.exe, mise-shim.exe}` plus `links/mise.exe -> real/bin/mise.exe`, strips PATH of any directory that can reach a mise-shim.exe so the linked mise is the only one visible, runs `reshim --force` with `MISE_WINDOWS_SHIM_MODE=exe`, and asserts that a native `shims/jq.exe` is written (hash-identical to the real mise-shim.exe) with no `jq.cmd`/`jq` file-mode leftovers. When the host cannot create file symlinks (no Developer Mode/elevation), the suite skips via `Set-ItResult` rather than failing; only privilege/unsupported-filesystem errors trigger the skip, any other setup error fails the run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows shim handling when the active `mise.exe` is accessed through a symlink or junction.
  - Native executable shims are now created correctly in these redirected installations, with fallback behavior preserved when needed.
  - Prevented incorrect file-based shims from being generated in executable shim mode.

- **Tests**
  - Added coverage for symlinked, chained, and direct Windows binary layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->