### PR TITLE
refactor: simplify match guards for rust 1.95 clippy

### DIFF
--- a/src/backend/cargo.rs
+++ b/src/backend/cargo.rs
@@ -282,16 +282,15 @@ impl Backend for CargoBackend {
                     bail!("cargo-binstall is not available, but cargo.binstall_only is set");
                 }
                 BinstallStatus::Unavailable => match Settings::get().cargo.binstall_native {
-                    Some(true) => {
+                    Some(true)
                         if self
                             .native_binstall(ctx, &tv, NativeBinstallAction::Install)
-                            .await?
-                        {
-                            self.write_install_state_best_effort(&tv);
-                            return Ok(tv.clone());
-                        }
+                            .await? =>
+                    {
+                        self.write_install_state_best_effort(&tv);
+                        return Ok(tv.clone());
                     }
-                    Some(false) => {}
+                    Some(_) => {}
                     None if native_binstall::rollout_warning_active() => {
                         self.native_binstall(ctx, &tv, NativeBinstallAction::WarnOnly)
                             .await?;

--- a/src/task/task_source_checker.rs
+++ b/src/task/task_source_checker.rs
@@ -289,10 +289,8 @@ fn parent_dir_pops_glob(pattern: &Path) -> bool {
     for component in pattern.components() {
         match component {
             Component::CurDir => {}
-            Component::ParentDir => {
-                if stack.pop() == Some(true) {
-                    return true;
-                }
+            Component::ParentDir if stack.pop() == Some(true) => {
+                return true;
             }
             Component::Normal(part) => {
                 stack.push(part.to_string_lossy().contains(['*', '?', '[', '{']));


### PR DESCRIPTION
## Summary

Prerequisite for the replacement explicit-tracking stack. Simplify two existing nested match conditions so Rust 1.95 Clippy can run with warnings denied, without lint exclusions or behavior changes.

## Verification

- Repository lint-fix passed on the integrated tree containing these exact changes.
- Full workspace Clippy and CI are being checked as the replacement stack is assembled.

This PR must not be merged automatically.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical control-flow refactors only; install and task source-matching logic are unchanged aside from Clippy-friendly syntax.
> 
> **Overview**
> Prepares the tree for **Rust 1.95 Clippy with warnings denied** by rewriting two nested `match` patterns into guard-style arms, with **no intended behavior change**.
> 
> In **`cargo.rs`**, the native-binstall fallback when `cargo-binstall` is unavailable now uses **`Some(true) if native_binstall(...).await?`** instead of an inner `if`, and **`Some(false)`** is folded into **`Some(_)`** for other explicit settings values.
> 
> In **`task_source_checker.rs`**, **`parent_dir_pops_glob`** detects a `..` that pops a glob segment via a **`Component::ParentDir if stack.pop() == Some(true)`** guard instead of a nested block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 158c392f1891db1816b50c4c8a96d677e2fcbf6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal control flow was simplified while preserving existing installation behavior.
  * Parent-directory handling for glob paths was streamlined without changing traversal detection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->