### PR TITLE
docs: remove homepage tagline

### DIFF
--- a/docs/.vitepress/theme/HomeHero.vue
+++ b/docs/.vitepress/theme/HomeHero.vue
@@ -101,9 +101,8 @@ onUnmounted(() => clearTimeout(copyTimeout));
 <template>
   <section class="home-hero" aria-labelledby="home-title">
     <div class="hero-copy">
-      <p class="hero-eyebrow">mise-en-place / everything in its place</p>
-      <h1 id="home-title">
-        Your dev setup. <br class="hero-break" /><em>In good order.</em>
+      <h1 id="home-title" class="hero-eyebrow">
+        mise-en-place / everything in its place
       </h1>
       <p class="hero-lede">
         Declare your tool versions, environment variables, and commands in

--- a/docs/.vitepress/theme/landing.css
+++ b/docs/.vitepress/theme/landing.css
@@ -751,17 +751,6 @@ a:hover > div + .card-link::after {
   color: var(--vp-c-brand-1);
   line-height: 1.7;
 }
-.hero-copy h1 {
-  font-family: var(--vp-font-family-heading);
-  font-size: clamp(3.5rem, 5.6vw, 5rem);
-  font-weight: 500;
-  letter-spacing: -0.045em;
-  line-height: 0.98;
-}
-.hero-copy h1 em {
-  color: var(--vp-c-brand-1);
-  font-weight: 400;
-}
 .hero-lede {
   max-width: 42ch;
   margin: 26px 0 0;
@@ -1035,9 +1024,6 @@ a:hover > div + .card-link::after {
     gap: 40px;
     padding-top: 48px;
   }
-  .hero-copy h1 {
-    font-size: clamp(3.5rem, 9vw, 5rem);
-  }
   .hero-lede {
     max-width: 48ch;
   }
@@ -1057,14 +1043,8 @@ a:hover > div + .card-link::after {
   .hero-eyebrow {
     margin-bottom: 20px;
   }
-  .hero-copy h1 {
-    font-size: clamp(3rem, 12vw, 4rem);
-  }
   .hero-lede {
     font-size: 1rem;
-  }
-  .hero-break {
-    display: none;
   }
   .hero-actions {
     gap: 10px;


### PR DESCRIPTION
Remove “Your dev setup. In good order.” from the homepage and delete its unused styles. Use the existing mise-en-place line as the page heading, preserving the hero section's accessible label.

Validation: scoped hk formatting passed; the docs build passed, including 6 social-image tests and metadata checks for 333 pages.

*AI-assisted — Tool: Codex; model: openai/gpt-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only homepage copy and CSS cleanup with no runtime or security impact.
> 
> **Overview**
> Removes the large hero headline **“Your dev setup. In good order.”** from the docs homepage and promotes the **mise-en-place / everything in its place** line to the sole `<h1>` (still `id="home-title"` for `aria-labelledby`).
> 
> **`landing.css`** drops the dedicated `.hero-copy h1` typography (including the emphasized brand styling) and responsive rules for that headline and `.hero-break`, since the hero no longer uses that layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 384258169fd92b199f4e9b3207e9117da00d8b49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the homepage hero heading to display “mise-en-place / everything in its place.”
  * Simplified the hero heading layout and removed the previous tagline, heading text, and line break.
  * Removed styling specific to the former hero heading and responsive line-break behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->