### PR TITLE
test(bootstrap): cover ordinary dotfile history and recovery

### DIFF
--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -164,6 +164,7 @@ jobs:
           '^test_dotfiles_rollback_types$' '^test_bootstrap_user_services$'
           '^test_dotfiles_rollback_review$' '^test_dotfiles_sync_permissions$'
           '^test_dotfiles_managed_manual$' '^test_bootstrap_from_git_dumb_http$'
+          '^test_dotfiles_alias_enrollment$'
           '^test_dotfiles_watch$' '^test_dotfiles_watch_pending$'
           '^test_dotfiles_watch_throttle$' '^test_dotfiles_sync$'
           '^test_dotfiles_sync_files_encrypted$' '^test_dotfiles_directory_permissions$'

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -153,6 +153,23 @@ jobs:
       # The full E2E suite runs on Linux. Tests whose filenames contain `macos`
       # are also discovered and exercised here for platform-specific coverage.
       - run: mise run test:e2e macos
+      # Tracked history shells out to git and needs the Xcode Command
+      # Line Tools guard exercised on a real macOS runner.
+      - run: mise run test:e2e e2e/cli/test_dotfiles_history_bootstrap
+      - run: mise run test:e2e e2e/cli/test_dotfiles_history
+      - run: mise run test:e2e e2e/cli/test_dotfiles_recovery_journey
+      - run: mise run test:e2e e2e/cli/test_dotfiles_capture
+      - run: mise run test:e2e e2e/cli/test_dotfiles_onboarding
+      - run: mise run test:e2e e2e/cli/test_dotfiles_track
+      - run: mise run test:e2e e2e/cli/test_dotfiles_history_policies
+      - run: mise run test:e2e e2e/cli/test_dotfiles_rollback
+      - run: mise run test:e2e e2e/cli/test_dotfiles_rollback_types
+      - run: mise run test:e2e e2e/cli/test_bootstrap_user_services
+      - run: mise run test:e2e e2e/cli/test_dotfiles_watch
+      - run: mise run test:e2e e2e/cli/test_dotfiles_watch_pending
+      - run: mise run test:e2e e2e/cli/test_dotfiles_watch_throttle
+      - run: mise run test:e2e e2e/cli/test_dotfiles_sync
+      - run: mise run test:e2e e2e/cli/test_dotfiles_sync_files_encrypted e2e/cli/test_dotfiles_directory_permissions
 
   lint:
     runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-large;overrides.cache-tag=cache' }}

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -162,6 +162,7 @@ jobs:
           '^test_dotfiles_onboarding$' '^test_dotfiles_track$'
           '^test_dotfiles_history_policies$' '^test_dotfiles_rollback$'
           '^test_dotfiles_rollback_types$' '^test_bootstrap_user_services$'
+          '^test_dotfiles_rollback_review$' '^test_dotfiles_sync_permissions$'
           '^test_dotfiles_watch$' '^test_dotfiles_watch_pending$'
           '^test_dotfiles_watch_throttle$' '^test_dotfiles_sync$'
           '^test_dotfiles_sync_files_encrypted$' '^test_dotfiles_directory_permissions$'

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -163,6 +163,7 @@ jobs:
           '^test_dotfiles_history_policies$' '^test_dotfiles_rollback$'
           '^test_dotfiles_rollback_types$' '^test_bootstrap_user_services$'
           '^test_dotfiles_rollback_review$' '^test_dotfiles_sync_permissions$'
+          '^test_dotfiles_managed_manual$' '^test_bootstrap_from_git_dumb_http$'
           '^test_dotfiles_watch$' '^test_dotfiles_watch_pending$'
           '^test_dotfiles_watch_throttle$' '^test_dotfiles_sync$'
           '^test_dotfiles_sync_files_encrypted$' '^test_dotfiles_directory_permissions$'

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -155,21 +155,16 @@ jobs:
       - run: mise run test:e2e macos
       # Tracked history shells out to git and needs the Xcode Command
       # Line Tools guard exercised on a real macOS runner.
-      - run: mise run test:e2e e2e/cli/test_dotfiles_history_bootstrap
-      - run: mise run test:e2e e2e/cli/test_dotfiles_history
-      - run: mise run test:e2e e2e/cli/test_dotfiles_recovery_journey
-      - run: mise run test:e2e e2e/cli/test_dotfiles_capture
-      - run: mise run test:e2e e2e/cli/test_dotfiles_onboarding
-      - run: mise run test:e2e e2e/cli/test_dotfiles_track
-      - run: mise run test:e2e e2e/cli/test_dotfiles_history_policies
-      - run: mise run test:e2e e2e/cli/test_dotfiles_rollback
-      - run: mise run test:e2e e2e/cli/test_dotfiles_rollback_types
-      - run: mise run test:e2e e2e/cli/test_bootstrap_user_services
-      - run: mise run test:e2e e2e/cli/test_dotfiles_watch
-      - run: mise run test:e2e e2e/cli/test_dotfiles_watch_pending
-      - run: mise run test:e2e e2e/cli/test_dotfiles_watch_throttle
-      - run: mise run test:e2e e2e/cli/test_dotfiles_sync
-      - run: mise run test:e2e e2e/cli/test_dotfiles_sync_files_encrypted e2e/cli/test_dotfiles_directory_permissions
+      - run: >-
+          mise run test:e2e
+          '^test_dotfiles_history_bootstrap$' '^test_dotfiles_history$'
+          '^test_dotfiles_recovery_journey$' '^test_dotfiles_capture$'
+          '^test_dotfiles_onboarding$' '^test_dotfiles_track$'
+          '^test_dotfiles_history_policies$' '^test_dotfiles_rollback$'
+          '^test_dotfiles_rollback_types$' '^test_bootstrap_user_services$'
+          '^test_dotfiles_watch$' '^test_dotfiles_watch_pending$'
+          '^test_dotfiles_watch_throttle$' '^test_dotfiles_sync$'
+          '^test_dotfiles_sync_files_encrypted$' '^test_dotfiles_directory_permissions$'
 
   lint:
     runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-large;overrides.cache-tag=cache' }}

--- a/e2e-win/dotfiles.Tests.ps1
+++ b/e2e-win/dotfiles.Tests.ps1
@@ -102,32 +102,17 @@ Describe 'dotfiles' {
         Test-Path $script:Target | Should -BeFalse
     }
 
-    It 'records a history checkpoint pair for an apply' {
-        # The previous test left the target unapplied, so this apply changes something and
-        # must leave a pair of checkpoints behind; a no-op apply would record nothing.
+    It 'does not enroll an untracked deployment or retain its operation history' {
+        # Deployment ownership is not enrollment. Temporary write recovery must
+        # not become ongoing file history after a successful apply.
         mise bootstrap dotfiles apply 2>&1 | Out-String | Out-Null
         $LASTEXITCODE | Should -Be 0
 
         $json = mise bootstrap dotfiles history --json 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
-        $checkpoints = $json | ConvertFrom-Json
-        @($checkpoints).Count | Should -BeGreaterOrEqual 1
-        $latest = @($checkpoints)[0]
-        $latest.operation.status | Should -Be 'completed'
-        $latest.operation.command | Should -BeLike 'bootstrap dotfiles apply*'
-        $latest.trigger | Should -Be 'bootstrap'
-        $status = mise bootstrap dotfiles status --json 2>&1 | Out-String | ConvertFrom-Json
-        $status.history.unavailable | Should -BeNullOrEmpty -Because ("the store should be usable: " + ($status.history | ConvertTo-Json -Depth 6 -Compress))
-        $latest.tree.available | Should -BeTrue -Because ("the checkpoint should hold a snapshot: " + ($latest.tree | ConvertTo-Json -Depth 4 -Compress))
-        Test-Path (Join-Path $env:MISE_STATE_DIR 'history\repo.git') | Should -BeTrue -Because ("the store lives under " + $env:MISE_STATE_DIR)
-
-        $out = mise bootstrap dotfiles history show latest 2>&1 | Out-String
-        $LASTEXITCODE | Should -Be 0
-        $out | Should -BeLike '*Operation:*bootstrap (completed)*'
-
-        $history = mise bootstrap dotfiles history --json 2>&1 | Out-String
-        $LASTEXITCODE | Should -Be 0
-        $checkpoints = $history | ConvertFrom-Json
-        @($checkpoints)[1].trigger | Should -Be 'bootstrap-before'
+        $checkpoints = @($json | ConvertFrom-Json)
+        $checkpoints.Count | Should -Be 0
+        $pending = Join-Path $env:MISE_STATE_DIR 'history\pending'
+        @(Get-ChildItem $pending -ErrorAction SilentlyContinue).Count | Should -Be 0
     }
 }

--- a/e2e-win/dotfiles.Tests.ps1
+++ b/e2e-win/dotfiles.Tests.ps1
@@ -1,5 +1,7 @@
 Describe 'dotfiles' {
     BeforeAll {
+        $script:OriginalExperimental = [Environment]::GetEnvironmentVariable('MISE_EXPERIMENTAL', 'Process')
+        $env:MISE_EXPERIMENTAL = '0'
         $script:OriginalDir = Get-Location
         $script:TestRoot = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
         New-Item -ItemType Directory -Path $script:TestRoot | Out-Null
@@ -8,6 +10,9 @@ Describe 'dotfiles' {
         # an inherited value would leave the next suite without it.
         $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
         $env:MISE_TRUSTED_CONFIG_PATHS = $script:TestRoot
+        # Applies record file checkpoints under the state dir; keep them out of the runner's.
+        $script:OriginalStateDir = [Environment]::GetEnvironmentVariable('MISE_STATE_DIR', 'Process')
+        $env:MISE_STATE_DIR = Join-Path $script:TestRoot "state"
 
         New-Item -ItemType Directory -Path (Join-Path $script:TestRoot "dotfiles") | Out-Null
         $script:Source = Join-Path $script:TestRoot "dotfiles\gitconfig"
@@ -24,12 +29,18 @@ Describe 'dotfiles' {
     }
 
     AfterAll {
+        [Environment]::SetEnvironmentVariable('MISE_EXPERIMENTAL', $script:OriginalExperimental, 'Process')
         Set-Location $script:OriginalDir
         Remove-Item -Path $script:TestRoot -Recurse -Force -ErrorAction Ignore
         if ($null -eq $script:OriginalTrusted) {
             Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
         } else {
             [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+        if ($null -eq $script:OriginalStateDir) {
+            Remove-Item Env:MISE_STATE_DIR -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_STATE_DIR', $script:OriginalStateDir, 'Process')
         }
     }
 
@@ -61,6 +72,21 @@ Describe 'dotfiles' {
         Write-Host "  applied as: $(if ($link) { $link } else { 'copy' })"
     }
 
+    It 'keeps history private despite inherited parent permissions' {
+        mise bootstrap dotfiles apply 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        $history = Join-Path $env:MISE_STATE_DIR 'history'
+        $acl = Get-Acl -LiteralPath $history
+        $acl.AreAccessRulesProtected | Should -BeTrue
+        $acl.Sddl | Should -Match ';;;OW\)'
+        @($acl.Access).Count | Should -Be 1
+        $probe = Join-Path $history 'private-acl-probe'
+        Set-Content -LiteralPath $probe -Value 'private'
+        $inherited = Get-Acl -LiteralPath $probe
+        @($inherited.Access).Count | Should -Be 1
+        $inherited.Sddl | Should -Match ';;;OW\)'
+    }
+
     It 'unapplies without needing --force' {
         # The regression this guards: a real symlink used to be routed through the content
         # comparison, which rejects a symlink and demands --force.
@@ -74,5 +100,34 @@ Describe 'dotfiles' {
         mise bootstrap dotfiles unapply 2>&1 | Out-String | Out-Null
         $LASTEXITCODE | Should -Be 0
         Test-Path $script:Target | Should -BeFalse
+    }
+
+    It 'records a history checkpoint pair for an apply' {
+        # The previous test left the target unapplied, so this apply changes something and
+        # must leave a pair of checkpoints behind; a no-op apply would record nothing.
+        mise bootstrap dotfiles apply 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        $json = mise bootstrap dotfiles history --json 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $checkpoints = $json | ConvertFrom-Json
+        @($checkpoints).Count | Should -BeGreaterOrEqual 1
+        $latest = @($checkpoints)[0]
+        $latest.operation.status | Should -Be 'completed'
+        $latest.operation.command | Should -BeLike 'bootstrap dotfiles apply*'
+        $latest.trigger | Should -Be 'bootstrap'
+        $status = mise bootstrap dotfiles status --json 2>&1 | Out-String | ConvertFrom-Json
+        $status.history.unavailable | Should -BeNullOrEmpty -Because ("the store should be usable: " + ($status.history | ConvertTo-Json -Depth 6 -Compress))
+        $latest.tree.available | Should -BeTrue -Because ("the checkpoint should hold a snapshot: " + ($latest.tree | ConvertTo-Json -Depth 4 -Compress))
+        Test-Path (Join-Path $env:MISE_STATE_DIR 'history\repo.git') | Should -BeTrue -Because ("the store lives under " + $env:MISE_STATE_DIR)
+
+        $out = mise bootstrap dotfiles history show latest 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -BeLike '*Operation:*bootstrap (completed)*'
+
+        $history = mise bootstrap dotfiles history --json 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $checkpoints = $history | ConvertFrom-Json
+        @($checkpoints)[1].trigger | Should -Be 'bootstrap-before'
     }
 }

--- a/e2e-win/dotfiles_watch.Tests.ps1
+++ b/e2e-win/dotfiles_watch.Tests.ps1
@@ -1,0 +1,69 @@
+Describe 'history watch' {
+    BeforeAll {
+        $script:OriginalExperimental = [Environment]::GetEnvironmentVariable('MISE_EXPERIMENTAL', 'Process')
+        $env:MISE_EXPERIMENTAL = '0'
+        $script:OriginalDir = Get-Location
+        Set-Location TestDrive:
+
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $env:MISE_TRUSTED_CONFIG_PATHS = $TestDrive
+        $script:OriginalConfigDir = [Environment]::GetEnvironmentVariable('MISE_CONFIG_DIR', 'Process')
+        $script:OriginalStateDir = [Environment]::GetEnvironmentVariable('MISE_STATE_DIR', 'Process')
+        $env:MISE_CONFIG_DIR = Join-Path $TestDrive 'config'
+        $env:MISE_STATE_DIR = Join-Path $TestDrive 'state'
+        New-Item -ItemType Directory -Force -Path $env:MISE_CONFIG_DIR | Out-Null
+        $script:Tracked = Join-Path $TestDrive 'tracked'
+        New-Item -ItemType Directory -Force -Path $script:Tracked | Out-Null
+        'one' | Out-File -FilePath (Join-Path $script:Tracked 'file.txt') -Encoding utf8NoBOM
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        foreach ($pair in @(
+                @('MISE_EXPERIMENTAL', $script:OriginalExperimental),
+                @('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted),
+                @('MISE_CONFIG_DIR', $script:OriginalConfigDir),
+                @('MISE_STATE_DIR', $script:OriginalStateDir))) {
+            if ($null -eq $pair[1]) {
+                Remove-Item ("Env:" + $pair[0]) -ErrorAction Ignore
+            } else {
+                [Environment]::SetEnvironmentVariable($pair[0], $pair[1], 'Process')
+            }
+        }
+    }
+
+    It 'tracks without experimental opt-in' {
+        $env:MISE_EXPERIMENTAL = '0'
+        try {
+            $output = mise bootstrap dotfiles track $script:Tracked 2>&1 | Out-String
+            $LASTEXITCODE | Should -Be 0
+            $output | Should -Not -Match 'dotfile tracking is experimental'
+        } finally {
+            $env:MISE_EXPERIMENTAL = '0'
+        }
+    }
+
+    It 'reconciles once and reports capture health' {
+        $tracked = $script:Tracked -replace '\\', '/'
+        mise bootstrap dotfiles track $tracked 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+
+        $status = mise bootstrap dotfiles status --json | Out-String | ConvertFrom-Json
+        $status.history.watcher | Should -Be 'not-declared'
+        $before = @(mise bootstrap dotfiles history --json | Out-String | ConvertFrom-Json).Count
+
+        'two' | Out-File -FilePath (Join-Path $script:Tracked 'file.txt') -Encoding utf8NoBOM
+        mise bootstrap dotfiles watch --once 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        $entries = mise bootstrap dotfiles history --json | Out-String | ConvertFrom-Json
+        $entries.Count | Should -Be ($before + 1)
+        $entries[0].trigger | Should -Be 'edit'
+
+        @"
+[bootstrap.services.mise-history]
+builtin = "history-watch"
+"@ | Out-File -FilePath (Join-Path $env:MISE_CONFIG_DIR 'config.toml') -Encoding utf8NoBOM
+        $status = mise bootstrap dotfiles status --json | Out-String | ConvertFrom-Json
+        $status.history.watcher | Should -Be 'declared-not-running'
+    }
+}

--- a/e2e-win/dotfiles_watch.Tests.ps1
+++ b/e2e-win/dotfiles_watch.Tests.ps1
@@ -55,7 +55,7 @@ Describe 'history watch' {
         'two' | Out-File -FilePath (Join-Path $script:Tracked 'file.txt') -Encoding utf8NoBOM
         mise bootstrap dotfiles watch --once 2>&1 | Out-String | Out-Null
         $LASTEXITCODE | Should -Be 0
-        $entries = mise bootstrap dotfiles history --json | Out-String | ConvertFrom-Json
+        $entries = @(mise bootstrap dotfiles history --json | Out-String | ConvertFrom-Json)
         $entries.Count | Should -Be ($before + 1)
         $entries[0].trigger | Should -Be 'edit'
 

--- a/e2e-win/dotfiles_watch.Tests.ps1
+++ b/e2e-win/dotfiles_watch.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'history watch' {
         $env:MISE_CONFIG_DIR = Join-Path $TestDrive 'config'
         $env:MISE_STATE_DIR = Join-Path $TestDrive 'state'
         New-Item -ItemType Directory -Force -Path $env:MISE_CONFIG_DIR | Out-Null
-        $script:Tracked = Join-Path $TestDrive 'tracked'
+        $script:Tracked = Join-Path $env:MISE_CONFIG_DIR 'tracked'
         New-Item -ItemType Directory -Force -Path $script:Tracked | Out-Null
         'one' | Out-File -FilePath (Join-Path $script:Tracked 'file.txt') -Encoding utf8NoBOM
     }

--- a/e2e-win/dotfiles_watch.Tests.ps1
+++ b/e2e-win/dotfiles_watch.Tests.ps1
@@ -62,7 +62,7 @@ Describe 'history watch' {
         @"
 [bootstrap.services.mise-history]
 builtin = "history-watch"
-"@ | Out-File -FilePath (Join-Path $env:MISE_CONFIG_DIR 'config.toml') -Encoding utf8NoBOM
+"@ | Out-File -FilePath (Join-Path $env:MISE_CONFIG_DIR 'config.toml') -Encoding utf8NoBOM -Append
         $status = mise bootstrap dotfiles status --json | Out-String | ConvertFrom-Json
         $status.history.watcher | Should -Be 'declared-not-running'
     }

--- a/e2e-win/services.Tests.ps1
+++ b/e2e-win/services.Tests.ps1
@@ -1,0 +1,106 @@
+Describe 'bootstrap user services' {
+    BeforeAll {
+        $script:OriginalExperimental = [Environment]::GetEnvironmentVariable('MISE_EXPERIMENTAL', 'Process')
+        $env:MISE_EXPERIMENTAL = '1'
+        $script:OriginalDir = Get-Location
+        Set-Location TestDrive:
+
+        $script:OriginalTrusted = [Environment]::GetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', 'Process')
+        $env:MISE_TRUSTED_CONFIG_PATHS = $TestDrive
+        $script:Task = 'mise\mise-e2e-sleep'
+    }
+
+    AfterAll {
+        if ($null -eq $script:OriginalExperimental) {
+            Remove-Item Env:MISE_EXPERIMENTAL -ErrorAction Ignore
+        } else {
+            $env:MISE_EXPERIMENTAL = $script:OriginalExperimental
+        }
+        schtasks /delete /tn $script:Task /f 2>&1 | Out-Null
+        Set-Location $script:OriginalDir
+        if ($null -eq $script:OriginalTrusted) {
+            Remove-Item Env:MISE_TRUSTED_CONFIG_PATHS -ErrorAction Ignore
+        } else {
+            [Environment]::SetEnvironmentVariable('MISE_TRUSTED_CONFIG_PATHS', $script:OriginalTrusted, 'Process')
+        }
+    }
+
+    It 'renders and validates a user service without installing it' {
+        @"
+[bootstrap.services.agent]
+scope = "user"
+command = "C:\\Tools\\agent.exe --serve"
+environment = { RUST_LOG = "info" }
+
+[bootstrap.services.mise-history]
+builtin = "history-watch"
+"@ | Out-File -FilePath mise.toml -Encoding utf8NoBOM
+
+        $json = mise bootstrap status --json 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $status = $json | ConvertFrom-Json
+        $agent = $status.user_services | Where-Object { $_.name -eq 'agent' }
+        $agent.definition | Should -BeLike '*<Command>cmd.exe</Command>*'
+        $agent.definition | Should -BeLike '*RUST_LOG=info*'
+        $agent.current | Should -Be 'not installed'
+        $history = $status.user_services | Where-Object { $_.name -eq 'mise-history' }
+        $history.command | Should -BeLike '*dotfiles watch*'
+        $history.definition | Should -BeLike '*<LogonTrigger>*'
+
+        @"
+[bootstrap.services.docker]
+command = "dockerd"
+"@ | Out-File -FilePath mise.toml -Encoding utf8NoBOM
+        $out = mise bootstrap services status 2>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        # a regex: the backtick escapes wildcard characters in -BeLike patterns
+        $out | Should -Match 'only applies to `scope = "user"` services'
+    }
+
+    It 'installs, runs, and removes a scheduled task' {
+        @"
+[bootstrap.services.mise-e2e-sleep]
+scope = "user"
+command = "powershell.exe -NoProfile -Command Start-Sleep 300"
+"@ | Out-File -FilePath mise.toml -Encoding utf8NoBOM
+
+        mise bootstrap services apply --yes 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        schtasks /query /tn $script:Task 2>&1 | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        $json = mise bootstrap services status --json | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $status = ($json | ConvertFrom-Json)[0]
+        $status.current | Should -Be 'running'
+        $status.action | Should -Be 'noop'
+
+        @"
+[bootstrap.services.mise-e2e-sleep]
+scope = "user"
+command = "powershell.exe -NoProfile -Command Start-Sleep 300"
+state = "absent"
+"@ | Out-File -FilePath mise.toml -Encoding utf8NoBOM
+        $json = mise bootstrap services status --json | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $status = ($json | ConvertFrom-Json)[0]
+        $status.action | Should -Be 'remove'
+        mise bootstrap services apply --yes 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        schtasks /query /tn $script:Task 2>&1 | Out-Null
+        $LASTEXITCODE | Should -Not -Be 0
+
+        @"
+[bootstrap.services.mise-e2e-sleep]
+scope = "user"
+command = "powershell.exe -NoProfile -Command Start-Sleep 300"
+"@ | Out-File -FilePath mise.toml -Encoding utf8NoBOM
+        mise bootstrap services apply --yes 2>&1 | Out-String | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        "[tools]" | Out-File -FilePath mise.toml -Encoding utf8NoBOM
+        $out = mise bootstrap services remove mise-e2e-sleep 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -BeLike '*removed its Scheduled Task*'
+        schtasks /query /tn $script:Task 2>&1 | Out-Null
+        $LASTEXITCODE | Should -Not -Be 0
+    }
+}

--- a/e2e-win/services.Tests.ps1
+++ b/e2e-win/services.Tests.ps1
@@ -68,9 +68,14 @@ command = "powershell.exe -NoProfile -Command Start-Sleep 300"
         $LASTEXITCODE | Should -Be 0
         schtasks /query /tn $script:Task 2>&1 | Out-Null
         $LASTEXITCODE | Should -Be 0
-        $json = mise bootstrap services status --json | Out-String
-        $LASTEXITCODE | Should -Be 0
-        $status = ($json | ConvertFrom-Json)[0]
+        $deadline = (Get-Date).AddSeconds(20)
+        do {
+            $json = mise bootstrap services status --json | Out-String
+            $LASTEXITCODE | Should -Be 0
+            $status = ($json | ConvertFrom-Json)[0]
+            if ($status.current -eq 'running') { break }
+            Start-Sleep -Milliseconds 200
+        } while ((Get-Date) -lt $deadline)
         $status.current | Should -Be 'running'
         $status.action | Should -Be 'noop'
 

--- a/e2e-win/services.Tests.ps1
+++ b/e2e-win/services.Tests.ps1
@@ -72,7 +72,7 @@ command = "powershell.exe -NoProfile -Command Start-Sleep 300"
         do {
             $json = mise bootstrap services status --json | Out-String
             $LASTEXITCODE | Should -Be 0
-            $status = ($json | ConvertFrom-Json)[0]
+            $status = @($json | ConvertFrom-Json)[0]
             if ($status.current -eq 'running') { break }
             Start-Sleep -Milliseconds 200
         } while ((Get-Date) -lt $deadline)
@@ -87,7 +87,7 @@ state = "absent"
 "@ | Out-File -FilePath mise.toml -Encoding utf8NoBOM
         $json = mise bootstrap services status --json | Out-String
         $LASTEXITCODE | Should -Be 0
-        $status = ($json | ConvertFrom-Json)[0]
+        $status = @($json | ConvertFrom-Json)[0]
         $status.action | Should -Be 'remove'
         mise bootstrap services apply --yes 2>&1 | Out-String | Out-Null
         $LASTEXITCODE | Should -Be 0

--- a/e2e/cli/test_bootstrap_from
+++ b/e2e/cli/test_bootstrap_from
@@ -111,6 +111,14 @@ relative_checkout="bootstrap-relative-checkout"
 assert_succeed "mise -E work bootstrap --from '$source_repo' --from-dir '$relative_checkout' --yes --only dotfiles"
 assert "git -C '$relative_checkout' remote get-url origin" "$source_repo"
 
+# A reused checkout without --update changes nothing and records no
+# "bootstrap --from" generation of its own; a clone or pull does. The run
+# is identified by its --from-dir, which the child bootstrap never carries.
+count_from_runs="mise bootstrap dotfiles history --json | jq '[.[] | select((.operation.command // \"\") | contains(\"--from-dir $checkout\"))] | length'"
+before="$(eval "$count_from_runs")"
+assert_succeed "mise -E work bootstrap --from '$source_repo' --from-dir '$checkout' --yes --only dotfiles"
+assert "$count_from_runs" "$before"
+
 # Existing checkouts are reused, while --update fast-forwards before bootstrap.
 echo work-v2 >"$source_repo/profile"
 perl -pi -e 's/work-v1/work-v2/' "$source_repo/mise.work.toml"
@@ -119,6 +127,7 @@ git -C "$source_repo" commit -qm update
 assert_succeed "mise -E work bootstrap --from '$source_repo' --from-dir '$checkout' --update --yes --only dotfiles,task"
 assert "cat ~/.bootstrap-from-profile" "work-v2"
 assert "cat ~/bootstrap-from-task" "work-v2"
+assert "mise bootstrap dotfiles history --json | jq '[.[] | select((.operation.command // \"\") | contains(\"--from-dir $checkout\") and contains(\"--update\"))] | length'" "1"
 
 # --dry-run also leaves an existing checkout untouched when --update is set.
 echo work-v3 >"$source_repo/profile"

--- a/e2e/cli/test_bootstrap_from
+++ b/e2e/cli/test_bootstrap_from
@@ -100,6 +100,7 @@ assert_succeed "mise -E work bootstrap --from '$source_repo' --from-dir '$checko
 assert "cat ~/.bootstrap-from-profile" "work-v1"
 assert "cat ~/bootstrap-from-task" "work-v1"
 assert "git -C '$checkout' remote get-url origin" "$source_repo"
+assert_succeed "mise --cd '$checkout' -E work bootstrap dotfiles track ~/.bootstrap-from-profile --yes"
 
 # An existing empty destination and a single-component relative destination
 # are both valid clone targets.
@@ -112,9 +113,9 @@ assert_succeed "mise -E work bootstrap --from '$source_repo' --from-dir '$relati
 assert "git -C '$relative_checkout' remote get-url origin" "$source_repo"
 
 # A reused checkout without --update changes nothing and records no
-# "bootstrap --from" generation of its own; a clone or pull does. The run
-# is identified by its --from-dir, which the child bootstrap never carries.
-count_from_runs="mise bootstrap dotfiles history --json | jq '[.[] | select((.operation.command // \"\") | contains(\"--from-dir $checkout\"))] | length'"
+# "bootstrap --from" generation of its own; a clone or pull does. Its checkout
+# summary distinguishes the parent operation from the child bootstrap.
+count_from_runs="mise bootstrap dotfiles history --json | jq '[.[] | select((.description // \"\") | contains(\"checkout of $source_repo\"))] | length'"
 before="$(eval "$count_from_runs")"
 assert_succeed "mise -E work bootstrap --from '$source_repo' --from-dir '$checkout' --yes --only dotfiles"
 assert "$count_from_runs" "$before"
@@ -127,7 +128,7 @@ git -C "$source_repo" commit -qm update
 assert_succeed "mise -E work bootstrap --from '$source_repo' --from-dir '$checkout' --update --yes --only dotfiles,task"
 assert "cat ~/.bootstrap-from-profile" "work-v2"
 assert "cat ~/bootstrap-from-task" "work-v2"
-assert "mise bootstrap dotfiles history --json | jq '[.[] | select((.operation.command // \"\") | contains(\"--from-dir $checkout\") and contains(\"--update\"))] | length'" "1"
+assert "$count_from_runs" "$((before + 1))"
 
 # --dry-run also leaves an existing checkout untouched when --update is set.
 echo work-v3 >"$source_repo/profile"

--- a/e2e/cli/test_bootstrap_from_git_dumb_http
+++ b/e2e/cli/test_bootstrap_from_git_dumb_http
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Format probing must retain ordinary Git transports without shallow support.
+require_cmd git
+require_cmd python3
+mkdir -p seed served
+git -C seed init -q -b main
+printf '[dotfiles]\n' >seed/config.toml
+git -C seed add config.toml
+git -C seed -c user.name=Test -c user.email=test@example.invalid commit -qm initial
+git clone -q --bare seed served/origin.git
+git --git-dir=served/origin.git update-server-info
+python3 - "$PWD/served" >port 2>http.log <<'PY' &
+import functools
+import http.server
+import sys
+
+handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=sys.argv[1])
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+print(server.server_port, flush=True)
+server.serve_forever()
+PY
+http_pid=$!
+trap 'kill "$http_pid" 2>/dev/null || true; wait "$http_pid" 2>/dev/null || true' EXIT
+for _ in $(seq 1 30); do
+  test -s port && break
+  sleep 0.1
+done
+assert_succeed 'test -s port'
+url="http://127.0.0.1:$(cat port)/origin.git"
+git init -q --bare probe.git
+assert_fail "git --git-dir=probe.git fetch --depth=1 '$url' main" 'dumb http transport does not support shallow capabilities'
+assert_succeed "MISE_CONFIG_DIR='$PWD/target' mise bootstrap --from-git '$url' --only dotfiles --dry-run"
+assert_fail 'test -e target/config.toml'
+assert_succeed "MISE_CONFIG_DIR='$PWD/target' mise bootstrap --from-git '$url' --only dotfiles --yes"
+assert_directory_exists 'target/.git'
+assert 'cat target/config.toml' '[dotfiles]'

--- a/e2e/cli/test_bootstrap_remote_setup_repository
+++ b/e2e/cli/test_bootstrap_remote_setup_repository
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# `mise bootstrap remote --from-git` on a history-managed setup repository sets
+# the target up from it over the transferred bundle. A dry run connects,
+# inspects the target and the repository, and shows the plan without writing
+# configuration, recording a connection, or keeping the fetched branch; the
+# real run writes what the dry run showed.
+# shellcheck disable=SC2016
+
+require_cmd git
+
+binary=$(command -v mise)
+mkdir -p fakebin remotes
+export FAKE_REMOTE_BASE="$PWD/remotes"
+export SSH_LOG="$PWD/ssh.log"
+# the fake ssh runs the remote command locally under a per-host HOME
+cat >fakebin/ssh <<'EOF2'
+#!/bin/sh
+printf '%s\n' "$*" >>"$SSH_LOG"
+while test "$#" -gt 0; do
+  case "$1" in
+    -o|-p|-i|-S) shift 2 ;;
+    -tt) shift ;;
+    -O) exit 0 ;;
+    *)
+      destination=$1
+      shift
+      export HOME="$FAKE_REMOTE_BASE/$destination"
+      export XDG_CONFIG_HOME="$HOME/.config" XDG_STATE_HOME="$HOME/.local/state"
+      export MISE_CONFIG_DIR="$HOME/.config/mise"
+      unset MISE_GLOBAL_CONFIG_FILE
+      export MISE_DATA_DIR="$HOME/.local/share/mise"
+      export MISE_CACHE_DIR="$HOME/.cache/mise"
+      export MISE_STATE_DIR="$HOME/.local/state/mise"
+      unset MISE_GITHUB_TOKEN MISE_GITHUB_API_TOKEN GITHUB_TOKEN GH_TOKEN
+      mkdir -p "$HOME"
+      cd "$HOME" || exit 1
+      exec sh -c "$1"
+      ;;
+  esac
+done
+EOF2
+chmod +x fakebin/ssh
+export PATH="$PWD/fakebin:$PATH"
+
+# ---- this machine publishes its setup: a tracked directory
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+mkdir -p ~/.config/hypr
+echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+assert_succeed 'mise bootstrap dotfiles track ~/.config/mise/config.toml'
+cat >>"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+
+[bootstrap.repos]
+"~/preview-only-repo" = { url = "https://example.invalid/preview-only.git" }
+EOF
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --yes"
+assert_contains "git --git-dir=$origin ls-tree -r --name-only main" "home/.config/hypr/bindings.lua"
+
+# ---- a dry run on a fresh host previews and leaves no trace
+out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only repos --dry-run 2>&1)"
+export out
+assert_contains 'printf "%s\n" "$out"' "is a mise setup repository"
+assert_contains 'printf "%s\n" "$out"' "bindings.lua"
+assert_contains 'printf "%s\n" "$out"' "Dry run: nothing was changed"
+assert_contains 'printf "%s\n" "$out"' "git clone https://example.invalid/preview-only.git"
+assert_fail "test -e remotes/fresh/preview-only-repo"
+assert_contains "cat '$SSH_LOG'" '--repository-dry-run'
+assert_not_contains "cat '$SSH_LOG'" '/.config/mise bootstrap'
+assert_fail "test -e remotes/fresh/.config/mise/config.toml"
+assert_fail "test -e remotes/fresh/.config/hypr/bindings.lua"
+assert "find remotes/fresh -name sync.json | wc -l | tr -d ' '" "0"
+assert "find remotes/fresh -path '*/refs/setup/*' | wc -l | tr -d ' '" "0"
+assert "find remotes/fresh -name config.local.toml | wc -l | tr -d ' '" "0"
+
+# ---- the real run writes what the dry run showed
+assert_succeed "mise bootstrap remote --host fresh --from-git file://$origin --remote-mise '$binary' --only dotfiles --yes"
+assert_fail "test -e remotes/fresh/.config/mise/.git"
+assert "cat remotes/fresh/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
+assert_contains "cat remotes/fresh/.config/mise/config.toml" '"~/.config/hypr" = { mode = "track" }'
+assert_contains "cat remotes/fresh/.config/mise/config.local.toml" "file://$origin"
+assert "find remotes/fresh -name sync.json | wc -l | tr -d ' '" "1"
+assert_contains "cat '$SSH_LOG'" '/.config/mise bootstrap'
+
+# ---- a dry run on a set-up host previews the bootstrap against its configuration
+out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only dotfiles --dry-run 2>&1)"
+assert_contains 'printf "%s\n" "$out"' "Dry run: nothing was changed"
+assert_contains "cat '$SSH_LOG'" 'bootstrap --dry-run'
+assert "cat remotes/fresh/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"

--- a/e2e/cli/test_bootstrap_remote_setup_repository
+++ b/e2e/cli/test_bootstrap_remote_setup_repository
@@ -83,6 +83,7 @@ assert "find remotes/fresh -name sync.json | wc -l | tr -d ' '" "1"
 assert_contains "cat '$SSH_LOG'" '/.config/mise bootstrap'
 
 # ---- a dry run on a set-up host previews the bootstrap against its configuration
+: >"$SSH_LOG"
 out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only dotfiles --dry-run 2>&1)"
 assert_contains 'printf "%s\n" "$out"' "Dry run: nothing was changed"
 assert_contains "cat '$SSH_LOG'" 'bootstrap --dry-run'

--- a/e2e/cli/test_bootstrap_remote_setup_repository
+++ b/e2e/cli/test_bootstrap_remote_setup_repository
@@ -63,7 +63,10 @@ assert_succeed "mise bootstrap dotfiles origin set file://$origin --yes"
 assert_contains "git --git-dir=$origin ls-tree -r --name-only main" "home/.config/hypr/bindings.lua"
 
 # ---- a dry run on a fresh host previews and leaves no trace
-out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only repos,dotfiles --dry-run 2>&1)"
+out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only repos,dotfiles --dry-run 2>&1)" || {
+  printf '%s\n' "$out"
+  exit 1
+}
 export out
 assert_contains 'printf "%s\n" "$out"' "is a mise setup repository"
 assert_contains 'printf "%s\n" "$out"' "bindings.lua"

--- a/e2e/cli/test_bootstrap_remote_setup_repository
+++ b/e2e/cli/test_bootstrap_remote_setup_repository
@@ -45,25 +45,30 @@ export PATH="$PWD/fakebin:$PATH"
 # ---- this machine publishes its setup: a tracked directory
 origin="$PWD/origin.git"
 git init -q --bare -b main "$origin"
+preview_source="$PWD/preview-source"
+git init -q -b main "$preview_source"
+echo 'cloned by bootstrap' >"$preview_source/README"
+git -C "$preview_source" add README
+git -C "$preview_source" -c user.name=Test -c user.email=test@example.invalid commit -qm 'test: seed bootstrap repository'
 mkdir -p ~/.config/hypr
 echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
 assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
 assert_succeed 'mise bootstrap dotfiles track ~/.config/mise/config.toml'
-cat >>"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+cat >>"$MISE_CONFIG_DIR/config.toml" <<EOF
 
 [bootstrap.repos]
-"~/preview-only-repo" = { url = "https://example.invalid/preview-only.git" }
+"~/preview-only-repo" = { url = "file://$preview_source" }
 EOF
 assert_succeed "mise bootstrap dotfiles origin set file://$origin --yes"
 assert_contains "git --git-dir=$origin ls-tree -r --name-only main" "home/.config/hypr/bindings.lua"
 
 # ---- a dry run on a fresh host previews and leaves no trace
-out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only repos --dry-run 2>&1)"
+out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only repos,dotfiles --dry-run 2>&1)"
 export out
 assert_contains 'printf "%s\n" "$out"' "is a mise setup repository"
 assert_contains 'printf "%s\n" "$out"' "bindings.lua"
 assert_contains 'printf "%s\n" "$out"' "Dry run: nothing was changed"
-assert_contains 'printf "%s\n" "$out"' "git clone https://example.invalid/preview-only.git"
+assert_contains 'printf "%s\n" "$out"' "git clone file://$preview_source"
 assert_fail "test -e remotes/fresh/preview-only-repo"
 assert_contains "cat '$SSH_LOG'" '--repository-dry-run'
 assert_not_contains "cat '$SSH_LOG'" '/.config/mise bootstrap'
@@ -74,7 +79,9 @@ assert "find remotes/fresh -path '*/refs/setup/*' | wc -l | tr -d ' '" "0"
 assert "find remotes/fresh -name config.local.toml | wc -l | tr -d ' '" "0"
 
 # ---- the real run writes what the dry run showed
-assert_succeed "mise bootstrap remote --host fresh --from-git file://$origin --remote-mise '$binary' --only dotfiles --yes"
+assert_succeed "mise bootstrap remote --host fresh --from-git file://$origin --remote-mise '$binary' --only repos,dotfiles --yes"
+assert_directory_exists "remotes/fresh/preview-only-repo/.git"
+assert "cat remotes/fresh/preview-only-repo/README" "cloned by bootstrap"
 assert_fail "test -e remotes/fresh/.config/mise/.git"
 assert "cat remotes/fresh/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
 assert_contains "cat remotes/fresh/.config/mise/config.toml" '"~/.config/hypr" = { mode = "track" }'

--- a/e2e/cli/test_bootstrap_user_services
+++ b/e2e/cli/test_bootstrap_user_services
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# `[bootstrap.services]` with `scope = "user"`: one declaration rendered for the
+# platform's user service manager, validated before anything is written, and
+# reported as unknown (never written) when that manager is unavailable.
+# shellcheck disable=SC2016
+
+cat <<'EOF' >mise.toml
+[bootstrap.services.agent]
+scope = "user"
+command = "~/.local/bin/agent --serve"
+description = "My agent"
+restart = "always"
+environment = { RUST_LOG = "info" }
+working_directory = "~"
+
+[bootstrap.services.mise-history]
+builtin = "history-watch"
+
+[bootstrap.services.later]
+scope = "user"
+command = "node server.js"
+requires_tools = true
+state = "stopped"
+enabled = false
+
+[bootstrap.services.gone]
+scope = "user"
+command = "x"
+state = "absent"
+EOF
+
+# every user service is listed by the services, aggregate status, and plan
+# commands with its desired state
+assert_contains "mise bootstrap services status" "user-service:agent"
+assert_contains "mise bootstrap services status" "user-service:mise-history"
+assert_contains "mise bootstrap services status" "stopped (not at login)"
+assert_contains "mise bootstrap services status" "absent"
+assert_contains "mise bootstrap status" "user-service"
+assert_contains "mise bootstrap plan" "user-service:later"
+
+# the rendered definition is inspectable before anything is installed, and a
+# builtin runs through the mise that installed it
+assert "mise bootstrap status --json | jq -r '.user_services[] | select(.name == \"agent\") | .restart'" "always"
+assert "mise bootstrap status --json | jq -r '.user_services[] | select(.name == \"later\") | .requires_tools'" "true"
+assert "mise bootstrap status --json | jq -r '.user_services[] | select(.name == \"mise-history\") | .builtin'" "history-watch"
+assert_contains "mise bootstrap status --json | jq -r '.user_services[] | select(.name == \"mise-history\") | .command'" "bootstrap dotfiles watch"
+if [[ "$(uname -s)" == "Linux" ]]; then
+  assert_contains "mise bootstrap status --json | jq -r '.user_services[] | select(.name == \"agent\") | .definition'" "Restart=always"
+  assert_contains "mise bootstrap status --json | jq -r '.user_services[] | select(.name == \"agent\") | .definition'" 'Environment="RUST_LOG=info"'
+  assert_contains "mise bootstrap status --json | jq -r '.user_services[] | select(.name == \"mise-history\") | .definition'" "Nice=10"
+  assert_contains "mise bootstrap status --json | jq -r '.user_services[] | select(.name == \"mise-history\") | .path'" "/.config/systemd/user/dev.mise.mise-history.service"
+fi
+
+# without a user service manager (this container has none) nothing is written:
+# status reports unknown, apply and the full bootstrap skip with a follow-up
+if ! mise bootstrap services status --json | jq -e 'all(.action != "unknown")' >/dev/null; then
+  assert_contains "mise bootstrap services status --json" '"action": "unknown"'
+  assert_fail "mise bootstrap services status --missing"
+  assert_contains "MISE_EXPERIMENTAL=0 mise bootstrap services apply --dry-run --yes 2>&1" "skipped"
+  assert_contains "mise bootstrap --only services --dry-run --yes 2>&1" "skipped"
+  assert_fail "test -e $HOME/.config/systemd/user/dev.mise.agent.service"
+  assert_fail "test -e $HOME/Library/LaunchAgents/dev.mise.agent.plist"
+  assert_fail "mise bootstrap services remove agent" "cannot remove user service 'agent'"
+fi
+
+# validation happens before any change: a system-scope entry cannot carry
+# user-only fields, a user service needs a command or a builtin, and names
+# shared with the platform-specific tables are rejected
+cat <<'EOF' >mise.toml
+[bootstrap.services.docker]
+command = "dockerd"
+EOF
+assert_fail "mise bootstrap services status" 'sets command, which only applies to `scope = "user"` services'
+cat <<'EOF' >mise.toml
+[bootstrap.services.docker]
+state = "absent"
+EOF
+assert_fail "mise bootstrap plan" 'sets state = "absent", which only applies to'
+cat <<'EOF' >mise.toml
+[bootstrap.services.agent]
+scope = "user"
+EOF
+assert_fail "mise bootstrap services status" 'must set `command` or `builtin`'
+cat <<'EOF' >mise.toml
+[bootstrap.services.agent]
+builtin = "history-watch"
+command = "x"
+EOF
+assert_fail "mise bootstrap services status" 'sets both `builtin` and `command`'
+cat <<'EOF' >mise.toml
+[bootstrap.services.agent]
+builtin = "nope"
+EOF
+assert_fail "mise bootstrap services status" "unknown builtin 'nope'; available: history-watch"
+cat <<'EOF' >mise.toml
+[bootstrap.services.agent]
+scope = "user"
+command = "agent"
+masked = true
+EOF
+assert_fail "mise bootstrap services status" "cannot be masked"
+cat <<'EOF' >mise.toml
+[bootstrap.services.agent]
+scope = "user"
+command = "agent"
+
+[bootstrap.linux.systemd.units.agent]
+exec_start = "agent"
+EOF
+assert_fail "mise bootstrap services status" "also declared in [bootstrap.linux.systemd.units]"
+cat <<'EOF' >mise.toml
+[bootstrap.services.agent]
+scope = "user"
+command = "agent"
+
+[bootstrap.macos.launchd.agents.agent]
+program = "agent"
+EOF
+assert_fail "mise bootstrap services status" "also declared in [bootstrap.macos.launchd.agents]"
+
+# managed-file notifications apply to system services only
+cat <<EOF >mise.toml
+[bootstrap.services.agent]
+scope = "user"
+command = "agent"
+
+[bootstrap.files."$PWD/notify"]
+content = "x"
+notify = ["agent"]
+EOF
+assert_fail "mise bootstrap plan" "notifies user-scope bootstrap service 'agent'"
+
+# a name is never guessed: the removal of an undeclared service is explicit
+cat <<'EOF' >mise.toml
+[tools]
+EOF
+assert_fail "mise bootstrap services remove 'bad name'" "must contain only letters"
+
+# the effective scope follows `builtin`, and skipping the services part skips
+# user services too
+cat <<'EOF' >mise.toml
+[bootstrap.services.mise-history]
+builtin = "history-watch"
+EOF
+assert_not_contains "mise bootstrap --skip services --dry-run --yes 2>&1" "user services"
+assert_contains "mise bootstrap status --json | jq -r '.user_services[0].scope'" "user"
+assert_contains "mise bootstrap services status --json | jq -r '.[0].id.kind'" "user-service"
+
+# on macOS the LaunchAgent is really installed, started, and removed
+if [[ "$(uname -s)" == "Darwin" ]] && mise bootstrap services status --json | jq -e 'all(.action != "unknown")' >/dev/null; then
+  cat <<'TOML' >mise.toml
+[bootstrap.services.mise-e2e-sleep]
+scope = "user"
+command = "/bin/sleep 300"
+TOML
+  assert_succeed "mise bootstrap services apply --yes"
+  assert "test -f $HOME/Library/LaunchAgents/dev.mise.mise-e2e-sleep.plist && echo yes" "yes"
+  assert "mise bootstrap services status --json | jq -r '.[0] | \"\\(.current) \\(.action)\"'" "running noop"
+  assert_contains "mise bootstrap status --json | jq -r '.user_services[0].definition'" "SuccessfulExit"
+  assert_succeed "mise bootstrap services status --missing"
+  cat <<'TOML' >mise.toml
+[bootstrap.services.mise-e2e-sleep]
+scope = "user"
+command = "/bin/sleep 300"
+state = "absent"
+TOML
+  assert "mise bootstrap services status --json | jq -r '.[0] | \"\\(.current) \\(.action)\"'" "installed remove"
+  assert_succeed "mise bootstrap services apply --yes"
+  assert_fail "test -e $HOME/Library/LaunchAgents/dev.mise.mise-e2e-sleep.plist"
+  assert "mise bootstrap services status --json | jq -r '.[0] | \"\\(.current) \\(.action)\"'" "absent noop"
+  # an undeclared leftover is removed once, explicitly
+  cat <<'TOML' >mise.toml
+[bootstrap.services.mise-e2e-sleep]
+scope = "user"
+command = "/bin/sleep 300"
+TOML
+  assert_succeed "mise bootstrap services apply --yes"
+  echo "[tools]" >mise.toml
+  assert_contains "mise bootstrap services remove mise-e2e-sleep 2>&1" "removed its LaunchAgent"
+  assert_fail "test -e $HOME/Library/LaunchAgents/dev.mise.mise-e2e-sleep.plist"
+  assert_contains "mise bootstrap services remove mise-e2e-sleep 2>&1" "no LaunchAgent installed"
+fi

--- a/e2e/cli/test_dotfiles_bootstrap_from_git
+++ b/e2e/cli/test_dotfiles_bootstrap_from_git
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# `mise bootstrap --from-git` on a history-managed setup repository sets a
+# fresh machine up from it with one command: the branch goes into mise's own
+# store (no checkout in the configuration directory), the shared configuration,
+# its sources, and this machine's tracked files are written by a recoverable
+# pull, the connection is remembered for the watcher, and the ordinary
+# bootstrap runs afterwards. An ordinary repository keeps the old clone.
+# shellcheck disable=SC2016
+
+require_cmd git
+
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+
+# ---- machine A publishes its setup: a tracked directory and a template with
+# its source
+mkdir -p ~/.config/hypr "$MISE_CONFIG_DIR/templates"
+echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
+printf 'name = "{{ vars.name }}"\n' >"$MISE_CONFIG_DIR/templates/gitconfig.tera"
+cat <<'EOF2' >"$MISE_CONFIG_DIR/config.toml"
+[vars]
+name = "shared"
+
+[dotfiles]
+"~/.gitconfig-shared" = { source = "templates/gitconfig.tera", mode = "template" }
+EOF2
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr $MISE_CONFIG_DIR/config.toml $MISE_CONFIG_DIR/templates"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --yes"
+assert_contains "git --git-dir=$origin ls-tree -r --name-only main" "templates/gitconfig.tera"
+
+# other machines are other HOMEs reached through wrapper scripts
+wrapper() {
+  local home="$1" script="$2"
+  mkdir -p "$home"
+  cat <<EOF2 >"$script"
+#!/usr/bin/env bash
+export HOME="$home" XDG_CONFIG_HOME="$home/.config" MISE_CONFIG_DIR="$home/.config/mise" \\
+  MISE_STATE_DIR="$home/.local/state/mise" MISE_DATA_DIR="$home/.local/share/mise" \\
+  MISE_CACHE_DIR="$home/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$home"
+cd "\$HOME" && exec mise "\$@"
+EOF2
+  chmod +x "$script"
+}
+
+# ---- machine C: a fresh HOME, one command
+preview_home="$(dirname "$HOME")/conflict-preview-home"
+wrapper "$preview_home" "$PWD/conflict-preview"
+mkdir -p "$preview_home/.config/hypr"
+echo local >"$preview_home/.config/hypr/bindings.lua"
+preview="$("$PWD/conflict-preview" bootstrap --from-git "file://$origin" --dry-run 2>&1)"
+[[ $preview == *bindings.lua* ]] || fail "preview omits tracked file"
+[[ $preview == *'held: unresolved conflict'* ]] || fail "preview omits conflict"
+[[ $preview == *config.toml* ]] || fail "preview omits enrolled configuration"
+assert "cat $preview_home/.config/hypr/bindings.lua" "local"
+assert_fail "test -e $preview_home/.config/mise/config.toml"
+
+C="$(dirname "$HOME")/c-home"
+wrapper "$C" "$PWD/c"
+c="$PWD/c"
+assert_directory_not_exists "$C/.local/state/mise/history"
+assert_fail "test -e $C/.config/mise/config.toml"
+out="$($c bootstrap --from-git "file://$origin" --dry-run 2>&1)"
+[[ $out == *'is a mise setup repository'* ]] || fail "preview omits repository type"
+[[ $out == *config.toml* ]] || fail "preview omits configuration"
+[[ $out == *'Dry run: nothing was changed'* ]] || fail "preview omits dry-run assurance"
+assert_fail "test -e $C/.config/mise/config.toml"
+# a preview leaves no connection, pending changes, or fetched branch behind
+assert "find $C -name sync.json | wc -l | tr -d ' '" "0"
+assert "find $C -path '*/refs/setup/*' | wc -l | tr -d ' '" "0"
+assert_succeed "$c bootstrap --from-git file://$origin --yes --only dotfiles"
+assert_fail "test -e $C/.config/mise/.git"
+assert "cat $C/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
+assert_contains "cat $C/.config/mise/config.toml" '"~/.config/hypr" = { mode = "track" }'
+assert "cat $C/.config/mise/templates/gitconfig.tera" 'name = "{{ vars.name }}"'
+# the bootstrap that followed rendered the template on C from the shared source
+assert "cat $C/.gitconfig-shared" 'name = "shared"'
+assert_contains "cat $C/.config/mise/config.local.toml" 'url = "file://'
+assert_contains "$c bootstrap dotfiles status" "mode sync"
+assert "$c bootstrap dotfiles history --json | jq -r '[.[].trigger] | index(\"apply\") != null'" "true"
+# running it again is a sync, not a second setup
+assert_succeed "$c bootstrap --from-git file://$origin --yes --only dotfiles"
+# C's edits reach A through the usual sync
+echo 'bind = SUPER, Q, exec, foot' >"$C/.config/hypr/bindings.lua"
+assert_contains "$c bootstrap dotfiles sync 2>&1" "published"
+assert_succeed "mise bootstrap dotfiles sync && mise bootstrap dotfiles pull --yes"
+assert "cat ~/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, foot"
+
+# ---- machine D already has a differing configuration: nothing is overwritten
+D="$(dirname "$HOME")/d-home"
+wrapper "$D" "$PWD/d"
+d="$PWD/d"
+mkdir -p "$D/.config/mise"
+printf '[env]\nD_ONLY = "1"\n' >"$D/.config/mise/config.toml"
+# the differing configuration is held, so nothing is bootstrapped from the
+# old one: the command says what to decide and fails
+assert_fail "$d bootstrap --from-git file://$origin --yes --only dotfiles 2>&1" "need a decision"
+assert_fail "$d bootstrap --from-git file://$origin --yes --only dotfiles 2>&1" "nothing was bootstrapped"
+assert "cat $D/.config/mise/config.toml" $'[env]\nD_ONLY = "1"'
+assert_contains "$d bootstrap dotfiles status" "sharing is paused for the entire setup"
+assert_succeed "$d bootstrap dotfiles pull --take-remote $D/.config/mise/config.toml --yes"
+assert "cat $D/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, foot"
+
+# ---- an ordinary repository keeps the old behaviour: a checkout in the
+# configuration directory
+plain="$PWD/plain.git"
+git init -q --bare -b main "$plain"
+seed="$PWD/plain-seed"
+git init -q -b main "$seed"
+printf '[env]\nPLAIN = "1"\n' >"$seed/config.toml"
+git -C "$seed" add config.toml
+git -C "$seed" -c user.name=t -c user.email=t@t commit -q -m init
+git -C "$seed" push -q "file://$plain" main
+E="$(dirname "$HOME")/e-home"
+wrapper "$E" "$PWD/e"
+e="$PWD/e"
+assert_succeed "MISE_EXPERIMENTAL=0 $e bootstrap --from-git file://$plain --yes --only task"
+# Ordinary bootstrap may checkpoint configuration, but keeps the ordinary
+# checkout and does not connect it as a shared setup repository.
+assert_succeed "test -d $E/.config/mise/.git"
+assert_contains "cat $E/.config/mise/config.toml" 'PLAIN = "1"'
+assert_contains "$e bootstrap dotfiles status" "Setup repository: none"
+
+# ---- the repository's default branch is followed, not `main` by its name
+other="$PWD/other.git"
+git clone -q --bare "file://$origin" "$other"
+git --git-dir="$other" branch -q setup main
+git --git-dir="$other" symbolic-ref HEAD refs/heads/setup
+# a stale `main` left behind at the first commit
+git --git-dir="$other" update-ref refs/heads/main "$(git --git-dir="$other" rev-list --max-parents=0 setup | tail -1)"
+F="$(dirname "$HOME")/f-home"
+wrapper "$F" "$PWD/f"
+f="$PWD/f"
+assert_contains "$f bootstrap --from-git file://$other --dry-run 2>&1" "branch setup"

--- a/e2e/cli/test_dotfiles_capture
+++ b/e2e/cli/test_dotfiles_capture
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# External commands retain linked pairs and their own exit result.
+# shellcheck disable=SC2016
+require_cmd git
+export MISE_EXPERIMENTAL=0
+printf 'initial\n' >~/.captured
+assert_succeed 'mise bootstrap dotfiles track ~/.captured --no-autosave'
+printf 'user edit\n' >~/.captured
+assert_succeed "mise bootstrap dotfiles capture --label update -- sh -c 'printf \"updated\\n\" >~/.captured'"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].trigger, .[1].trigger, .[0].operation.status, .[0].labels[0]'" $'capture\ncapture-before\ncompleted\nupdate'
+assert_contains 'mise bootstrap dotfiles history diff --operation --patch' '-user edit'
+assert_contains 'mise bootstrap dotfiles history diff --operation --patch' '+updated'
+assert_not_contains 'mise bootstrap dotfiles history diff --operation --patch' '-initial'
+assert "mise bootstrap dotfiles history --label update --json | jq length" '1'
+operation=$(mise bootstrap dotfiles history --json | jq -r '.[0].uuid')
+# Commit trailers contain labels and pairing, not serialized machine records.
+repository="$MISE_STATE_DIR/history/repo.git"
+metadata=$(git --git-dir="$repository" show -s --format=%B "$operation" | sed -n 's/^Mise-History: //p')
+assert "echo '$metadata' | jq -r 'has(\"tree\"), has(\"machine\"), has(\"created_at\"), has(\"changes\")'" $'false\nfalse\nfalse\nfalse'
+assert "echo '$metadata' | jq -r '.operation | has(\"argv\"), has(\"cwd\"), has(\"journal\")'" $'false\nfalse\nfalse'
+# A later explicit save must not move the operation's baseline.
+printf 'afterward\n' >~/.captured
+assert_succeed 'mise bootstrap dotfiles save ~/.captured'
+assert_contains 'mise bootstrap dotfiles history diff --operation --patch' '+updated'
+assert_not_contains 'mise bootstrap dotfiles history diff --operation --patch' '+afterward'
+assert_contains "mise bootstrap dotfiles history diff $operation --operation --patch" '-user edit'
+assert_fail 'mise bootstrap dotfiles history diff latest --operation' 'is not an operation'
+assert_fail 'mise bootstrap dotfiles history diff latest latest --operation' 'at most one'
+
+# The caller sees the exact child exit code, with failed files still captured.
+set +e
+mise bootstrap dotfiles capture --label failed -- sh -c 'echo broken >~/.captured; exit 37'
+result=$?
+set -e
+assert "echo $result" '37'
+assert "mise bootstrap dotfiles history --label failed --json | jq -r '.[0].operation.status'" 'failed'
+assert_contains 'mise bootstrap dotfiles history diff --operation --patch' '+broken'
+# Recover the file from the recorded before checkpoint, leaving other files alone.
+before=$(mise bootstrap dotfiles history --json | jq -r '.[0].operation.before')
+assert_succeed "mise bootstrap dotfiles rollback ~/.captured --to $before --yes"
+assert 'cat ~/.captured' 'afterward'
+
+# No-op and spawn failures remain inspectable operations.
+assert_succeed 'mise bootstrap dotfiles capture --label noop -- true'
+assert "mise bootstrap dotfiles history --label noop --json | jq length" '1'
+assert_fail 'mise bootstrap dotfiles capture --label missing -- mise-capture-missing-command' 'could not run'
+assert "mise bootstrap dotfiles history --label missing --json | jq -r '.[0].operation.status'" 'failed'
+# An unavailable history store must not stop the command or mask its result.
+set +e
+MISE_HISTORY_ENABLED=0 mise bootstrap dotfiles capture -- sh -c 'echo ran >~/.ran; exit 23'
+result=$?
+set -e
+assert "echo $result" '23'
+assert 'cat ~/.ran' 'ran'
+# Signals are represented by the conventional 128 + signal exit status.
+set +e
+mise bootstrap dotfiles capture -- sh -c 'kill -TERM $$'
+result=$?
+set -e
+assert "echo $result" '143'
+
+# An interrupt delivered to the wrapper must not cancel outcome finalization.
+set +e
+mise bootstrap dotfiles capture --label ctrl-c -- bash -c 'echo interrupted-by-user >~/.captured; kill -INT "$PPID"; exit 130'
+result=$?
+set -e
+assert "echo $result" '130'
+assert "mise bootstrap dotfiles history --label ctrl-c --json | jq -r '.[0].operation.status'" 'failed'
+assert_contains 'mise bootstrap dotfiles history diff --operation --patch' '+interrupted-by-user'
+
+# Crash recovery retains the label and the live manual-save file.
+pidfile="$PWD/capture.pid"
+cat <<WRAPPER >"$PWD/interrupted-capture"
+#!/usr/bin/env bash
+echo \$\$ >"$pidfile"
+exec mise bootstrap dotfiles capture --label interrupted -- sh -c 'echo interrupted >~/.captured; kill -KILL "\$(cat "$pidfile")"'
+WRAPPER
+chmod +x "$PWD/interrupted-capture"
+assert_fail "$PWD/interrupted-capture"
+assert_succeed 'mise bootstrap dotfiles save ~/.captured'
+assert "mise bootstrap dotfiles history --label interrupted --json | jq -r '.[0].operation.status'" 'failed'
+interrupted=$(mise bootstrap dotfiles history --label interrupted --json | jq -r '.[0].uuid')
+assert_contains "mise bootstrap dotfiles history diff $interrupted --operation --patch" '+interrupted'
+
+# Untracking during a command stops capture, without erasing earlier versions.
+printf 'before removal\n' >~/.removed-during-command
+assert_succeed 'mise bootstrap dotfiles track ~/.removed-during-command --no-autosave'
+assert_succeed "mise bootstrap dotfiles capture --label untrack-edit -- sh -c 'echo after-removal >~/.removed-during-command; mise bootstrap dotfiles untrack ~/.removed-during-command'"
+assert_contains 'mise bootstrap dotfiles history diff --operation --patch' '-before removal'
+assert 'cat ~/.removed-during-command' 'after-removal'
+assert_fail "git --git-dir=$MISE_STATE_DIR/history/repo.git show HEAD:home/.removed-during-command"
+assert_not_contains 'mise bootstrap dotfiles history diff --operation --patch' '+after-removal'
+
+# Interruption recovery must not re-enroll a removed declaration either.
+printf 'before crash\n' >~/.removed-before-crash
+assert_succeed 'mise bootstrap dotfiles track ~/.removed-before-crash --no-autosave'
+cat <<WRAPPER >"$PWD/interrupted-capture"
+#!/usr/bin/env bash
+echo \$\$ >"$pidfile"
+exec mise bootstrap dotfiles capture --label untrack-crash -- sh -c 'echo after-crash >~/.removed-before-crash; mise bootstrap dotfiles untrack ~/.removed-before-crash; kill -KILL "\$(cat "$pidfile")"'
+WRAPPER
+assert_fail "$PWD/interrupted-capture"
+assert_succeed 'mise bootstrap dotfiles save ~/.captured'
+recovered=$(mise bootstrap dotfiles history --label untrack-crash --json | jq -r '.[0].uuid')
+assert_contains "mise bootstrap dotfiles history diff $recovered --operation --patch" '-before crash'
+assert 'cat ~/.removed-before-crash' 'after-crash'
+assert_fail "git --git-dir=$MISE_STATE_DIR/history/repo.git show HEAD:home/.removed-before-crash"
+assert_not_contains "mise bootstrap dotfiles history diff $recovered --operation --patch" '+after-crash'

--- a/e2e/cli/test_dotfiles_directory_permissions
+++ b/e2e/cli/test_dotfiles_directory_permissions
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+require_cmd git
+export MISE_HISTORY_NOTIFY=false
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+mkdir -p ~/private/nested
+echo private >~/private/nested/config
+chmod 700 ~/private
+chmod 750 ~/private/nested
+assert_succeed 'mise bootstrap dotfiles track ~/private'
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync manual --yes"
+second="$(dirname "$HOME")/directory-permissions-b"
+mkdir -p "$second"
+b() {
+  (
+    cd "$second" || exit
+    env HOME="$second" XDG_CONFIG_HOME="$second/.config" MISE_CONFIG_DIR="$second/.config/mise" \
+      MISE_STATE_DIR="$second/.local/state/mise" MISE_DATA_DIR="$second/.local/share/mise" \
+      MISE_CACHE_DIR="$second/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$second" mise "$@"
+  )
+}
+export second
+export -f b
+if [[ "$(uname)" == Darwin ]]; then
+  mode_of='stat -f %Lp'
+else
+  mode_of='stat -c %a'
+fi
+assert_succeed "b bootstrap --from-git file://$origin --yes"
+assert "$mode_of $second/private" 700
+assert "$mode_of $second/private/nested" 750
+chmod 750 ~/private
+assert_succeed 'mise bootstrap dotfiles save'
+assert_succeed 'mise bootstrap dotfiles sync'
+assert_succeed 'b bootstrap dotfiles sync'
+assert_succeed 'b bootstrap dotfiles pull --yes'
+assert "$mode_of $second/private" 750
+chmod 700 ~/private/nested
+assert_succeed 'mise bootstrap dotfiles save'
+assert_succeed 'mise bootstrap dotfiles sync'
+# Fetching continues, but an unsaved chmod must not be overwritten.
+assert_succeed 'b bootstrap dotfiles sync --fetch-only'
+chmod 711 "$second/private/nested"
+assert_fail 'b bootstrap dotfiles pull --yes' 'unsaved directory permission'
+assert "$mode_of $second/private/nested" 711
+assert "cat $second/private/nested/config" private

--- a/e2e/cli/test_dotfiles_encrypted_capture
+++ b/e2e/cli/test_dotfiles_encrypted_capture
@@ -14,6 +14,7 @@ TOML
 echo first-private-value >~/.private-config
 first_plain=$(git hash-object ~/.private-config)
 assert_succeed "mise bootstrap dotfiles save"
+baseline="$(mise bootstrap dotfiles history --json | jq -r '.[0].uuid')"
 repo="$MISE_STATE_DIR/history/repo.git"
 assert_contains "git --git-dir=$repo show HEAD:home/.private-config | head -1" 'mise-encrypted-file-v1'
 assert_fail "git --git-dir=$repo cat-file -e $first_plain"
@@ -24,7 +25,7 @@ second_plain=$(git hash-object ~/.private-config)
 assert_succeed "mise bootstrap dotfiles history diff --path ~/.private-config"
 assert_fail "git --git-dir=$repo cat-file -e $second_plain"
 
-assert_succeed "mise bootstrap dotfiles rollback ~/.private-config --to 1 --dry-run"
+assert_succeed "mise bootstrap dotfiles rollback ~/.private-config --to $baseline --dry-run"
 assert "cat ~/.private-config" 'second-private-value'
 assert_fail "git --git-dir=$repo cat-file -e $first_plain"
 assert_fail "git --git-dir=$repo cat-file -e $second_plain"
@@ -34,7 +35,7 @@ assert_fail "git --git-dir=$repo cat-file -e $second_plain"
 assert "git --git-dir=$repo rev-list --count HEAD" "2"
 
 # Actual restoration writes native plaintext, but its new commits remain encrypted.
-assert_succeed "mise bootstrap dotfiles rollback ~/.private-config --to 1 --yes"
+assert_succeed "mise bootstrap dotfiles rollback ~/.private-config --to $baseline --yes"
 assert "cat ~/.private-config" 'first-private-value'
 assert_fail "git --git-dir=$repo cat-file -e $first_plain"
 assert_fail "git --git-dir=$repo cat-file -e $second_plain"

--- a/e2e/cli/test_dotfiles_encrypted_capture
+++ b/e2e/cli/test_dotfiles_encrypted_capture
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Capture and read-only history inspection must not store secret plaintext.
+require_cmd git
+
+export MISE_AGE_KEY="AGE-SECRET-KEY-142E7VJ8GUWR94MXDCYQJ7ZTQZRXKQSP9PUJU8HUQJ206QN7QPV4SM5QRL8"
+mkdir -p "$MISE_CONFIG_DIR"
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[history.encryption]
+recipients = ["age1fuvsfq02qr5ju0nhh3rulrwracymjljlr5j49kres24ltd3fjq0s9z9d8l"]
+[dotfiles]
+"~/.private-config" = { mode = "track", encrypt = true }
+TOML
+echo first-private-value >~/.private-config
+first_plain=$(git hash-object ~/.private-config)
+assert_succeed "mise bootstrap dotfiles save"
+repo="$MISE_STATE_DIR/history/repo.git"
+assert_contains "git --git-dir=$repo show HEAD:home/.private-config | head -1" 'mise-encrypted-file-v1'
+assert_fail "git --git-dir=$repo cat-file -e $first_plain"
+assert_fail "git --git-dir=$repo cat-file -e HEAD:config/config.toml"
+
+echo second-private-value >~/.private-config
+second_plain=$(git hash-object ~/.private-config)
+assert_succeed "mise bootstrap dotfiles history diff --path ~/.private-config"
+assert_fail "git --git-dir=$repo cat-file -e $second_plain"
+
+assert_succeed "mise bootstrap dotfiles rollback ~/.private-config --to 1 --dry-run"
+assert "cat ~/.private-config" 'second-private-value'
+assert_fail "git --git-dir=$repo cat-file -e $first_plain"
+assert_fail "git --git-dir=$repo cat-file -e $second_plain"
+assert "git --git-dir=$repo for-each-ref --format='%(refname)' refs/mise-decrypted-files refs/mise-history refs/machines" ""
+assert_succeed "mise bootstrap dotfiles save"
+assert_fail "git --git-dir=$repo cat-file -e $second_plain"
+assert "git --git-dir=$repo rev-list --count HEAD" "2"
+
+# Actual restoration writes native plaintext, but its new commits remain encrypted.
+assert_succeed "mise bootstrap dotfiles rollback ~/.private-config --to 1 --yes"
+assert "cat ~/.private-config" 'first-private-value'
+assert_fail "git --git-dir=$repo cat-file -e $first_plain"
+assert_fail "git --git-dir=$repo cat-file -e $second_plain"
+assert_contains "git --git-dir=$repo show HEAD:home/.private-config | head -1" 'mise-encrypted-file-v1'
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert "cat ~/.private-config" 'second-private-value'
+assert_fail "git --git-dir=$repo cat-file -e $first_plain"
+assert_fail "git --git-dir=$repo cat-file -e $second_plain"
+
+# The ordinary repository carries recipients independently of mise config.
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[dotfiles]
+"~/.private-config" = { mode = "track", encrypt = true }
+TOML
+echo manifest-recipient-value >~/.private-config
+manifest_plain=$(git hash-object ~/.private-config)
+assert_succeed "mise bootstrap dotfiles save"
+assert_contains "git --git-dir=$repo show HEAD:home/.private-config | head -1" 'mise-encrypted-file-v1'
+assert_fail "git --git-dir=$repo cat-file -e $manifest_plain"

--- a/e2e/cli/test_dotfiles_encrypted_diff
+++ b/e2e/cli/test_dotfiles_encrypted_diff
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Plaintext diffs and restoration never write plaintext into Git objects.
+# shellcheck disable=SC2016
+require_cmd git
+export MISE_AGE_KEY=AGE-SECRET-KEY-142E7VJ8GUWR94MXDCYQJ7ZTQZRXKQSP9PUJU8HUQJ206QN7QPV4SM5QRL8
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[history.encryption]
+recipients = ["age1fuvsfq02qr5ju0nhh3rulrwracymjljlr5j49kres24ltd3fjq0s9z9d8l"]
+[dotfiles]
+"~/.encrypted" = { mode = "track", encrypt = true, variants = [{ os = "macos" }, { os = "linux" }] }
+TOML
+printf 'original-secret\n' >"$HOME/.encrypted"
+assert_succeed 'mise bootstrap dotfiles save'
+repository="$MISE_STATE_DIR/history/repo.git"
+original=$(git --git-dir="$repository" rev-parse HEAD)
+original_blob=$(git hash-object "$HOME/.encrypted")
+printf 'edited-secret\n' >"$HOME/.encrypted"
+edited_blob=$(git hash-object "$HOME/.encrypted")
+assert_contains 'mise bootstrap dotfiles history diff --patch --path ~/.encrypted' '+edited-secret'
+assert_not_contains 'mise bootstrap dotfiles history diff --patch --path ~/.encrypted' 'mise-encrypted-file'
+assert_fail "git --git-dir=$repository cat-file -e $edited_blob"
+assert_succeed 'mise bootstrap dotfiles save'
+assert_contains "mise bootstrap dotfiles history diff $original latest --patch --path ~/.encrypted" '-original-secret'
+assert_succeed "mise bootstrap dotfiles rollback ~/.encrypted --to $original --yes"
+assert 'cat ~/.encrypted' original-secret
+assert_succeed 'mise bootstrap dotfiles undo --yes'
+assert 'cat ~/.encrypted' edited-secret
+assert_fail "git --git-dir=$repository cat-file -e $original_blob"
+assert_fail "git --git-dir=$repository cat-file -e $edited_blob"

--- a/e2e/cli/test_dotfiles_explicit_tracking
+++ b/e2e/cli/test_dotfiles_explicit_tracking
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Deployment and referencing a source never enroll either path in history.
+require_cmd git
+
+mkdir -p "$MISE_CONFIG_DIR/dotfiles" ~/templates/nested
+echo source >"$MISE_CONFIG_DIR/dotfiles/source"
+echo template >~/templates/nested/gitconfig.tera
+echo native >~/.native
+echo target >~/.link-target
+ln -s "$HOME/.link-target" ~/.observed-link
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[dotfiles]
+"~/.generated" = { mode = "copy", source = "dotfiles/source" }
+TOML
+
+assert "mise bootstrap dotfiles paths --json | jq '.entries | length'" "0"
+assert_succeed "mise bootstrap dotfiles track ~/.native ~/templates ~/.observed-link"
+assert "mise bootstrap dotfiles paths --json | jq '.entries | length'" "3"
+assert "mise bootstrap dotfiles paths --json | jq '[.entries[] | select(.path == \"~/.generated\" or .mode == \"implicit\" or .mode == \"source\" or .mode == \"derived\")] | length'" "0"
+
+echo added >~/templates/nested/new.tera
+echo excluded >~/templates/nested/config.local.toml
+echo excluded >~/templates/nested/credentials.json
+assert_succeed "mise bootstrap dotfiles save"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git rev-list --count refs/heads/main" "2"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git show HEAD:home/.native" "native"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git for-each-ref --format='%(refname)' refs/checkpoints refs/promoted refs/mise-history" ""
+assert_fail "git --git-dir=$MISE_STATE_DIR/history/repo.git cat-file -e HEAD:home/.config/mise/config.toml"
+assert "mise bootstrap dotfiles paths --json | jq '.entries[] | select(.path == \"~/templates\") | .files'" "2"
+assert "cat ~/.link-target" "target"
+assert_succeed "test -L ~/.observed-link"
+assert_fail "test -e ~/.git"
+assert_fail "test -e ~/templates/.git"
+
+# Exact managed outputs and referenced sources can be observed independently.
+echo live-output >~/.generated
+assert_succeed "mise bootstrap dotfiles track ~/.generated $MISE_CONFIG_DIR/dotfiles/source"
+assert "cat ~/.generated" "live-output"
+assert_contains "cat $MISE_CONFIG_DIR/config.toml" 'mode = "copy"'
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git show HEAD:home/.generated" "live-output"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git show HEAD:config/dotfiles/source" "source"
+assert_succeed "mise bootstrap dotfiles untrack ~/.generated"
+assert "cat ~/.generated" "live-output"
+assert_contains "cat $MISE_CONFIG_DIR/config.toml" 'mode = "copy"'
+assert_fail "git --git-dir=$MISE_STATE_DIR/history/repo.git cat-file -e HEAD:home/.generated"

--- a/e2e/cli/test_dotfiles_history
+++ b/e2e/cli/test_dotfiles_history
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Browsing and restoring ordinary Git commits, with a disposable derived index.
+require_cmd git
+repository="$MISE_STATE_DIR/history/repo.git"
+echo one >~/.history-file
+assert_succeed 'mise bootstrap dotfiles track ~/.history-file'
+first=$(git --git-dir="$repository" rev-parse HEAD)
+assert_contains 'mise bootstrap dotfiles save 2>&1' 'nothing changed'
+echo two >~/.history-file
+assert_succeed 'mise bootstrap dotfiles save --description second'
+second=$(git --git-dir="$repository" rev-parse HEAD)
+assert "mise bootstrap dotfiles history show latest --json | jq -r .uuid" "$second"
+assert "mise bootstrap dotfiles history show latest --json | jq -r .changes.since" "$first"
+echo three >~/.history-file
+assert_contains 'mise bootstrap dotfiles history diff --patch --path ~/.history-file' '+three'
+assert_fail 'mise bootstrap dotfiles history diff --exit-code'
+assert_contains "mise bootstrap dotfiles history diff $first $second --patch" '+two'
+assert_fail 'mise bootstrap dotfiles history show 999999'
+assert_succeed "mise bootstrap dotfiles history describe $second 'the second version'"
+assert "mise bootstrap dotfiles history show $second --json | jq -r .description" 'the second version'
+assert "git --git-dir=$repository for-each-ref --format='%(refname)' refs/notes" ''
+assert_succeed "mise bootstrap dotfiles rollback ~/.history-file --to $first --yes"
+assert 'cat ~/.history-file' one
+assert_succeed 'mise bootstrap dotfiles undo --yes'
+assert 'cat ~/.history-file' three
+mv "$MISE_STATE_DIR/history/index" "$MISE_STATE_DIR/history/old-index"
+assert "mise bootstrap dotfiles history show $second --json | jq -r .description" 'the second version'
+assert_succeed "git --git-dir=$repository merge-base --is-ancestor $first HEAD"
+assert_succeed "git --git-dir=$repository fsck --no-progress"
+assert_fail 'MISE_HISTORY_ENABLED=0 mise bootstrap dotfiles save' 'history is disabled'

--- a/e2e/cli/test_dotfiles_history_bootstrap
+++ b/e2e/cli/test_dotfiles_history_bootstrap
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Bootstrap records ordinary boundaries for explicitly tracked files only.
+# Temporary recovery data for untracked writes is never durable file history.
+# shellcheck disable=SC2016
+require_cmd git
+repository="$MISE_STATE_DIR/history/repo.git"
+mkdir -p "$MISE_CONFIG_DIR/dotfiles"
+printf 'one\n' >"$MISE_CONFIG_DIR/dotfiles/copied"
+printf 'untracked-secret\n' >"$HOME/.copied"
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[dotfiles]
+"~/.copied" = { source = "dotfiles/copied", mode = "copy" }
+TOML
+assert_succeed 'mise bootstrap dotfiles apply --dry-run'
+assert_succeed 'mise bootstrap dotfiles apply --yes'
+assert 'cat ~/.copied' one
+assert 'mise bootstrap dotfiles history --json -n 0 | jq length' 0
+assert_fail "git --git-dir=$repository rev-parse --verify HEAD"
+
+# Enroll the managed output without displacing its deployment declaration.
+assert_succeed 'mise bootstrap dotfiles track ~/.copied'
+before=$(git --git-dir="$repository" rev-parse HEAD)
+printf 'two\n' >"$MISE_CONFIG_DIR/dotfiles/copied"
+assert_succeed 'mise bootstrap --yes --only dotfiles'
+assert 'cat ~/.copied' two
+assert "git --git-dir=$repository show HEAD:home/.copied" two
+assert "git --git-dir=$repository show $before:home/.copied" one
+assert 'mise bootstrap dotfiles history --json | jq -r ".[0].trigger, .[1].trigger"' $'bootstrap\nbootstrap-before'
+assert 'mise bootstrap dotfiles history --json | jq -r ".[0].operation.status"' completed
+assert 'mise bootstrap dotfiles history --json | jq ".[0].operation.journal | length"' 0
+assert_not_contains "git --git-dir=$repository ls-tree -r --name-only HEAD" 'config/'
+assert_not_contains "git --git-dir=$repository log --format=%B" 'untracked-secret'
+assert_not_contains "git --git-dir=$repository log --format=%B" '--only'
+assert_contains "mise bootstrap dotfiles history diff $before latest --patch --path ~/.copied" '+two'
+
+# Tracked restoration uses the same Git ancestry; completed private journals go away.
+assert_succeed "mise bootstrap dotfiles rollback ~/.copied --to $before --yes"
+assert 'cat ~/.copied' one
+assert_succeed 'mise bootstrap dotfiles undo --yes'
+assert 'cat ~/.copied' two
+assert_succeed "git --git-dir=$repository merge-base --is-ancestor $before HEAD"
+assert "find $MISE_STATE_DIR/history/pending -type f | wc -l | tr -d ' '" 0

--- a/e2e/cli/test_dotfiles_history_policies
+++ b/e2e/cli/test_dotfiles_history_policies
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Manual capture, absence, and permission isolation use the ordinary parent.
+require_cmd git
+repository="$MISE_STATE_DIR/history/repo.git"
+echo v1 >~/.manual
+assert_succeed 'mise bootstrap dotfiles track ~/.manual --no-autosave'
+first=$(git --git-dir="$repository" rev-parse HEAD)
+echo v2 >~/.manual
+assert_succeed 'mise bootstrap dotfiles save --description unrelated'
+assert "git --git-dir=$repository show HEAD:home/.manual" v1
+assert_contains 'mise bootstrap dotfiles history diff --patch --path ~/.manual' '+v2'
+assert_succeed 'mise bootstrap dotfiles save ~/.manual'
+assert "git --git-dir=$repository show HEAD:home/.manual" v2
+rm ~/.manual
+assert_succeed 'mise bootstrap dotfiles save ~/.manual'
+echo recreated >~/.manual
+assert_succeed 'mise bootstrap dotfiles save --description unrelated-again'
+assert_fail "git --git-dir=$repository cat-file -e HEAD:home/.manual"
+assert_succeed 'mise bootstrap dotfiles save ~/.manual'
+assert "git --git-dir=$repository show HEAD:home/.manual" recreated
+mkdir -p ~/manual-dir
+echo a1 >~/manual-dir/a
+echo b1 >~/manual-dir/b
+chmod 600 ~/manual-dir/b
+assert_succeed 'mise bootstrap dotfiles track ~/manual-dir --no-autosave'
+echo a2 >~/manual-dir/a
+echo b2 >~/manual-dir/b
+chmod 644 ~/manual-dir/b
+assert_succeed 'mise bootstrap dotfiles save ~/manual-dir/a'
+assert "git --git-dir=$repository show HEAD:home/manual-dir/a" a2
+assert "git --git-dir=$repository show HEAD:home/manual-dir/b" b1
+assert "git --git-dir=$repository show HEAD:.mise-history/manifest.json | jq '.permissions[\"home/manual-dir/b\"]'" 384
+# Old versions remain reachable indefinitely; no promoted/checkpoint refs.
+assert_succeed "git --git-dir=$repository merge-base --is-ancestor $first HEAD"
+assert "git --git-dir=$repository show $first:home/.manual" v1
+assert "git --git-dir=$repository for-each-ref --format='%(refname)' refs/promoted refs/checkpoints" ''
+assert_fail 'mise settings set history.keep_count 1'
+assert_fail 'mise bootstrap dotfiles save ~/.never-tracked'

--- a/e2e/cli/test_dotfiles_incoming_enrollment
+++ b/e2e/cli/test_dotfiles_incoming_enrollment
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Enrollment changes travel with ordinary commits, independently of mise config.
+require_cmd git
+export MISE_HISTORY_NOTIFY=false
+origin="$PWD/setup.git"
+git init -q --bare -b main "$origin"
+echo initial >~/.native
+assert_succeed "mise bootstrap dotfiles track ~/.native"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync manual --yes"
+second="$(dirname "$HOME")/enrollment-machine"
+mkdir -p "$second"
+b() {
+  (
+    cd "$second" || exit
+    env HOME="$second" XDG_CONFIG_HOME="$second/.config" MISE_CONFIG_DIR="$second/.config/mise" \
+      MISE_STATE_DIR="$second/.local/state/mise" MISE_DATA_DIR="$second/.local/share/mise" \
+      MISE_CACHE_DIR="$second/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$second" mise "$@"
+  )
+}
+export second
+export -f b
+assert_succeed "b bootstrap --from-git file://$origin --yes"
+assert_fail "test -e $second/.config/mise/config.toml"
+echo independently-enrolled >"$second/.machine-added"
+assert_succeed "b bootstrap dotfiles track $second/.machine-added"
+echo enrolled-later >~/.new-file
+assert_succeed "mise bootstrap dotfiles track ~/.new-file"
+assert_succeed "mise bootstrap dotfiles sync"
+added=$(git --git-dir="$origin" rev-parse main)
+assert_succeed "b bootstrap dotfiles sync --fetch-only"
+assert_succeed "b bootstrap dotfiles pull --yes"
+assert "cat $second/.new-file" "enrolled-later"
+repository="$second/.local/state/mise/history/repo.git"
+assert_succeed "git --git-dir=$repository merge-base --is-ancestor $added main"
+assert_succeed "b bootstrap dotfiles sync"
+assert "git --git-dir=$origin show main:home/.machine-added" "independently-enrolled"
+assert_succeed "mise bootstrap dotfiles sync --fetch-only"
+assert_succeed "mise bootstrap dotfiles pull --yes"
+assert "cat ~/.machine-added" "independently-enrolled"
+
+# Untracking changes the committed inventory but never deletes live contents.
+assert_succeed "mise bootstrap dotfiles untrack ~/.new-file"
+assert_succeed "mise bootstrap dotfiles sync"
+assert_succeed "b bootstrap dotfiles sync --fetch-only"
+assert_contains "b bootstrap dotfiles status" "repository enrollment"
+assert_succeed "b bootstrap dotfiles watch --once"
+assert "cat $second/.new-file" "enrolled-later"
+assert_fail "git --git-dir=$repository cat-file -e main:home/.new-file"
+echo untracked-edit >"$second/.new-file"
+assert_succeed "b bootstrap dotfiles save"
+assert_fail "git --git-dir=$repository cat-file -e main:home/.new-file"
+assert "git --git-dir=$repository show $added:home/.new-file" "enrolled-later"
+
+# Ordinary repository files also travel, but are never deployed to HOME.
+git clone -q "$origin" "$PWD/maintenance"
+echo repository-documentation >"$PWD/maintenance/README.md"
+git -C "$PWD/maintenance" add README.md
+git -C "$PWD/maintenance" -c user.name=test -c user.email=test@example.com commit -qm documentation
+git -C "$PWD/maintenance" push -q origin main
+assert_succeed "b bootstrap dotfiles watch --once"
+assert "git --git-dir=$repository show main:README.md" "repository-documentation"
+assert_fail "test -e $second/README.md"

--- a/e2e/cli/test_dotfiles_manifest_bootstrap
+++ b/e2e/cli/test_dotfiles_manifest_bootstrap
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Fresh setup is driven by ordinary Git enrollment, not implicit config capture.
+require_cmd git
+require_cmd jq
+export MISE_HISTORY_NOTIFY=false
+origin="$PWD/setup.git"
+git init -q --bare -b main "$origin"
+echo native >~/.native
+chmod 600 ~/.native
+assert_succeed "mise bootstrap dotfiles track ~/.native"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync manual --yes"
+initial=$(git --git-dir="$origin" rev-parse main)
+second="$(dirname "$HOME")/fresh-machine"
+mkdir -p "$second"
+b() {
+  (
+    cd "$second" || exit
+    env HOME="$second" XDG_CONFIG_HOME="$second/.config" MISE_CONFIG_DIR="$second/.config/mise" \
+      MISE_STATE_DIR="$second/.local/state/mise" MISE_DATA_DIR="$second/.local/share/mise" \
+      MISE_CACHE_DIR="$second/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$second" mise "$@"
+  )
+}
+export second
+export -f b
+# Earlier non-tracking bootstrap work must not create unrelated file history.
+assert_succeed "b bootstrap --yes"
+assert_fail "git --git-dir=$second/.local/state/mise/history/repo.git rev-parse --verify HEAD"
+assert_succeed "b bootstrap --from-git file://$origin --yes"
+assert "cat $second/.native" "native"
+assert "(b doctor --json 2>/dev/null || true) | jq -r .dotfiles.tracked" "1"
+if [[ "$(uname)" == Darwin ]]; then
+  mode_of="stat -f %Lp"
+else
+  mode_of="stat -c %a"
+fi
+assert "$mode_of $second/.native" "600"
+repository="$second/.local/state/mise/history/repo.git"
+assert_succeed "git --git-dir=$repository merge-base --is-ancestor $initial main"
+
+assert_fail "test -e $second/.git"
+assert_fail "test -e $second/.config/mise/.git"
+assert_fail "test -e $second/.config/mise/config.toml"
+echo edited >"$second/.native"
+assert_succeed "b bootstrap dotfiles save"
+assert "git --git-dir=$repository show main:home/.native" "edited"
+assert_succeed "b bootstrap dotfiles sync"
+assert "git --git-dir=$origin show main:home/.native" "edited"
+
+# An identical existing file is not a conflict on first adoption.
+second="$(dirname "$HOME")/identical-machine"
+mkdir -p "$second"
+echo edited >"$second/.native"
+assert_succeed "b bootstrap --from-git file://$origin --yes"
+assert "cat $second/.native" "edited"
+
+# A differing existing file pauses adoption without inventing local ancestry.
+second="$(dirname "$HOME")/conflicted-machine"
+mkdir -p "$second"
+echo keep-me >"$second/.native"
+assert_fail "b bootstrap --from-git file://$origin --yes" "paused"
+assert "cat $second/.native" "keep-me"
+repository="$second/.local/state/mise/history/repo.git"
+assert_fail "git --git-dir=$repository rev-parse --verify main"
+assert_succeed "b bootstrap dotfiles pull --take-remote $second/.native --yes"
+assert "cat $second/.native" "edited"
+assert_succeed "git --git-dir=$repository merge-base --is-ancestor $initial main"
+
+# Encrypted enrollment and public recipients arrive in the same Git history.
+encrypted_origin="$PWD/encrypted-setup.git"
+git init -q --bare -b main "$encrypted_origin"
+export MISE_AGE_KEY="AGE-SECRET-KEY-142E7VJ8GUWR94MXDCYQJ7ZTQZRXKQSP9PUJU8HUQJ206QN7QPV4SM5QRL8"
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[history.encryption]
+recipients = ["age1fuvsfq02qr5ju0nhh3rulrwracymjljlr5j49kres24ltd3fjq0s9z9d8l"]
+[dotfiles]
+"~/.encrypted-value" = { mode = "track", encrypt = true }
+TOML
+echo confidential >~/.encrypted-value
+plaintext=$(git hash-object ~/.encrypted-value)
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "mise bootstrap dotfiles origin set file://$encrypted_origin --sync manual --yes"
+second="$(dirname "$HOME")/encrypted-machine"
+mkdir -p "$second"
+assert_succeed "b bootstrap --from-git file://$encrypted_origin --yes"
+assert "cat $second/.encrypted-value" "confidential"
+repository="$second/.local/state/mise/history/repo.git"
+assert_fail "git --git-dir=$repository cat-file -e $plaintext"
+echo changed-confidential >"$second/.encrypted-value"
+changed_plaintext=$(git hash-object "$second/.encrypted-value")
+assert_succeed "b bootstrap dotfiles save"
+assert_fail "git --git-dir=$repository cat-file -e $changed_plaintext"
+assert_succeed "b bootstrap dotfiles sync"
+assert_fail "git --git-dir=$encrypted_origin cat-file -e $changed_plaintext"

--- a/e2e/cli/test_dotfiles_manifest_enrollment
+++ b/e2e/cli/test_dotfiles_manifest_enrollment
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Git enrollment works without copying the declaring mise configuration.
+require_cmd git
+export MISE_HISTORY_NOTIFY=false
+echo original >~/.native
+echo untouched >~/.other
+assert_succeed "mise bootstrap dotfiles track ~/.native ~/.other"
+repository="$MISE_STATE_DIR/history/repo.git"
+second="$(dirname "$HOME")/manifest-machine"
+mkdir -p "$second/.local/state/mise/history"
+git clone -q --bare "$repository" "$second/.local/state/mise/history/repo.git"
+echo original >"$second/.native"
+echo untouched >"$second/.other"
+b() {
+  (
+    cd "$second" || exit
+    env HOME="$second" XDG_CONFIG_HOME="$second/.config" MISE_CONFIG_DIR="$second/.config/mise" \
+      MISE_STATE_DIR="$second/.local/state/mise" MISE_DATA_DIR="$second/.local/share/mise" \
+      MISE_CACHE_DIR="$second/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$second" mise "$@"
+  )
+}
+export second
+export -f b
+echo changed >"$second/.native"
+assert_succeed "b bootstrap dotfiles save"
+second_repo="$second/.local/state/mise/history/repo.git"
+assert "git --git-dir=$second_repo show main:home/.native" "changed"
+assert "git --git-dir=$second_repo show main:home/.other" "untouched"
+assert_fail "test -f $second/.config/mise/config.toml"
+before=$(git --git-dir="$second_repo" rev-parse main)
+assert_succeed "b bootstrap dotfiles capture -- mise bootstrap dotfiles untrack $second/.native"
+assert "cat $second/.native" "changed"
+assert_fail "git --git-dir=$second_repo cat-file -e main:home/.native"
+assert "git --git-dir=$second_repo show $before:home/.native" "changed"
+assert "git --git-dir=$second_repo show main:home/.other" "untouched"
+echo later >"$second/.native"
+assert_succeed "b bootstrap dotfiles save"
+assert_fail "git --git-dir=$second_repo cat-file -e main:home/.native"
+assert_succeed "b bootstrap dotfiles track $second/.native"
+assert "git --git-dir=$second_repo show main:home/.native" "later"

--- a/e2e/cli/test_dotfiles_onboard_review
+++ b/e2e/cli/test_dotfiles_onboard_review
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+require_cmd git
+export MISE_EXPERIMENTAL=0
+printf 'original\n' >~/.onboard-review
+assert_succeed 'mise bootstrap dotfiles track ~/.onboard-review'
+origin="$PWD/origin.git"
+git init -q --bare "$origin"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync fetch-only --yes"
+assert 'mise settings get history.sync' 'fetch-only'
+assert_succeed 'mise settings set history.sync manual'
+assert 'mise settings get history.sync' 'manual'
+assert_contains 'mise bootstrap dotfiles status' 'mode manual'
+assert_succeed 'mise settings set history.sync sync'
+assert 'mise settings get history.sync' 'sync'
+assert_succeed 'mise settings unset history.sync'
+assert 'mise settings get history.sync' 'sync'
+assert_succeed 'mise bootstrap dotfiles sync'
+
+# A broken local store must not turn a marked repository into a plain clone.
+broken="$PWD/broken-state"
+mkdir -p "$broken/history"
+printf 'not a repository\n' >"$broken/history/repo.git"
+assert_fail "MISE_STATE_DIR=$broken mise bootstrap --from-git file://$origin --yes" 'history is unavailable'
+assert_fail 'test -d ~/.config/mise/.git'
+
+# Preview and refusal cannot alter an existing connection's bookkeeping.
+status="$MISE_STATE_DIR/history/sync.json"
+cp "$status" "$PWD/sync-before.json"
+refs="$(git --git-dir="$MISE_STATE_DIR/history/repo.git" for-each-ref --format='%(refname) %(objectname)')"
+assert_succeed "mise bootstrap --from-git file://$origin --dry-run --only dotfiles"
+assert_succeed "cmp '$status' '$PWD/sync-before.json'"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git for-each-ref --format='%(refname) %(objectname)'" "$refs"
+assert_fail "MISE_YES=0 mise bootstrap --from-git file://$origin --only dotfiles </dev/null" 'not set up'
+assert_succeed "cmp '$status' '$PWD/sync-before.json'"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git for-each-ref --format='%(refname) %(objectname)'" "$refs"
+
+# A validation failure after fetching also leaves the old state untouched.
+git clone -q "$origin" damaged
+printf '[broken\n' >damaged/config.toml
+git -C damaged add config.toml
+git -C damaged -c user.name=test -c user.email=test@example.com commit -qm invalid
+git -C damaged push -q
+assert_fail "mise bootstrap --from-git file://$origin --dry-run --only dotfiles"
+assert_succeed "cmp '$status' '$PWD/sync-before.json'"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git for-each-ref --format='%(refname) %(objectname)'" "$refs"

--- a/e2e/cli/test_dotfiles_onboard_review
+++ b/e2e/cli/test_dotfiles_onboard_review
@@ -3,8 +3,9 @@ require_cmd git
 export MISE_EXPERIMENTAL=0
 printf 'original\n' >~/.onboard-review
 assert_succeed 'mise bootstrap dotfiles track ~/.onboard-review'
+assert_succeed 'mise bootstrap dotfiles track ~/.config/mise/config.toml'
 origin="$PWD/origin.git"
-git init -q --bare "$origin"
+git init -q --bare -b main "$origin"
 assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync fetch-only --yes"
 assert 'mise settings get history.sync' 'fetch-only'
 assert_succeed 'mise settings set history.sync manual'
@@ -36,8 +37,8 @@ assert "git --git-dir=$MISE_STATE_DIR/history/repo.git for-each-ref --format='%(
 
 # A validation failure after fetching also leaves the old state untouched.
 git clone -q "$origin" damaged
-printf '[broken\n' >damaged/config.toml
-git -C damaged add config.toml
+printf '[broken\n' >damaged/config/config.toml
+git -C damaged add config/config.toml
 git -C damaged -c user.name=test -c user.email=test@example.com commit -qm invalid
 git -C damaged push -q
 assert_fail "mise bootstrap --from-git file://$origin --dry-run --only dotfiles"

--- a/e2e/cli/test_dotfiles_onboarding
+++ b/e2e/cli/test_dotfiles_onboarding
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Connecting origin publishes the same explicitly tracked ordinary history.
+require_cmd git
+export MISE_HISTORY_NOTIFY=false
+echo first >~/.shared-config
+echo never-capture >~/.netrc
+assert_contains 'mise bootstrap dotfiles track ~/.shared-config 2>&1' 'automatic capture is inactive'
+echo second >~/.shared-config
+assert_succeed 'mise bootstrap dotfiles save'
+repository="$MISE_STATE_DIR/history/repo.git"
+saved=$(git --git-dir="$repository" rev-parse HEAD)
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync manual --yes"
+assert_succeed "git --git-dir=$origin merge-base --is-ancestor $saved main"
+assert "git --git-dir=$origin show main:home/.shared-config" second
+assert_fail "git --git-dir=$origin cat-file -e main:home/.netrc"
+assert_fail "git --git-dir=$origin cat-file -e main:config/config.toml"
+assert "git --git-dir=$origin for-each-ref --format='%(refname)' refs/mise-history" ''
+echo third >~/.shared-config
+assert_succeed 'mise bootstrap dotfiles save'
+assert "git --git-dir=$origin show main:home/.shared-config" second
+assert_succeed 'mise bootstrap dotfiles sync'
+assert "git --git-dir=$origin show main:home/.shared-config" third
+assert_succeed 'mise bootstrap dotfiles untrack ~/.shared-config'
+assert 'cat ~/.shared-config' third
+assert_succeed 'mise bootstrap dotfiles sync'
+assert_fail "git --git-dir=$origin cat-file -e main:home/.shared-config"
+assert "git --git-dir=$origin show $saved:home/.shared-config" second

--- a/e2e/cli/test_dotfiles_one_history
+++ b/e2e/cli/test_dotfiles_one_history
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Manual files use the ordinary parent commit, never a second saved history.
+require_cmd git
+
+echo saved >~/.manual
+echo first >~/.automatic
+assert_succeed "mise bootstrap dotfiles track ~/.manual --no-autosave"
+assert_succeed "mise bootstrap dotfiles track ~/.automatic"
+echo unsaved >~/.manual
+echo second >~/.automatic
+assert_succeed "mise bootstrap dotfiles save"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git show HEAD:home/.manual" "saved"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git show HEAD:home/.automatic" "second"
+assert_succeed "mise bootstrap dotfiles save ~/.manual"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git show HEAD:home/.manual" "unsaved"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git for-each-ref --format='%(refname)' refs/promoted refs/checkpoints" ""
+
+mkdir -p ~/manual-dir
+echo old-a >~/manual-dir/a
+echo old-b >~/manual-dir/b
+assert_succeed "mise bootstrap dotfiles track ~/manual-dir --no-autosave"
+echo new-a >~/manual-dir/a
+echo new-b >~/manual-dir/b
+assert_succeed "mise bootstrap dotfiles save ~/manual-dir/a"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git show HEAD:home/manual-dir/a" "new-a"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git show HEAD:home/manual-dir/b" "old-b"
+
+before_untrack=$(git --git-dir="$MISE_STATE_DIR/history/repo.git" rev-parse HEAD)
+assert_succeed "mise bootstrap dotfiles untrack ~/.manual"
+assert "cat ~/.manual" "unsaved"
+assert_fail "git --git-dir=$MISE_STATE_DIR/history/repo.git cat-file -e HEAD:home/.manual"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git show $before_untrack:home/.manual" "unsaved"
+
+# The local index can be discarded and rebuilt from ordinary commits alone.
+mv "$MISE_STATE_DIR/history/index" "$MISE_STATE_DIR/history/index-before-rebuild"
+assert_succeed "mise bootstrap dotfiles history --json"
+echo third >~/.automatic
+assert_succeed "mise bootstrap dotfiles save"
+assert "git --git-dir=$MISE_STATE_DIR/history/repo.git show HEAD:home/manual-dir/b" "old-b"

--- a/e2e/cli/test_dotfiles_ordinary_annotations
+++ b/e2e/cli/test_dotfiles_ordinary_annotations
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Descriptions live in ordinary ancestry and survive a clone without Git notes.
+require_cmd git
+export MISE_HISTORY_NOTIFY=false
+echo native >~/.native
+assert_succeed "mise bootstrap dotfiles track ~/.native"
+original=$(mise bootstrap dotfiles history show latest --json | jq -r .uuid)
+repo="$MISE_STATE_DIR/history/repo.git"
+tree=$(git --git-dir="$repo" rev-parse 'main^{tree}')
+assert_succeed "mise bootstrap dotfiles history describe $original 'configure native shell'"
+assert "mise bootstrap dotfiles history show $original --json | jq -r .description" 'configure native shell'
+assert "git --git-dir=$repo rev-parse main^{tree}" "$tree"
+assert "git --git-dir=$repo for-each-ref --format='%(refname)' refs/notes/" ''
+assert_succeed "git --git-dir=$repo merge-base --is-ancestor $original main"
+
+origin="$PWD/setup.git"
+git init -q --bare -b main "$origin"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync manual --yes"
+assert "git --git-dir=$origin rev-parse main" "$(git --git-dir="$repo" rev-parse main)"
+second="$(dirname "$HOME")/annotation-machine"
+mkdir -p "$second/.local/state/mise/history"
+git clone -q --bare "$origin" "$second/.local/state/mise/history/repo.git"
+b() {
+  (
+    cd "$second" || exit
+    env HOME="$second" XDG_CONFIG_HOME="$second/.config" MISE_CONFIG_DIR="$second/.config/mise" \
+      MISE_STATE_DIR="$second/.local/state/mise" MISE_DATA_DIR="$second/.local/share/mise" \
+      MISE_CACHE_DIR="$second/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$second" mise "$@"
+  )
+}
+export second
+export -f b
+assert "b bootstrap dotfiles history show $original --json | jq -r .description" 'configure native shell'
+assert "git --git-dir=$second/.local/state/mise/history/repo.git for-each-ref --format='%(refname)' refs/notes/" ''

--- a/e2e/cli/test_dotfiles_ordinary_preflight
+++ b/e2e/cli/test_dotfiles_ordinary_preflight
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Validate required template inputs even when configuration is not tracked.
+require_cmd git
+export MISE_HISTORY_NOTIFY=false
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+echo template >~/.template
+echo base >~/.other
+mkdir -p "$MISE_CONFIG_DIR"
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[dotfiles]
+"~/.template" = { mode = "track" }
+"~/.other" = { mode = "track" }
+"~/.rendered" = { mode = "template", source = "~/.template" }
+TOML
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync manual --yes"
+second="$(dirname "$HOME")/second"
+mkdir -p "$second/.config/mise" "$second/.local/state/mise/history"
+git clone -q --bare "$origin" "$second/.local/state/mise/history/repo.git"
+cp "$MISE_CONFIG_DIR/config.toml" "$second/.config/mise/config.toml"
+echo template >"$second/.template"
+echo base >"$second/.other"
+b() {
+  (
+    cd "$second" || exit
+    env HOME="$second" XDG_CONFIG_HOME="$second/.config" MISE_CONFIG_DIR="$second/.config/mise" \
+      MISE_STATE_DIR="$second/.local/state/mise" MISE_DATA_DIR="$second/.local/share/mise" \
+      MISE_CACHE_DIR="$second/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$second" mise "$@"
+  )
+}
+export second
+export -f b
+assert_succeed "b bootstrap dotfiles origin set file://$origin --sync manual --yes"
+mv ~/.template ~/.template-removed-for-test
+echo incoming >~/.other
+assert_succeed 'mise bootstrap dotfiles save'
+assert_succeed 'mise bootstrap dotfiles sync'
+published=$(git --git-dir="$origin" rev-parse main)
+assert_succeed 'b bootstrap dotfiles sync --fetch-only'
+assert_contains 'b bootstrap dotfiles status' 'required source'
+assert_fail 'b bootstrap dotfiles pull --yes' 'paused'
+assert "cat $second/.other" 'base'
+assert "cat $second/.template" 'template'
+assert "git --git-dir=$origin rev-parse main" "$published"
+assert_fail "git --git-dir=$origin cat-file -e main:config/config.toml"

--- a/e2e/cli/test_dotfiles_ordinary_sync
+++ b/e2e/cli/test_dotfiles_ordinary_sync
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Manual synchronization publishes exactly the accumulated ordinary commits.
+require_cmd git
+origin="$PWD/ordinary-origin.git"
+git init -q --bare -b main "$origin"
+echo initial >~/.native
+assert_succeed "mise bootstrap dotfiles track ~/.native"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync manual --yes"
+repo="$MISE_STATE_DIR/history/repo.git"
+initial=$(git --git-dir="$repo" rev-parse HEAD)
+assert "git --git-dir=$origin rev-parse main" "$initial"
+echo intermediate >~/.native
+assert_succeed "mise bootstrap dotfiles save"
+intermediate=$(git --git-dir="$repo" rev-parse HEAD)
+echo final >~/.native
+assert_succeed "mise bootstrap dotfiles save"
+final=$(git --git-dir="$repo" rev-parse HEAD)
+assert "git --git-dir=$origin rev-parse main" "$initial"
+assert_succeed "mise bootstrap dotfiles sync"
+assert "git --git-dir=$origin rev-parse main" "$final"
+assert "git --git-dir=$origin show $intermediate:home/.native" "intermediate"
+assert "git --git-dir=$origin show main:home/.native" "final"
+assert "git --git-dir=$repo rev-list HEAD" "$(git --git-dir="$origin" rev-list main)"
+assert "git --git-dir=$repo for-each-ref --format='%(refname)' refs/setup refs/mise-history refs/machines" ""
+assert "git --git-dir=$origin for-each-ref --format='%(refname)'" "refs/heads/main"
+assert_fail "git --git-dir=$origin cat-file -e main:config/config.toml"
+assert_succeed "mise bootstrap dotfiles sync"
+assert "git --git-dir=$repo rev-parse HEAD" "$final"
+assert "git --git-dir=$origin rev-parse main" "$final"
+
+# Encryption is already present in those same commits, not added by publishing.
+export MISE_AGE_KEY="AGE-SECRET-KEY-142E7VJ8GUWR94MXDCYQJ7ZTQZRXKQSP9PUJU8HUQJ206QN7QPV4SM5QRL8"
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[history.encryption]
+recipients = ["age1fuvsfq02qr5ju0nhh3rulrwracymjljlr5j49kres24ltd3fjq0s9z9d8l"]
+[dotfiles]
+"~/.native" = { mode = "track" }
+"~/.encrypted-value" = { mode = "track", encrypt = true }
+TOML
+echo private-value >~/.encrypted-value
+plaintext=$(git hash-object ~/.encrypted-value)
+assert_succeed "mise bootstrap dotfiles save"
+encrypted=$(git --git-dir="$repo" rev-parse HEAD)
+assert_fail "git --git-dir=$repo cat-file -e $plaintext"
+assert_succeed "mise bootstrap dotfiles sync"
+assert "git --git-dir=$origin rev-parse main" "$encrypted"
+assert_fail "git --git-dir=$origin cat-file -e $plaintext"
+assert_contains "git --git-dir=$origin show main:home/.encrypted-value | head -1" 'mise-encrypted-file-v1'
+assert_succeed "mise bootstrap dotfiles sync"
+assert "git --git-dir=$repo rev-parse HEAD" "$encrypted"
+assert "git --git-dir=$origin rev-parse main" "$encrypted"

--- a/e2e/cli/test_dotfiles_ordinary_two_machine
+++ b/e2e/cli/test_dotfiles_ordinary_two_machine
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# A common Git ancestor is sufficient even without a per-machine sync baseline.
+require_cmd git
+export MISE_HISTORY_NOTIFY=false
+origin="$PWD/ordinary-origin.git"
+git init -q --bare -b main "$origin"
+echo base >~/.native
+echo base >~/.other
+echo base >~/.third
+assert_succeed "mise bootstrap dotfiles track ~/.native ~/.other ~/.third"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync manual --yes"
+
+second="$(dirname "$HOME")/second"
+mkdir -p "$second/.config/mise" "$second/.local/state/mise/history"
+git clone -q --bare "$origin" "$second/.local/state/mise/history/repo.git"
+echo base >"$second/.native"
+echo base >"$second/.other"
+echo base >"$second/.third"
+cat >"$second/.config/mise/config.toml" <<'TOML'
+[dotfiles]
+"~/.native" = { mode = "track" }
+"~/.other" = { mode = "track" }
+"~/.third" = { mode = "track" }
+TOML
+b() {
+  (
+    cd "$second" || exit
+    env HOME="$second" XDG_CONFIG_HOME="$second/.config" MISE_CONFIG_DIR="$second/.config/mise" \
+      MISE_STATE_DIR="$second/.local/state/mise" MISE_DATA_DIR="$second/.local/share/mise" \
+      MISE_CACHE_DIR="$second/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$second" mise "$@"
+  )
+}
+export second
+export -f b
+assert_succeed "b bootstrap dotfiles origin set file://$origin --sync manual --yes"
+state="$second/.local/state/mise/history/repo.git/mise-sync-state.json"
+if [[ -f $state ]]; then
+  mv "$state" "$state.saved-for-test"
+fi
+echo incoming >~/.native
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "mise bootstrap dotfiles sync"
+incoming=$(git --git-dir="$origin" rev-parse main)
+assert_succeed "b bootstrap dotfiles sync --fetch-only"
+assert_succeed "b bootstrap dotfiles pull --yes"
+assert "cat $second/.native" "incoming"
+assert_succeed "b bootstrap dotfiles sync"
+assert_succeed "git --git-dir=$origin merge-base --is-ancestor $incoming main"
+
+# Two unresolved files hold unrelated incoming changes until all choices exist.
+assert_succeed "mise bootstrap dotfiles sync"
+echo first-machine >~/.native
+echo first-machine >~/.third
+echo incoming-other >~/.other
+echo second-machine >"$second/.native"
+echo second-machine >"$second/.third"
+echo newly-enrolled >~/.fourth
+assert_succeed "mise bootstrap dotfiles track ~/.fourth"
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "mise bootstrap dotfiles sync"
+first_head=$(git --git-dir="$origin" rev-parse main)
+assert_succeed "b bootstrap dotfiles save"
+assert_succeed "b bootstrap dotfiles sync"
+assert "git --git-dir=$origin rev-parse main" "$first_head"
+assert "cat $second/.other" "base"
+assert_fail "test -e $second/.fourth"
+assert_succeed "b bootstrap dotfiles pull --keep-local $second/.native --yes"
+assert "cat $second/.other" "base"
+assert_fail "test -e $second/.fourth"
+assert "git --git-dir=$origin rev-parse main" "$first_head"
+echo newer-second-machine >"$second/.native"
+assert_succeed "b bootstrap dotfiles save"
+assert_succeed "b bootstrap dotfiles pull --keep-local $second/.third --yes"
+assert "cat $second/.other" "base"
+assert_fail "test -e $second/.fourth"
+assert_succeed "b bootstrap dotfiles pull --keep-local $second/.native --yes"
+assert "cat $second/.other" "incoming-other"
+assert "cat $second/.fourth" "newly-enrolled"
+assert_succeed "b bootstrap dotfiles sync"
+assert "git --git-dir=$origin show main:home/.native" "newer-second-machine"
+assert "git --git-dir=$origin show main:home/.third" "second-machine"
+assert "git --git-dir=$origin show main:home/.other" "incoming-other"
+assert_succeed "git --git-dir=$origin merge-base --is-ancestor $first_head main"

--- a/e2e/cli/test_dotfiles_portable_permissions
+++ b/e2e/cli/test_dotfiles_portable_permissions
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Permission metadata travels with ordinary trees, not machine-local trailers.
+require_cmd git
+require_cmd jq
+export MISE_HISTORY_NOTIFY=false
+
+mkdir -p ~/mode-files
+printf 'one\n' >~/mode-files/one
+printf 'two\n' >~/mode-files/two
+chmod 700 ~/mode-files
+chmod 600 ~/mode-files/one ~/mode-files/two
+assert_succeed "mise bootstrap dotfiles track ~/mode-files --no-autosave"
+repo="$MISE_STATE_DIR/history/repo.git"
+assert "git --git-dir='$repo' show main:.mise-history/manifest.json | jq -r '.permissions[\"home/mode-files/one\"]'" "384"
+assert "git --git-dir='$repo' show main:.mise-history/manifest.json | jq -r '.permissions[\"home/mode-files\"]'" "448"
+
+# Saving one child cannot capture a chmod on its unsaved sibling.
+chmod 400 ~/mode-files/one
+chmod 640 ~/mode-files/two
+assert_succeed "mise bootstrap dotfiles save ~/mode-files/one"
+assert "git --git-dir='$repo' show main:.mise-history/manifest.json | jq -r '.permissions[\"home/mode-files/one\"]'" "256"
+assert "git --git-dir='$repo' show main:.mise-history/manifest.json | jq -r '.permissions[\"home/mode-files/two\"]'" "384"
+
+# A new operational store derives permissions from the cloned ordinary Git tree.
+clone_state="$PWD/cloned-state"
+mkdir -p "$clone_state/history"
+git clone -q --bare "$repo" "$clone_state/history/repo.git"
+assert "MISE_STATE_DIR='$clone_state' mise bootstrap dotfiles history show latest --json | jq -r '.tree.modes[\"~/mode-files/one\"]'" "256"
+assert "MISE_STATE_DIR='$clone_state' mise bootstrap dotfiles history show latest --json | jq -r '.tree.modes[\"~/mode-files/two\"]'" "384"
+
+# Untracking removes permission metadata without touching live files.
+assert_succeed "mise bootstrap dotfiles untrack ~/mode-files"
+assert "git --git-dir='$repo' show main:.mise-history/manifest.json | jq '.permissions | length'" "0"
+assert_succeed "test -f ~/mode-files/one"
+assert_succeed "test -f ~/mode-files/two"

--- a/e2e/cli/test_dotfiles_private_write_recovery
+++ b/e2e/cli/test_dotfiles_private_write_recovery
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Untracked preimages are temporary recovery material, never Git history.
+require_cmd git
+mkdir -p "$MISE_CONFIG_DIR"
+awk 'BEGIN { for (i = 0; i < 70000; i++) printf "a"; print "" }' >~/.managed
+old_hash=$(git hash-object ~/.managed)
+echo first >~/source
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[dotfiles]
+"~/.managed" = { mode = "copy", source = "~/source" }
+TOML
+assert_succeed 'mise bootstrap dotfiles apply --force --yes'
+assert 'cat ~/.managed' 'first'
+repo="$MISE_STATE_DIR/history/repo.git"
+assert_fail "git --git-dir=$repo rev-parse --verify HEAD"
+assert_fail "git --git-dir=$repo cat-file -e $old_hash"
+assert "find $MISE_STATE_DIR/history/index/blobs -type f | wc -l | tr -d ' '" '0'
+
+echo second >~/source
+cat >>"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[bootstrap.hooks.post-dotfiles]
+run = 'kill -KILL "$(cat "$HOME/bootstrap.pid")"'
+TOML
+cat >"$PWD/interrupted-bootstrap" <<'SH'
+#!/usr/bin/env bash
+echo $$ >"$HOME/bootstrap.pid"
+exec mise bootstrap dotfiles apply --force --yes
+SH
+chmod +x "$PWD/interrupted-bootstrap"
+assert_fail "$PWD/interrupted-bootstrap"
+assert 'cat ~/.managed' 'second'
+assert 'mise bootstrap dotfiles history --pending --json | jq length' '1'
+
+# A later user edit must survive and keep the unresolved journal available.
+echo concurrent >~/.managed
+assert_fail 'mise bootstrap dotfiles save' 'recovery needs attention'
+assert 'cat ~/.managed' 'concurrent'
+assert 'mise bootstrap dotfiles history --pending --json | jq length' '1'
+
+# Once the recorded result is restored, recovery can finish safely.
+echo second >~/.managed
+assert_succeed 'mise bootstrap dotfiles save'
+assert 'cat ~/.managed' 'first'
+assert 'mise bootstrap dotfiles history --pending --json | jq length' '0'
+assert_fail "git --git-dir=$repo cat-file -e HEAD:home/.managed"
+assert_fail "git --git-dir=$repo cat-file -e $old_hash"
+
+# A normally returned hook failure does not roll back completed bootstrap phases.
+echo third >~/source
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[dotfiles]
+"~/.managed" = { mode = "copy", source = "~/source" }
+[bootstrap.hooks.post-dotfiles]
+run = "exit 29"
+TOML
+assert_fail 'mise bootstrap dotfiles apply --force --yes'
+assert 'cat ~/.managed' 'third'
+assert 'mise bootstrap dotfiles history --pending --json | jq length' '0'

--- a/e2e/cli/test_dotfiles_recovery_journey
+++ b/e2e/cli/test_dotfiles_recovery_journey
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# One recovery journey: independent/offline edits, conflicts, an interrupted
+# pull, undo, and fresh setup on a third machine from ordinary Git history.
+# shellcheck disable=SC2016
+require_cmd git
+export MISE_EXPERIMENTAL=0
+
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+mkdir -p ~/.config/journey
+printf 'initial\n' >~/.config/journey/bindings
+printf 'machine-specific\n' >~/.config/journey/monitor
+chmod 600 ~/.config/journey/monitor
+assert_succeed 'mise bootstrap dotfiles track ~/.config/journey/bindings'
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync manual --yes"
+initial=$(git --git-dir="$origin" rev-parse main)
+
+wrapper() {
+  mkdir -p "$2/.config/mise"
+  cat <<WRAPPER >"$PWD/$1"
+#!/usr/bin/env bash
+export HOME="$2" XDG_CONFIG_HOME="$2/.config" MISE_CONFIG_DIR="$2/.config/mise" \\
+  MISE_STATE_DIR="$2/.local/state/mise" MISE_DATA_DIR="$2/.local/share/mise" \\
+  MISE_CACHE_DIR="$2/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$2"
+cd "\$HOME" && exec mise "\$@"
+WRAPPER
+  chmod +x "$PWD/$1"
+}
+B="$(dirname "$HOME")/journey-b"
+C="$(dirname "$HOME")/journey-c"
+wrapper journey-b "$B"
+wrapper journey-c "$C"
+b="$PWD/journey-b"
+c="$PWD/journey-c"
+assert_succeed "$b bootstrap --from-git file://$origin --yes --only dotfiles"
+assert "cat $B/.config/journey/bindings" 'initial'
+assert_fail "test -e $B/.config/journey/monitor"
+
+# Independent edits survive an offline interval; neither side silently wins.
+printf 'laptop edit\n' >~/.config/journey/bindings
+assert_succeed 'mise bootstrap dotfiles save'
+mv "$origin" "$origin.offline"
+printf 'desktop edit\n' >"$B/.config/journey/bindings"
+assert_succeed "$b bootstrap dotfiles save"
+assert_fail "$b bootstrap dotfiles sync"
+assert_contains "$b bootstrap dotfiles history diff latest --patch" '+desktop edit'
+mv "$origin.offline" "$origin"
+assert_succeed 'mise bootstrap dotfiles sync'
+assert_succeed "$b bootstrap dotfiles sync"
+assert_fail "$b bootstrap dotfiles pull --yes" 'sync paused'
+assert "cat $B/.config/journey/bindings" 'desktop edit'
+assert_succeed "$b bootstrap dotfiles pull --take-remote $B/.config/journey/bindings --yes"
+assert "cat $B/.config/journey/bindings" 'laptop edit'
+
+# Stop a real pull at its first Git operation after the live file changes,
+# before it records the outcome checkpoint. The shim affects only this child.
+pidfile="$PWD/pull.pid"
+real_git=$(command -v git)
+mkdir "$PWD/crash-bin"
+cat <<WRAPPER >"$PWD/crash-bin/git"
+#!/usr/bin/env bash
+if [[ \$(cat "$B/.config/journey/bindings") == 'incoming edit' ]]; then
+  kill -KILL "\$(cat "$pidfile")"
+  exit 1
+fi
+exec "$real_git" "\$@"
+WRAPPER
+chmod +x "$PWD/crash-bin/git"
+cat <<WRAPPER >"$PWD/interrupted-pull"
+#!/usr/bin/env bash
+echo \$\$ >"$pidfile"
+export PATH="$PWD/crash-bin:\$PATH"
+exec "$b" bootstrap dotfiles pull --yes
+WRAPPER
+chmod +x "$PWD/interrupted-pull"
+printf 'incoming edit\n' >~/.config/journey/bindings
+assert_succeed 'mise bootstrap dotfiles sync'
+assert_succeed "$b bootstrap dotfiles sync"
+assert_fail "$PWD/interrupted-pull"
+assert "cat $B/.config/journey/bindings" 'incoming edit'
+assert "$b bootstrap dotfiles history --pending --json | jq length" '1'
+assert_succeed "$b bootstrap dotfiles save"
+assert "cat $B/.config/journey/bindings" 'laptop edit'
+assert_succeed "$b bootstrap dotfiles pull --yes"
+assert_succeed "$b bootstrap dotfiles undo --yes"
+assert "cat $B/.config/journey/bindings" 'laptop edit'
+
+# Fresh-machine bootstrap restores shared state, but not private machine files.
+assert_succeed "$c bootstrap --from-git file://$origin --yes --only dotfiles"
+assert "cat $C/.config/journey/bindings" 'incoming edit'
+assert_fail "test -e $C/.config/journey/monitor"
+assert_succeed "$c bootstrap dotfiles rollback $C/.config/journey/bindings --to $initial --yes"
+assert "cat $C/.config/journey/bindings" 'initial'
+assert_succeed "$c bootstrap dotfiles undo --yes"
+assert "cat $C/.config/journey/bindings" 'incoming edit'
+assert_fail "test -e $C/.config/mise/config.toml"
+assert "git --git-dir=$origin for-each-ref --format='%(refname)' refs/mise-history" ''

--- a/e2e/cli/test_dotfiles_removed_backup_interfaces
+++ b/e2e/cli/test_dotfiles_removed_backup_interfaces
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# The unreleased backup/local-only model is removed, not silently downgraded.
+require_cmd git
+echo tracked >~/.tracked
+assert_fail 'mise bootstrap dotfiles track ~/.tracked --private'
+assert_fail 'mise bootstrap dotfiles track ~/.tracked --no-share'
+assert_fail 'mise bootstrap dotfiles track ~/.tracked --no-backup'
+assert_fail 'mise bootstrap dotfiles origin set owner/repo --encrypt-backups --yes'
+assert_fail 'mise bootstrap dotfiles origin set owner/repo --include-existing --yes'
+assert_fail 'mise bootstrap dotfiles machines'
+assert_fail 'mise bootstrap dotfiles history purge'
+assert_succeed 'mise bootstrap dotfiles track ~/.tracked'
+repository="$MISE_STATE_DIR/history/repo.git"
+assert "git --git-dir=$repository for-each-ref --format='%(refname)' refs/mise-history refs/machines refs/setup refs/promoted refs/checkpoints" ''
+assert_not_contains 'mise bootstrap dotfiles status' 'backup'

--- a/e2e/cli/test_dotfiles_rollback
+++ b/e2e/cli/test_dotfiles_rollback
@@ -16,6 +16,7 @@ cat <<EOF2 >"$config"
 "~/.config/hypr/**" = "echo reloaded >> $HOME/reloads"
 EOF2
 assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+baseline="$(mise bootstrap dotfiles history --json | jq -r '.[0].uuid')"
 
 # noisy checkpoints of another file never influence which version a path returns to
 for i in 1 2 3; do
@@ -60,9 +61,9 @@ echo extra >~/.config/hypr/extra.conf
 mkdir -p ~/.config/other
 echo other >~/.config/other/file
 assert_succeed "mise bootstrap dotfiles save"
-assert "mise bootstrap dotfiles rollback --to 1 --all --dry-run | grep -c 'extra.conf *delete'" "1"
-assert "mise bootstrap dotfiles rollback --to 1 --all --dry-run | grep -c 'state.json *delete'" "1"
-assert_succeed "mise bootstrap dotfiles rollback --to 1 --all --yes"
+assert "mise bootstrap dotfiles rollback --to $baseline --all --dry-run | grep -c 'extra.conf *delete'" "1"
+assert "mise bootstrap dotfiles rollback --to $baseline --all --dry-run | grep -c 'state.json *delete'" "1"
+assert_succeed "mise bootstrap dotfiles rollback --to $baseline --all --yes"
 assert_fail "test -e ~/.config/hypr/extra.conf"
 assert_fail "test -e ~/.config/hypr/state.json"
 assert "cat ~/.config/hypr/monitors.lua" "monitor=DP-1"
@@ -107,8 +108,8 @@ assert_contains "mise bootstrap dotfiles rollback ~/.config/mise/extra.toml --ye
 assert "cat '$MISE_CONFIG_DIR/extra.toml'" "[settings]"
 
 # a rollback refuses a checkpoint whose run did not finish, and a missing state
-assert_fail "mise bootstrap dotfiles rollback ~/.config/hypr/bindings.lua --to 99" "no history checkpoint 99"
-assert_fail "mise bootstrap dotfiles undo 1" "not an operation"
+assert_fail "mise bootstrap dotfiles rollback ~/.config/hypr/bindings.lua --to 99" 'no history checkpoint matches "99"'
+assert_fail "mise bootstrap dotfiles undo $baseline" "not an operation"
 
 # no-op: rolling back a path that already matches records nothing
 n="$(eval "$count")"

--- a/e2e/cli/test_dotfiles_rollback
+++ b/e2e/cli/test_dotfiles_rollback
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# `mise bootstrap dotfiles rollback` and `undo`: returning tracked files to the version a
+# checkpoint holds, selectively, with the previous state saved first.
+# shellcheck disable=SC2016
+
+require_cmd git
+
+count="mise bootstrap dotfiles history --json -n 0 | jq length"
+config="$MISE_CONFIG_DIR/config.toml"
+
+mkdir -p ~/.config/hypr "$MISE_CONFIG_DIR"
+echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
+echo 'monitor=DP-1' >~/.config/hypr/monitors.lua
+cat <<EOF2 >"$config"
+[history.reload]
+"~/.config/hypr/**" = "echo reloaded >> $HOME/reloads"
+EOF2
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+
+# noisy checkpoints of another file never influence which version a path returns to
+for i in 1 2 3; do
+  echo "state $i" >~/.config/hypr/state.json
+  assert_succeed "mise bootstrap dotfiles save"
+done
+echo 'bind = SUPER, Q, exec, alacritty' >~/.config/hypr/bindings.lua
+assert_succeed "mise bootstrap dotfiles save"
+assert "$count" "5"
+
+# path-first: the newest saved version that differs from the working tree
+assert "mise bootstrap dotfiles rollback ~/.config/hypr/bindings.lua --dry-run | grep -c 'bindings.lua *write'" "1"
+assert "cat ~/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, alacritty"
+assert "$count" "5"
+echo 'monitor=DP-2' >~/.config/hypr/monitors.lua
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/bindings.lua --yes"
+assert "cat ~/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
+# unrelated later work is preserved, the reload hook ran once, and the pair is recorded
+assert "cat ~/.config/hypr/monitors.lua" "monitor=DP-2"
+assert "cat ~/reloads | wc -l | tr -d ' '" "1"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].trigger, .[1].trigger'" $'rollback\nrollback-before'
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].operation | \"\\(.kind) \\(.status) \\(.affected | join(\",\"))\"'" "rollback completed ~/.config/hypr/bindings.lua"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].operation.to == (.[] | select(.id == 4) | .uuid)'" "true"
+assert_contains "mise bootstrap dotfiles history show latest" "rolled back ~/.config/hypr/bindings.lua to checkpoint 4"
+# the protective checkpoint holds what was overwritten, including the unsaved edit
+assert "mise bootstrap dotfiles history --json | jq -r '.[1].changes.modified | join(\",\")'" "~/.config/hypr/monitors.lua"
+
+# undo reverses exactly the paths the rollback touched
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert "cat ~/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, alacritty"
+assert "cat ~/.config/hypr/monitors.lua" "monitor=DP-2"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].operation | \"\\(.kind) \\(.undoes | length)\"'" "undo 40"
+assert_contains "mise bootstrap dotfiles history show latest" "undid rollback"
+# undo of an undo re-applies; nothing is left to undo after that but the undo itself
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert "cat ~/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
+
+# checkpoint-first: --to with --all deletes files created later and preserves
+# unrelated later edits outside the selection; a path the checkpoint never covered
+# is skipped, never deleted
+echo extra >~/.config/hypr/extra.conf
+mkdir -p ~/.config/other
+echo other >~/.config/other/file
+assert_succeed "mise bootstrap dotfiles save"
+assert "mise bootstrap dotfiles rollback --to 1 --all --dry-run | grep -c 'extra.conf *delete'" "1"
+assert "mise bootstrap dotfiles rollback --to 1 --all --dry-run | grep -c 'state.json *delete'" "1"
+assert_succeed "mise bootstrap dotfiles rollback --to 1 --all --yes"
+assert_fail "test -e ~/.config/hypr/extra.conf"
+assert_fail "test -e ~/.config/hypr/state.json"
+assert "cat ~/.config/hypr/monitors.lua" "monitor=DP-1"
+assert "cat ~/.config/other/file" "other"
+assert_fail "mise bootstrap dotfiles rollback ~/.config/other/file" "is not tracked"
+
+# a type change is a conflict unless forced
+rm ~/.config/hypr/monitors.lua
+mkdir ~/.config/hypr/monitors.lua
+assert_contains "mise bootstrap dotfiles rollback ~/.config/hypr/monitors.lua --dry-run 2>&1" "conflict: a file became a directory"
+assert_fail "mise bootstrap dotfiles rollback ~/.config/hypr/monitors.lua --yes" "conflict"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/monitors.lua --yes --force"
+assert "cat ~/.config/hypr/monitors.lua" "monitor=DP-1"
+
+# an undo that must recreate an empty directory where something history does not
+# capture now stands is refused before anything is written
+rm ~/.config/hypr/monitors.lua && mkdir -p ~/.config/hypr/monitors.lua/sub
+echo inner >~/.config/hypr/monitors.lua/f
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/monitors.lua --yes --force"
+assert "cat ~/.config/hypr/monitors.lua" "monitor=DP-1"
+printf '\n[history]\nexclude = ["~/.config/hypr/monitors.lua/sub"]\n' >>"$config"
+rm ~/.config/hypr/monitors.lua && mkdir -p ~/.config/hypr/monitors.lua ~/elsewhere
+ln -s ~/elsewhere ~/.config/hypr/monitors.lua/sub
+assert_contains "mise bootstrap dotfiles undo --dry-run 2>&1" "conflict: a symlink history does not capture stands where a directory was"
+assert_fail "mise bootstrap dotfiles undo --yes" "conflict"
+assert_fail "test -e ~/.config/hypr/monitors.lua/f"
+assert "readlink ~/.config/hypr/monitors.lua/sub" "$HOME/elsewhere"
+rm ~/.config/hypr/monitors.lua/sub
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert "cat ~/.config/hypr/monitors.lua/f" "inner"
+assert "test -d ~/.config/hypr/monitors.lua/sub && echo dir" "dir"
+rm -r ~/.config/hypr/monitors.lua && echo 'monitor=DP-1' >~/.config/hypr/monitors.lua
+assert_succeed "mise bootstrap dotfiles save"
+
+# a config file rolled back prints the bootstrap hint; declarations are never run
+echo '[settings]' >"$MISE_CONFIG_DIR/extra.toml"
+assert_succeed 'mise bootstrap dotfiles track ~/.config/mise/extra.toml'
+assert_succeed "mise bootstrap dotfiles save"
+rm "$MISE_CONFIG_DIR/extra.toml"
+assert_contains "mise bootstrap dotfiles rollback ~/.config/mise/extra.toml --yes 2>&1" 'run `mise bootstrap --dry-run`'
+assert "cat '$MISE_CONFIG_DIR/extra.toml'" "[settings]"
+
+# a rollback refuses a checkpoint whose run did not finish, and a missing state
+assert_fail "mise bootstrap dotfiles rollback ~/.config/hypr/bindings.lua --to 99" "no history checkpoint 99"
+assert_fail "mise bootstrap dotfiles undo 1" "not an operation"
+
+# no-op: rolling back a path that already matches records nothing
+n="$(eval "$count")"
+assert_contains "mise bootstrap dotfiles rollback ~/.config/hypr/bindings.lua --to latest --yes 2>&1" "nothing to do"
+assert "$count" "$n"
+
+# reload commands come from the trusted layers only
+mkdir -p ~/proj
+printf '[history.reload]\n"~/.config/hypr/**" = "echo project >> %s/reloads"\n' "$HOME" >~/proj/mise.toml
+echo 'bind = X' >~/.config/hypr/bindings.lua
+assert_succeed "mise bootstrap dotfiles save"
+: >~/reloads
+assert_succeed "cd ~/proj && mise trust -q && mise bootstrap dotfiles rollback ~/.config/hypr/bindings.lua --yes"
+assert "cat ~/reloads" "reloaded"

--- a/e2e/cli/test_dotfiles_rollback_review
+++ b/e2e/cli/test_dotfiles_rollback_review
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+require_cmd git
+mkdir -p ~/.config/review
+echo original >~/.config/review/file
+assert_succeed "mise bootstrap dotfiles track ~/.config/review"
+echo current >~/.config/review/file
+assert_succeed "mise bootstrap dotfiles save"
+chmod 600 ~/.config/review/file
+assert_succeed "mise bootstrap dotfiles save"
+# Directory selection must see child permission-only history too.
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/review --yes"
+assert "cat ~/.config/review/file" "current"
+if [[ "$(uname -s)" == Darwin ]]; then
+  assert "stat -f %Lp ~/.config/review/file" "644"
+else
+  assert "stat -c %a ~/.config/review/file" "644"
+fi
+assert_succeed "mise bootstrap dotfiles undo --yes"
+# The directory's differing tree predates the file's permission-only
+# checkpoint. The explicit child selection wins, in either argument order.
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/review ~/.config/review/file --yes"
+assert "cat ~/.config/review/file" "current"
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/review/file ~/.config/review --yes"
+assert "cat ~/.config/review/file" "current"
+
+mkdir ~/.config/review/empty
+chmod 700 ~/.config/review/empty
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/review/empty --yes"
+assert_fail "test -d ~/.config/review/empty"
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert_succeed "test -d ~/.config/review/empty"
+if [[ $(uname) == Darwin ]]; then
+  assert "stat -f %Lp ~/.config/review/empty" "700"
+else
+  assert "stat -c %a ~/.config/review/empty" "700"
+fi
+
+# Cleanup must retain contents that no checkpoint can restore.
+before="$(mise bootstrap dotfiles history --json | jq -r '.[0].id')"
+mkdir -p ~/.config/review/with-excluded
+echo saved >~/.config/review/with-excluded/tracked
+echo keep >~/.config/review/with-excluded/private
+printf '\n[history]\nexclude = ["~/.config/review/with-excluded/private"]\n' >>"$MISE_CONFIG_DIR/config.toml"
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/review --to $before --yes"
+assert "cat ~/.config/review/with-excluded/private" "keep"
+assert_fail "test -e ~/.config/review/with-excluded/tracked"
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert "cat ~/.config/review/with-excluded/private" "keep"
+assert "cat ~/.config/review/with-excluded/tracked" "saved"
+
+# Parent rollback preserves unrecorded empty descendants even when it
+# removes neighboring files and their otherwise-new parent directory.
+before="$(mise bootstrap dotfiles history --json | jq -r '.[0].id')"
+mkdir -p ~/.config/review/new-dir/empty
+mkdir -p ~/.config/review/unreadable-dir/child
+echo temporary >~/.config/review/unreadable-dir/transient
+echo temporary >~/.config/review/new-dir/transient
+assert_succeed "mise bootstrap dotfiles save"
+chmod 000 ~/.config/review/unreadable-dir/child
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/review --to $before --yes"
+chmod 755 ~/.config/review/unreadable-dir/child
+assert_succeed "test -d ~/.config/review/unreadable-dir/child"
+assert_fail "test -e ~/.config/review/unreadable-dir/transient"
+assert_fail "test -e ~/.config/review/new-dir/transient"
+assert_succeed "test -d ~/.config/review/new-dir/empty"
+assert_succeed "test -d ~/.config/review/empty"
+
+# A canonical target outside HOME retains restrictive parent permissions.
+external="$(dirname "$HOME")/external-private"
+mkdir -m 700 "$external"
+echo secret >"$external/key"
+chmod 600 "$external/key"
+ln -s "$external" ~/.config/review/external
+assert_succeed "mise bootstrap dotfiles track $external"
+before="$(mise bootstrap dotfiles history --json | jq -r '.[0].id')"
+mv "$external" "$external.removed"
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "mise bootstrap dotfiles rollback $external/key --to $before --yes"
+assert "cat $external/key" "secret"
+if [[ "$(uname -s)" == Darwin ]]; then
+  assert "stat -f %Lp $external" "700"
+  assert "stat -f %Lp $external/key" "600"
+else
+  assert "stat -c %a $external" "700"
+  assert "stat -c %a $external/key" "600"
+fi

--- a/e2e/cli/test_dotfiles_rollback_review
+++ b/e2e/cli/test_dotfiles_rollback_review
@@ -67,8 +67,15 @@ assert_fail "test -e ~/.config/review/new-dir/transient"
 assert_succeed "test -d ~/.config/review/new-dir/empty"
 assert_succeed "test -d ~/.config/review/empty"
 
-# A canonical target outside HOME retains restrictive parent permissions.
-external="$(dirname "$HOME")/external-private"
+# Paths outside the portable namespace cannot be enrolled.
+outside="$(dirname "$HOME")/external-private"
+mkdir -m 700 "$outside"
+echo secret >"$outside/key"
+assert_fail "mise bootstrap dotfiles track $outside" 'tracking requires a portable path'
+assert "cat $outside/key" 'secret'
+
+# An explicitly tracked target retains restrictive parent permissions.
+external="$HOME/external-private"
 mkdir -m 700 "$external"
 echo secret >"$external/key"
 chmod 600 "$external/key"

--- a/e2e/cli/test_dotfiles_rollback_types
+++ b/e2e/cli/test_dotfiles_rollback_types
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# `mise bootstrap dotfiles rollback` and `undo` across type changes: known absences,
+# directories replacing files (and back), empty directories, and the sources
+# a multi-path rollback records.
+# shellcheck disable=SC2016
+
+require_cmd git
+
+mkdir -p ~/.config/hypr
+echo 'monitor=DP-1' >~/.config/hypr/monitors.lua
+echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+
+# a known absence is a version to return to: a file created after a checkpoint
+# rolls back to "missing" without naming that checkpoint
+echo 'new' >~/.config/hypr/new.conf
+assert_succeed "mise bootstrap dotfiles save"
+assert "mise bootstrap dotfiles rollback ~/.config/hypr/new.conf --dry-run | grep -c 'new.conf *delete'" "1"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/new.conf --yes"
+assert_fail "test -e ~/.config/hypr/new.conf"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].operation.affected | join(\",\")'" "~/.config/hypr/new.conf"
+
+# a directory created after a checkpoint returns to missing with its files,
+# and undo brings it back
+mkdir -p ~/.config/hypr/later/deep
+echo 'l' >~/.config/hypr/later/deep/l.conf
+assert_succeed "mise bootstrap dotfiles save"
+assert_contains "mise bootstrap dotfiles rollback ~/.config/hypr/later --dry-run 2>&1" "later/deep  "
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/later --yes"
+assert_fail "test -e ~/.config/hypr/later"
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert "cat ~/.config/hypr/later/deep/l.conf" "l"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/later --yes"
+assert_fail "test -e ~/.config/hypr/later"
+
+# a nested repository is never written into or removed by a rollback, even
+# where a checkpoint held plain files
+mkdir -p ~/.config/hypr/plugin
+echo 'old' >~/.config/hypr/plugin/old.txt
+assert_succeed "mise bootstrap dotfiles save"
+plain_id="$(mise bootstrap dotfiles history --json | jq -r '.[0].id')"
+rm -r ~/.config/hypr/plugin
+git init -q ~/.config/hypr/plugin
+echo 'new' >~/.config/hypr/plugin/new.txt
+git -C ~/.config/hypr/plugin add new.txt
+git -C ~/.config/hypr/plugin -c user.name=t -c user.email=t@t commit -q -m init
+assert_succeed "mise bootstrap dotfiles save"
+assert_contains "mise bootstrap dotfiles rollback ~/.config/hypr/plugin --to $plain_id --dry-run 2>&1" "nested repository"
+assert_not_contains "mise bootstrap dotfiles rollback ~/.config/hypr/plugin --to $plain_id --dry-run 2>&1" "old.txt"
+assert_fail "test -e ~/.config/hypr/plugin/old.txt"
+assert "cat ~/.config/hypr/plugin/new.txt" "new"
+
+# --force replaces a file with the directory a checkpoint holds, and undo
+# reverses that type change exactly
+mkdir -p ~/.config/hypr/sub
+echo 'a' >~/.config/hypr/sub/a.conf
+assert_succeed "mise bootstrap dotfiles save"
+dir_id="$(mise bootstrap dotfiles history --json | jq -r '.[0].id')"
+rm -rf ~/.config/hypr/sub
+echo 'file now' >~/.config/hypr/sub
+assert_succeed "mise bootstrap dotfiles save"
+assert_fail "mise bootstrap dotfiles rollback ~/.config/hypr/sub --to $dir_id --yes" "conflict"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/sub --to $dir_id --yes --force"
+assert "cat ~/.config/hypr/sub/a.conf" "a"
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert "cat ~/.config/hypr/sub" "file now"
+
+# an empty directory an operation replaced is recreated by undo, although no
+# snapshot can hold it
+rm ~/.config/hypr/sub
+echo 'was a file' >~/.config/hypr/empty
+assert_succeed "mise bootstrap dotfiles save"
+file_id="$(mise bootstrap dotfiles history --json | jq -r '.[0].id')"
+rm ~/.config/hypr/empty
+mkdir ~/.config/hypr/empty
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/empty --to $file_id --yes --force"
+assert "cat ~/.config/hypr/empty" "was a file"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].operation.directories | join(\",\")'" "~/.config/hypr/empty"
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert "test -d ~/.config/hypr/empty && echo dir" "dir"
+
+# paths that resolve to different checkpoints are all recorded as sources
+rmdir ~/.config/hypr/empty
+echo 'm1' >~/.config/hypr/monitors.lua
+assert_succeed "mise bootstrap dotfiles save"
+echo 'b1' >~/.config/hypr/bindings.lua
+assert_succeed "mise bootstrap dotfiles save"
+echo 'm2' >~/.config/hypr/monitors.lua
+assert_succeed "mise bootstrap dotfiles save"
+echo 'b2' >~/.config/hypr/bindings.lua
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/monitors.lua ~/.config/hypr/bindings.lua --yes"
+assert "cat ~/.config/hypr/monitors.lua" "m1"
+assert "cat ~/.config/hypr/bindings.lua" "b1"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].operation.sources | length'" "2"
+assert "mise bootstrap dotfiles history show latest | grep -c 'Source:'" "2"
+
+# recreating an empty directory is a change of its own: with the file the
+# rollback wrote already gone, undo still restores the directory
+echo 'was a file' >~/.config/hypr/empty2
+assert_succeed "mise bootstrap dotfiles save"
+file2_id="$(mise bootstrap dotfiles history --json | jq -r '.[0].id')"
+rm ~/.config/hypr/empty2
+mkdir ~/.config/hypr/empty2
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/empty2 --to $file2_id --yes --force"
+rm ~/.config/hypr/empty2
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert "test -d ~/.config/hypr/empty2 && echo dir" "dir"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].operation.affected | length'" "1"
+rmdir ~/.config/hypr/empty2
+
+# replacing a directory removes what is inside it: an excluded file goes with
+# it (said out loud, since no checkpoint holds it), and an empty subdirectory
+# is recreated by undo although no snapshot can hold it
+mkdir -p ~/.config/hypr/pack
+echo 'p' >~/.config/hypr/pack/p.conf
+assert_succeed "mise bootstrap dotfiles save"
+rm -rf ~/.config/hypr/pack
+echo 'a file now' >~/.config/hypr/pack
+assert_succeed "mise bootstrap dotfiles save"
+pack_file_id="$(mise bootstrap dotfiles history --json | jq -r '.[0].id')"
+rm ~/.config/hypr/pack
+mkdir -p ~/.config/hypr/pack/empty-sub ~/.config/hypr/pack/cache
+echo 'p' >~/.config/hypr/pack/p.conf
+echo 'c' >~/.config/hypr/pack/cache/c.bin
+printf '\n[history]\nexclude = ["~/.config/hypr/pack/cache/**"]\n' >>"$MISE_CONFIG_DIR/config.toml"
+assert_succeed "mise bootstrap dotfiles save"
+assert_contains "mise bootstrap dotfiles rollback ~/.config/hypr/pack --to $pack_file_id --yes --force 2>&1" "files history does not cover; they are removed with it and cannot be undone: ~/.config/hypr/pack/cache/c.bin"
+assert "cat ~/.config/hypr/pack" "a file now"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].operation.directories | join(\",\")'" "~/.config/hypr/pack,~/.config/hypr/pack/empty-sub"
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert "cat ~/.config/hypr/pack/p.conf" "p"
+assert "test -d ~/.config/hypr/pack/empty-sub && echo dir" "dir"
+assert_fail "test -e ~/.config/hypr/pack/cache"
+
+# private files come back private: 0600 stays 0600 across rollback and undo,
+# and a deleted 0600 file (in a 0700 directory) is restored with the modes
+# the checkpoint recorded, never readable to others in between
+perm_of="$PWD/perm_of"
+cat <<'EOF2' >"$perm_of"
+#!/usr/bin/env bash
+stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1"
+EOF2
+chmod +x "$perm_of"
+
+# a permission change alone rolls back, in both directions
+echo 'mode=1' >~/.config/hypr/mode.conf
+assert_succeed "mise bootstrap dotfiles save"
+chmod 600 ~/.config/hypr/mode.conf
+assert_succeed "mise bootstrap dotfiles save"
+chmod 644 ~/.config/hypr/mode.conf
+assert_contains "mise bootstrap dotfiles rollback ~/.config/hypr/mode.conf --dry-run 2>&1" "mode 600"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/mode.conf --yes"
+assert "$perm_of ~/.config/hypr/mode.conf" "600"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/mode.conf --yes"
+assert "$perm_of ~/.config/hypr/mode.conf" "644"
+mkdir -p ~/.config/hypr/private
+chmod 700 ~/.config/hypr/private
+echo 'token=1' >~/.config/hypr/restricted.conf
+echo 'k1' >~/.config/hypr/private/key
+chmod 600 ~/.config/hypr/restricted.conf ~/.config/hypr/private/key
+assert_succeed "mise bootstrap dotfiles save"
+echo 'token=2' >~/.config/hypr/restricted.conf
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/restricted.conf --yes"
+assert "cat ~/.config/hypr/restricted.conf" "token=1"
+assert "$perm_of ~/.config/hypr/restricted.conf" "600"
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert "cat ~/.config/hypr/restricted.conf" "token=2"
+assert "$perm_of ~/.config/hypr/restricted.conf" "600"
+rm -r ~/.config/hypr/restricted.conf ~/.config/hypr/private
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/restricted.conf ~/.config/hypr/private/key --yes"
+assert "cat ~/.config/hypr/restricted.conf" "token=2"
+assert "$perm_of ~/.config/hypr/restricted.conf" "600"
+assert "$perm_of ~/.config/hypr/private/key" "600"
+assert "$perm_of ~/.config/hypr/private" "700"
+assert_succeed "mise bootstrap dotfiles undo --yes"
+assert_fail "test -e ~/.config/hypr/restricted.conf"

--- a/e2e/cli/test_dotfiles_sync
+++ b/e2e/cli/test_dotfiles_sync
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Ordinary origin lifecycle, including stale plans and disconnected operation.
+require_cmd git
+export MISE_HISTORY_NOTIFY=false
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+echo base >~/.native
+assert_succeed 'mise bootstrap dotfiles track ~/.native'
+assert_fail 'mise bootstrap dotfiles sync' 'no setup repository'
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync manual --yes"
+second="$(dirname "$HOME")/sync-b"
+mkdir -p "$second"
+b() {
+  (
+    cd "$second" || exit
+    env HOME="$second" XDG_CONFIG_HOME="$second/.config" MISE_CONFIG_DIR="$second/.config/mise" \
+      MISE_STATE_DIR="$second/.local/state/mise" MISE_DATA_DIR="$second/.local/share/mise" \
+      MISE_CACHE_DIR="$second/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$second" mise "$@"
+  )
+}
+export second
+export -f b
+assert_succeed "b bootstrap --from-git file://$origin --yes"
+echo incoming >~/.native
+assert_succeed 'mise bootstrap dotfiles sync'
+assert_succeed 'b bootstrap dotfiles sync --fetch-only'
+echo saved-after-plan >"$second/.native"
+assert_succeed 'b bootstrap dotfiles save'
+assert_fail 'b bootstrap dotfiles pull --yes' paused
+assert "cat $second/.native" saved-after-plan
+assert_succeed "b bootstrap dotfiles pull --keep-local $second/.native --yes"
+assert_succeed 'b bootstrap dotfiles sync'
+assert_succeed 'mise bootstrap dotfiles sync --fetch-only'
+echo unsaved-after-plan >~/.native
+assert_fail 'mise bootstrap dotfiles pull --yes' paused
+assert 'cat ~/.native' unsaved-after-plan
+assert_succeed "mise bootstrap dotfiles pull --take-remote $HOME/.native --yes"
+assert 'cat ~/.native' saved-after-plan
+head=$(git --git-dir="$origin" rev-parse main)
+mv "$origin" "$origin.offline"
+echo offline >~/.native
+assert_succeed 'mise bootstrap dotfiles save'
+assert_fail 'mise bootstrap dotfiles sync'
+assert 'cat ~/.native' offline
+mv "$origin.offline" "$origin"
+assert_succeed 'mise bootstrap dotfiles sync'
+assert_succeed "git --git-dir=$origin merge-base --is-ancestor $head main"
+assert 'mise bootstrap dotfiles status --json | jq -r .history.sync.last_error' null
+assert_succeed 'mise bootstrap dotfiles origin --remove'
+assert_contains 'mise bootstrap dotfiles status' 'Setup repository: none'
+assert_succeed 'mise bootstrap dotfiles save --description disconnected'
+assert_fail 'mise bootstrap dotfiles sync'

--- a/e2e/cli/test_dotfiles_sync_auto
+++ b/e2e/cli/test_dotfiles_sync_auto
@@ -150,7 +150,12 @@ kill "$b_watcher"
 wait "$b_watcher" 2>/dev/null || true
 MISE_HISTORY_SYNC=fetch-only $b bootstrap dotfiles watch --json >b.log 2>&1 &
 b_watcher=$!
+wait_until "grep -q '\"event\":\"started\"' b.log"
 echo '# only on B' >>"$B/.config/hypr/monitors.lua"
+wait_until "$b bootstrap dotfiles history diff --path $B/.config/hypr/monitors.lua --exit-code"
+# Require a completed synchronization after capture, not a pre-edit fetch.
+b_synced="$(grep -c '\"event\":\"synced\"' b.log || true)"
+wait_until "[[ \$(grep -c '\"event\":\"synced\"' b.log) -gt $b_synced ]]"
 echo 'bind = SUPER, E, exec, thunar' >>~/.config/hypr/bindings.lua
 # The pending count also includes repository metadata, not only live files.
 wait_until "grep '\"event\":\"synced\"' b.log | jq -e 'select(.pending > 0)'"

--- a/e2e/cli/test_dotfiles_sync_auto
+++ b/e2e/cli/test_dotfiles_sync_auto
@@ -157,6 +157,9 @@ wait_until "$b bootstrap dotfiles history diff --path $B/.config/hypr/monitors.l
 b_synced="$(grep -c '\"event\":\"synced\"' b.log || true)"
 wait_until "[[ \$(grep -c '\"event\":\"synced\"' b.log) -gt $b_synced ]]"
 echo 'bind = SUPER, E, exec, thunar' >>~/.config/hypr/bindings.lua
+wait_until "git --git-dir=$origin show main:home/.config/hypr/bindings.lua | grep -q thunar"
+b_synced="$(grep -c '\"event\":\"synced\"' b.log || true)"
+wait_until "[[ \$(grep -c '\"event\":\"synced\"' b.log) -gt $b_synced ]]"
 # The pending count also includes repository metadata, not only live files.
 wait_until "grep '\"event\":\"synced\"' b.log | jq -e 'select(.pending > 0)'"
 assert_not_contains "cat $B/.config/hypr/bindings.lua" "thunar"

--- a/e2e/cli/test_dotfiles_sync_auto
+++ b/e2e/cli/test_dotfiles_sync_auto
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Automatic synchronization by the watcher: A's saves are published without a
+# command on either side and B's watcher fetches and applies them; an
+# unreachable origin only backs off while saving continues; a conflict is
+# held with both versions kept, B's file untouched, and notified once; a
+# rollback travels like any other change; fetch-only never publishes or
+# writes by itself; manual does nothing by itself.
+# shellcheck disable=SC2016
+
+require_cmd git
+
+wait_until() {
+  for _ in $(seq 1 150); do
+    if eval "$1" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for: $1" >&2
+  cat a.log b.log >&2 2>/dev/null
+  return 1
+}
+
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+
+# short intervals; the same environment reaches machine B through its wrapper
+export MISE_HISTORY_SYNC_INTERVAL=1s MISE_HISTORY_FETCH_INTERVAL=2s
+export MISE_HISTORY_WATCH_DEBOUNCE=2s MISE_HISTORY_WATCH_RECONCILE=0
+
+# machine B is a second HOME reached through a wrapper script.
+# outside A's home, so none of A's files is discovered as a project config of B
+B="$(dirname "$HOME")/b-home"
+mkdir -p "$B/.config/mise" "$B/.config/hypr" "$B/bin"
+cat <<EOF2 >"$PWD/b"
+#!/usr/bin/env bash
+export HOME="$B" XDG_CONFIG_HOME="$B/.config" MISE_CONFIG_DIR="$B/.config/mise" \\
+  MISE_STATE_DIR="$B/.local/state/mise" MISE_DATA_DIR="$B/.local/share/mise" \\
+  MISE_CACHE_DIR="$B/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$B" PATH="$B/bin:\$PATH"
+cd "\$HOME" && exec mise "\$@"
+EOF2
+chmod +x "$PWD/b"
+b="$PWD/b"
+
+# ---- A tracks a directory and connects; both watchers start
+mkdir -p ~/.config/hypr
+echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --yes"
+assert_succeed "$b bootstrap --from-git file://$origin --yes"
+mise bootstrap dotfiles watch --json >a.log 2>&1 &
+a_watcher=$!
+$b bootstrap dotfiles watch --json >b.log 2>&1 &
+b_watcher=$!
+cleanup() {
+  kill "$a_watcher" "$b_watcher" 2>/dev/null || true
+  wait "$a_watcher" 2>/dev/null || true
+  wait "$b_watcher" 2>/dev/null || true
+}
+trap cleanup EXIT
+wait_until "grep -q '\"event\":\"started\"' a.log && grep -q '\"event\":\"started\"' b.log"
+
+# ---- Fresh setup already restored the ordinary repository's enrollment.
+# Configuration is not implicitly shared or needed to recover tracked files.
+assert "cat $B/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
+assert_contains "$b bootstrap dotfiles paths" "~/.config/hypr"
+
+# ---- an edit on A is published by its watcher and applied by B's
+echo 'bind = SUPER, Q, exec, alacritty' >~/.config/hypr/bindings.lua
+wait_until "grep -q 'alacritty' $B/.config/hypr/bindings.lua"
+assert "git --git-dir=$origin show main:home/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, alacritty"
+assert_contains "cat a.log" '"published":"'
+
+# ---- the origin becomes unreachable: saving continues, syncing backs off and
+# says so, and everything converges once it is back
+mv "$origin" "$origin.away"
+echo 'bind = SUPER, W, exec, firefox' >>~/.config/hypr/bindings.lua
+wait_until "grep -q '\"event\":\"sync-error\"' a.log"
+assert_contains "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "bindings.lua"
+assert_contains "mise bootstrap dotfiles status 2>&1" "last error"
+# the failure has a start, so an origin that never answered is not "transient"
+# forever: after three fetch intervals doctor escalates
+assert_contains "mise bootstrap dotfiles status 2>&1" "failing since"
+wait_until "(mise doctor 2>&1 || true) | grep -q 'keeps failing'"
+assert "(mise doctor --json 2>/dev/null || true) | jq '.dotfiles.sync_failing_for_secs > 6'" "true"
+mv "$origin.away" "$origin"
+wait_until "grep -q 'firefox' $B/.config/hypr/bindings.lua"
+assert_not_contains "mise bootstrap dotfiles status 2>&1" "last error"
+assert_not_contains "mise bootstrap dotfiles status 2>&1" "failing since"
+
+# ---- a conflict: B changes a line while its watcher is down and A changes the
+# same line; both versions are kept, the entire setup waits, and one
+# notification is shown by default however often the sync retries
+kill "$b_watcher"
+wait "$b_watcher" 2>/dev/null || true
+printf 'bind = SUPER, Q, exec, wezterm\nbind = SUPER, W, exec, firefox\n' >"$B/.config/hypr/bindings.lua"
+printf 'bind = SUPER, Q, exec, foot\nbind = SUPER, W, exec, firefox\n' >~/.config/hypr/bindings.lua
+wait_until "git --git-dir=$origin show main:home/.config/hypr/bindings.lua | grep -q foot"
+$b bootstrap dotfiles watch --json >b.log 2>&1 &
+b_watcher=$!
+wait_until "grep -q '\"conflicts\":1' b.log"
+assert_contains "cat $B/.config/hypr/bindings.lua" "wezterm"
+assert_contains "$b bootstrap dotfiles status 2>&1" "both sides changed the same lines"
+assert_contains "$b bootstrap dotfiles status 2>&1" "mise bootstrap dotfiles pull"
+assert_contains "$b doctor 2>&1 || true" "sync conflict"
+echo 'monitor=DP-1' >~/.config/hypr/monitors.lua
+wait_until "git --git-dir=$origin show main:home/.config/hypr/monitors.lua | grep -q DP-1"
+wait_until "grep -c '\"conflicts\":1' b.log | awk '{exit !(\$1 > 1)}'"
+assert_fail "test -e $B/.config/hypr/monitors.lua"
+assert "grep -c '\"conflicts\":1' b.log | awk '{print (\$1 > 1)}'" "1"
+# Notification delivery and deduplication are unit-tested without sending
+# real desktop alerts from the isolated test homes.
+assert_succeed "$b bootstrap dotfiles pull --take-remote $B/.config/hypr/bindings.lua --yes"
+wait_until "test -e $B/.config/hypr/monitors.lua"
+assert "cat $B/.config/hypr/bindings.lua" $'bind = SUPER, Q, exec, foot\nbind = SUPER, W, exec, firefox'
+assert_not_contains "$b bootstrap dotfiles status 2>&1" "both sides changed"
+assert_not_contains "$b doctor 2>&1 || true" "sync conflict"
+
+# ---- a rollback is a new shared change, received like any other: the
+# branch grows, nothing is rewritten
+commits="$(git --git-dir="$origin" rev-list --count main)"
+head_before="$(git --git-dir="$origin" rev-parse main)"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/bindings.lua --yes"
+assert_contains "cat ~/.config/hypr/bindings.lua" "alacritty"
+wait_until "grep -q 'alacritty' $B/.config/hypr/bindings.lua"
+assert "git --git-dir=$origin rev-list --count main | awk -v n=$commits '{print (\$1 > n)}'" "1"
+assert_succeed "git --git-dir=$origin merge-base --is-ancestor $head_before main"
+
+# ---- fetch-only: B's watcher fetches, never publishes, never writes a file
+kill "$b_watcher"
+wait "$b_watcher" 2>/dev/null || true
+MISE_HISTORY_SYNC=fetch-only $b bootstrap dotfiles watch --json >b.log 2>&1 &
+b_watcher=$!
+echo '# only on B' >>"$B/.config/hypr/monitors.lua"
+echo 'bind = SUPER, E, exec, thunar' >>~/.config/hypr/bindings.lua
+wait_until "grep '\"event\":\"synced\"' b.log | grep -q '\"pending\":1'"
+assert_not_contains "cat $B/.config/hypr/bindings.lua" "thunar"
+assert_not_contains "git --git-dir=$origin show main:home/.config/hypr/monitors.lua" "only on B"
+assert_succeed "MISE_HISTORY_SYNC=fetch-only $b bootstrap dotfiles pull --yes"
+assert_contains "cat $B/.config/hypr/bindings.lua" "thunar"
+
+# ---- manual: nothing happens on its own
+kill "$b_watcher"
+wait "$b_watcher" 2>/dev/null || true
+MISE_HISTORY_SYNC=manual $b bootstrap dotfiles watch --json >b.log 2>&1 &
+b_watcher=$!
+wait_until "grep -q '\"event\":\"started\"' b.log"
+echo 'bind = SUPER, R, exec, rofi' >>~/.config/hypr/bindings.lua
+wait_until "git --git-dir=$origin show main:home/.config/hypr/bindings.lua | grep -q rofi"
+sleep 3
+assert_fail "grep -q '\"event\":\"sync\"' b.log"
+assert_not_contains "cat $B/.config/hypr/bindings.lua" "rofi"

--- a/e2e/cli/test_dotfiles_sync_auto
+++ b/e2e/cli/test_dotfiles_sync_auto
@@ -21,6 +21,25 @@ wait_until() {
   return 1
 }
 
+# The live watcher can own the synchronization lock when a manual pull
+# starts. Retry only that documented transient error, never a failed apply.
+without_sync_contention() {
+  for _ in $(seq 1 30); do
+    if "$@" >manual-command.log 2>&1; then
+      cat manual-command.log
+      return 0
+    fi
+    if ! grep -q 'another setup sync or pull is running' manual-command.log; then
+      cat manual-command.log >&2
+      return 1
+    fi
+    sleep 1
+  done
+  cat manual-command.log >&2
+  return 1
+}
+export -f without_sync_contention
+
 origin="$PWD/origin.git"
 git init -q --bare -b main "$origin"
 
@@ -110,7 +129,7 @@ assert_fail "test -e $B/.config/hypr/monitors.lua"
 assert "grep -c '\"conflicts\":1' b.log | awk '{print (\$1 > 1)}'" "1"
 # Notification delivery and deduplication are unit-tested without sending
 # real desktop alerts from the isolated test homes.
-assert_succeed "$b bootstrap dotfiles pull --take-remote $B/.config/hypr/bindings.lua --yes"
+assert_succeed "without_sync_contention $b bootstrap dotfiles pull --take-remote $B/.config/hypr/bindings.lua --yes"
 wait_until "test -e $B/.config/hypr/monitors.lua"
 assert "cat $B/.config/hypr/bindings.lua" $'bind = SUPER, Q, exec, foot\nbind = SUPER, W, exec, firefox'
 assert_not_contains "$b bootstrap dotfiles status 2>&1" "both sides changed"
@@ -133,10 +152,11 @@ MISE_HISTORY_SYNC=fetch-only $b bootstrap dotfiles watch --json >b.log 2>&1 &
 b_watcher=$!
 echo '# only on B' >>"$B/.config/hypr/monitors.lua"
 echo 'bind = SUPER, E, exec, thunar' >>~/.config/hypr/bindings.lua
-wait_until "grep '\"event\":\"synced\"' b.log | grep -q '\"pending\":1'"
+# The pending count also includes repository metadata, not only live files.
+wait_until "grep '\"event\":\"synced\"' b.log | jq -e 'select(.pending > 0)'"
 assert_not_contains "cat $B/.config/hypr/bindings.lua" "thunar"
 assert_not_contains "git --git-dir=$origin show main:home/.config/hypr/monitors.lua" "only on B"
-assert_succeed "MISE_HISTORY_SYNC=fetch-only $b bootstrap dotfiles pull --yes"
+assert_succeed "MISE_HISTORY_SYNC=fetch-only without_sync_contention $b bootstrap dotfiles pull --yes"
 assert_contains "cat $B/.config/hypr/bindings.lua" "thunar"
 
 # ---- manual: nothing happens on its own
@@ -148,5 +168,5 @@ wait_until "grep -q '\"event\":\"started\"' b.log"
 echo 'bind = SUPER, R, exec, rofi' >>~/.config/hypr/bindings.lua
 wait_until "git --git-dir=$origin show main:home/.config/hypr/bindings.lua | grep -q rofi"
 sleep 3
-assert_fail "grep -q '\"event\":\"sync\"' b.log"
+assert_fail "grep -Eq '\"event\":\"(sync|synced)\"' b.log"
 assert_not_contains "cat $B/.config/hypr/bindings.lua" "rofi"

--- a/e2e/cli/test_dotfiles_sync_auto_reconcile
+++ b/e2e/cli/test_dotfiles_sync_auto_reconcile
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# A reload of the watcher's configuration (here: the periodic reconcile, every
+# second) keeps the pending publication and fetch deadlines instead of
+# rebuilding the plan, so a save is published within its sync interval even
+# though reconciliation runs more often than that.
+# shellcheck disable=SC2016
+
+require_cmd git
+
+wait_until() {
+  local tries=$1
+  shift
+  for _ in $(seq 1 "$tries"); do
+    if eval "$1" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for: $1" >&2
+  cat a.log >&2 2>/dev/null
+  return 1
+}
+
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+
+# reconcile far more often than the publication delay; the first fetch would
+# only come after 15 seconds, so a publication seen sooner is the save's own
+export MISE_HISTORY_SYNC_INTERVAL=3s MISE_HISTORY_FETCH_INTERVAL=30s
+export MISE_HISTORY_WATCH_DEBOUNCE=1s MISE_HISTORY_WATCH_RECONCILE=1s
+
+mkdir -p ~/.config/hypr
+echo 'bind = SUPER, Q, exec, kitty' >~/.config/hypr/bindings.lua
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --yes"
+mise bootstrap dotfiles watch --json >a.log 2>&1 &
+a_watcher=$!
+cleanup() {
+  kill "$a_watcher" 2>/dev/null || true
+  wait "$a_watcher" 2>/dev/null || true
+}
+trap cleanup EXIT
+wait_until 150 "grep -q '\"event\":\"started\"' a.log"
+
+# the edit is saved after the debounce and published within the sync
+# interval: well under the 15-second first fetch, reconcile ticks or not
+echo 'bind = SUPER, Q, exec, alacritty' >~/.config/hypr/bindings.lua
+wait_until 50 "git --git-dir=$origin show main:home/.config/hypr/bindings.lua | grep -q alacritty"
+# The remote ref becomes visible before the sync's remaining work and its
+# completion event finish. Wait for the event rather than racing that work.
+wait_until 50 "grep -q '\"published\":\"' a.log"
+# reconciliation did run meanwhile (each tick reloads the configuration)
+assert "grep -c '\"reason\":\"reconcile\"' a.log | awk '{print (\$1 >= 2) ? \"yes\" : \"no\"}'" "yes"

--- a/e2e/cli/test_dotfiles_sync_files_encrypted
+++ b/e2e/cli/test_dotfiles_sync_files_encrypted
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Shared encrypted files use one recipient list; local files stay plaintext.
+# shellcheck disable=SC2016
+require_cmd git
+export MISE_EXPERIMENTAL=0
+KEY="AGE-SECRET-KEY-142E7VJ8GUWR94MXDCYQJ7ZTQZRXKQSP9PUJU8HUQJ206QN7QPV4SM5QRL8"
+PUB="age1fuvsfq02qr5ju0nhh3rulrwracymjljlr5j49kres24ltd3fjq0s9z9d8l"
+KEY2="AGE-SECRET-KEY-12LCM5FM5DQ7HZDGYUZWMJ6QHM66J07NZ75VVP2VVGCZX53HYD5PQUXUN8K"
+PUB2="age15myzzpkenzud22ag88x5ksqd80g4tkwtruu976uev57l4r240qcqcuqnt9"
+export MISE_AGE_KEY="$KEY"
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+mkdir -p "$HOME/.config/app" "$MISE_CONFIG_DIR/templates" "$MISE_CONFIG_DIR/assets"
+printf 'private-value-123\n' >"$HOME/.config/app/value"
+printf '#!/bin/sh\necho private-script-123\n' >"$HOME/.config/app/script"
+chmod +x "$HOME/.config/app/script"
+ln -s value "$HOME/.config/app/link"
+printf 'template-private-123\n' >"$MISE_CONFIG_DIR/templates/app.tera"
+printf 'copy-private-123\n' >"$MISE_CONFIG_DIR/assets/copy"
+printf 'symlink-private-123\n' >"$MISE_CONFIG_DIR/assets/link"
+cat >"$MISE_CONFIG_DIR/config.toml" <<TOML
+[history.encryption]
+recipients = ["$PUB", "$PUB2"]
+[dotfiles]
+"~/.config/app/value" = { mode = "track", encrypt = true }
+"~/.config/app/script" = { mode = "track", encrypt = true }
+"~/.config/app/link" = { mode = "track", encrypt = true }
+"~/.config/app/copied" = { mode = "copy", source = "assets/copy" }
+"~/.config/app/linked" = { mode = "symlink", source = "assets/link" }
+"~/.config/app/rendered" = { mode = "template", source = "templates/app.tera" }
+"~/.config/mise/config.toml" = { mode = "track" }
+"~/.config/mise/templates/app.tera" = { mode = "track", encrypt = true }
+"~/.config/mise/assets/copy" = { mode = "track", encrypt = true }
+"~/.config/mise/assets/link" = { mode = "track", encrypt = true }
+TOML
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --sync manual --yes"
+assert_contains "git --git-dir=$origin show main:home/.config/app/value | head -1" 'mise-encrypted-file-v1'
+assert_not_contains "git --git-dir=$origin show main:home/.config/app/value" 'private-value-123'
+assert_not_contains "git --git-dir=$origin show main:config/templates/app.tera" 'template-private-123'
+head_before=$(git --git-dir="$origin" rev-parse main)
+assert_succeed "mise bootstrap dotfiles sync"
+assert "git --git-dir=$origin rev-parse main" "$head_before"
+# No reachable commit carries the protected bytes in plaintext.
+for commit in $(git --git-dir="$origin" rev-list --all); do
+  assert_not_contains "git --git-dir=$origin grep -a private-value-123 $commit || true" 'private-value-123'
+  assert_not_contains "git --git-dir=$origin grep -a template-private-123 $commit || true" 'template-private-123'
+  assert_not_contains "git --git-dir=$origin grep -a copy-private-123 $commit || true" 'copy-private-123'
+  assert_not_contains "git --git-dir=$origin grep -a symlink-private-123 $commit || true" 'symlink-private-123'
+done
+B="$(dirname "$HOME")/encrypted-files-b"
+mkdir -p "$B/.config/mise"
+cat >"$PWD/b" <<WRAPPER
+#!/usr/bin/env bash
+export HOME="$B" XDG_CONFIG_HOME="$B/.config" MISE_CONFIG_DIR="$B/.config/mise" \\
+ MISE_STATE_DIR="$B/.local/state/mise" MISE_DATA_DIR="$B/.local/share/mise" \\
+ MISE_CACHE_DIR="$B/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$B" MISE_AGE_KEY="$KEY2"
+cd "\$HOME" && exec mise "\$@"
+WRAPPER
+chmod +x "$PWD/b"
+b="$PWD/b"
+assert_succeed "$b bootstrap --from-git file://$origin --yes --only dotfiles"
+assert "cat $B/.config/app/value" 'private-value-123'
+assert "cat $B/.config/app/rendered" 'template-private-123'
+assert "cat $B/.config/app/copied" 'copy-private-123'
+assert "cat $B/.config/app/linked" 'symlink-private-123'
+assert_succeed "test -L $B/.config/app/linked"
+assert "readlink $B/.config/app/link" 'value'
+assert_succeed "test -x $B/.config/app/script"
+printf 'changed-by-b\n' >"$B/.config/app/value"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_succeed "mise bootstrap dotfiles sync --fetch-only"
+assert_succeed "mise bootstrap dotfiles pull --yes"
+assert "cat $HOME/.config/app/value" 'changed-by-b'
+# A changed ciphertext cannot be applied without an identity or cached copy.
+printf 'needs-unlock\n' >"$B/.config/app/value"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_fail "MISE_AGE_KEY= mise bootstrap dotfiles sync --fetch-only 2>&1" 'cannot unlock'
+assert_fail "MISE_AGE_KEY= mise bootstrap dotfiles pull --yes 2>&1" 'cannot unlock'
+assert "cat $HOME/.config/app/value" 'changed-by-b'
+assert_succeed "mise bootstrap dotfiles pull --yes"
+assert "cat $HOME/.config/app/value" 'needs-unlock'
+# Different-line encrypted edits produce an ordinary merge, never a plaintext blob.
+printf 'first\nmiddle\nlast\n' >"$HOME/.config/app/value"
+assert_succeed 'mise bootstrap dotfiles sync'
+assert_succeed "$b bootstrap dotfiles sync --fetch-only && $b bootstrap dotfiles pull --yes"
+printf 'from-a\nmiddle\nlast\n' >"$HOME/.config/app/value"
+printf 'first\nmiddle\nfrom-b\n' >"$B/.config/app/value"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_succeed 'mise bootstrap dotfiles sync'
+assert_succeed 'mise bootstrap dotfiles pull --yes'
+assert 'cat ~/.config/app/value' $'from-a\nmiddle\nfrom-b'
+merged_plaintext=$(git hash-object "$HOME/.config/app/value")
+assert_fail "git --git-dir=$MISE_STATE_DIR/history/repo.git cat-file -e $merged_plaintext"
+assert_succeed 'mise bootstrap dotfiles sync'
+assert_fail "git --git-dir=$origin cat-file -e $merged_plaintext"
+assert_succeed "$b bootstrap dotfiles sync --fetch-only && $b bootstrap dotfiles pull --yes"
+assert "cat $B/.config/app/value" $'from-a\nmiddle\nfrom-b'
+# Reconciliation and conflict decisions operate on plaintext, never ciphertext.
+printf 'local-conflict\n' >"$HOME/.config/app/value"
+printf 'remote-conflict\n' >"$B/.config/app/value"
+assert_succeed "$b bootstrap dotfiles sync"
+conflict_head=$(git --git-dir="$origin" rev-parse main)
+assert_succeed "mise bootstrap dotfiles sync"
+assert_contains "mise bootstrap dotfiles status" 'sync paused'
+assert "git --git-dir=$origin rev-parse main" "$conflict_head"
+assert_succeed "mise bootstrap dotfiles pull --take-remote $HOME/.config/app/value --yes"
+assert "cat $HOME/.config/app/value" 'remote-conflict'
+# Deleting an encrypted file removes it remotely and at the other consumer.
+rm "$B/.config/app/script"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_succeed "mise bootstrap dotfiles sync --fetch-only && mise bootstrap dotfiles pull --yes"
+assert_fail "test -e $HOME/.config/app/script"
+assert_fail "git --git-dir=$origin cat-file -e main:home/.config/app/script"
+# Explicit recipient rotation rewrites unchanged encrypted files once.
+old_payload=$(git --git-dir="$origin" rev-parse main:home/.config/app/value)
+sed -i.bak "s/\"$PUB\", \"$PUB2\"/\"$PUB\"/" "$MISE_CONFIG_DIR/config.toml"
+assert_succeed "mise bootstrap dotfiles sync"
+new_payload=$(git --git-dir="$origin" rev-parse main:home/.config/app/value)
+assert_fail "test $old_payload = $new_payload"
+head_before=$(git --git-dir="$origin" rev-parse main)
+assert_succeed "mise bootstrap dotfiles sync"
+assert "git --git-dir=$origin rev-parse main" "$head_before"
+
+# No recipients and inline encrypted secrets both fail closed.
+cp "$MISE_CONFIG_DIR/config.toml" "$PWD/valid-config.toml"
+sed -i.bak "s/recipients = .*/recipients = []/" "$MISE_CONFIG_DIR/config.toml"
+assert_fail "mise bootstrap dotfiles sync 2>&1" '[history.encryption].recipients'
+assert "git --git-dir=$origin rev-parse main" "$head_before"
+cp "$PWD/valid-config.toml" "$MISE_CONFIG_DIR/config.toml"
+printf '\n"~/.config/app/inline" = { content = "must-not-upload", encrypt = true }\n' >>"$MISE_CONFIG_DIR/config.toml"
+assert_fail "mise bootstrap dotfiles sync 2>&1" 'invalid dotfile declarations'
+assert "git --git-dir=$origin rev-parse main" "$head_before"
+# Malformed encryption flags must never silently fall back to plaintext.
+cp "$PWD/valid-config.toml" "$MISE_CONFIG_DIR/config.toml"
+printf '\n"~/.config/app/malformed" = { mode = "track", encrypt = "true" }\n' >>"$MISE_CONFIG_DIR/config.toml"
+assert_fail "mise bootstrap dotfiles sync 2>&1" 'invalid dotfile declarations'
+assert "git --git-dir=$origin rev-parse main" "$head_before"

--- a/e2e/cli/test_dotfiles_sync_permissions
+++ b/e2e/cli/test_dotfiles_sync_permissions
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Mode-only versions and content merges preserve both chmod +x and chmod -x.
+require_cmd git
+export MISE_HISTORY_NOTIFY=false
+
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+B="$(dirname "$HOME")/permissions-b"
+mkdir -p "$B/.config/mise"
+cat <<EOF >"$PWD/b"
+#!/usr/bin/env bash
+export HOME="$B" XDG_CONFIG_HOME="$B/.config" MISE_CONFIG_DIR="$B/.config/mise" \\
+  MISE_STATE_DIR="$B/.local/state/mise" MISE_DATA_DIR="$B/.local/share/mise" \\
+  MISE_CACHE_DIR="$B/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$B"
+cd "\$HOME" && exec mise "\$@"
+EOF
+chmod +x "$PWD/b"
+b="$PWD/b"
+
+printf 'first\nmiddle\nlast\n' >~/.script
+chmod 644 ~/.script
+assert_succeed "mise bootstrap dotfiles track ~/.script"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --yes"
+assert_succeed "$b bootstrap --from-git file://$origin --yes"
+assert_fail "test -x $B/.script"
+
+# Identical bytes, different mode: publish and apply the mode-only edit.
+chmod +x ~/.script
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "mise bootstrap dotfiles sync"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_succeed "$b bootstrap dotfiles pull --yes"
+assert_succeed "test -x $B/.script"
+assert_contains "git --git-dir=$origin ls-tree main home/.script" "100755"
+
+# A removes +x while both machines edit different lines. Neither direction
+# may restore +x just because one side of a clean text merge still has it.
+printf 'local\nmiddle\nlast\n' >~/.script
+chmod -x ~/.script
+printf 'first\nmiddle\nremote\n' >"$B/.script"
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "$b bootstrap dotfiles save"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_succeed "mise bootstrap dotfiles sync"
+assert_succeed "mise bootstrap dotfiles pull --yes"
+assert_succeed "mise bootstrap dotfiles sync"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_succeed "$b bootstrap dotfiles pull --yes"
+assert "cat ~/.script" $'local\nmiddle\nremote'
+assert "cat $B/.script" $'local\nmiddle\nremote'
+assert_fail "test -x ~/.script"
+assert_fail "test -x $B/.script"
+assert_contains "git --git-dir=$origin ls-tree main home/.script" "100644"
+
+# Non-executable permission changes also travel in the ordinary tree.
+if [[ "$(uname)" == Darwin ]]; then
+  mode_of="stat -f %Lp"
+else
+  mode_of="stat -c %a"
+fi
+chmod 600 ~/.script
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "mise bootstrap dotfiles sync"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_succeed "$b bootstrap dotfiles pull --yes"
+assert "$mode_of $B/.script" "600"
+
+# An unsaved chmod after fetching is an edit, not permission to overwrite.
+chmod 640 ~/.script
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "mise bootstrap dotfiles sync"
+assert_succeed "$b bootstrap dotfiles sync --fetch-only"
+chmod 400 "$B/.script"
+assert_fail "$b bootstrap dotfiles pull --yes"
+assert "$mode_of $B/.script" "400"
+assert_contains "$b bootstrap dotfiles status" "paused"

--- a/e2e/cli/test_dotfiles_sync_preflight
+++ b/e2e/cli/test_dotfiles_sync_preflight
@@ -7,7 +7,6 @@ origin="$PWD/origin.git"
 git init -q --bare -b main "$origin"
 B="$(dirname "$HOME")/b-home"
 mkdir -p "$B/.config/mise"
-printf '[env]\nB_ONLY = "yes"\n' >"$B/.config/mise/config.toml"
 cat <<EOF >"$PWD/b"
 #!/usr/bin/env bash
 export HOME="$B" XDG_CONFIG_HOME="$B/.config" MISE_CONFIG_DIR="$B/.config/mise" \\
@@ -25,10 +24,7 @@ assert_succeed 'mise bootstrap dotfiles track ~/.config/mise/conf.d'
 assert_fail "mise bootstrap dotfiles origin set https://user:secret@example.invalid/setup.git --yes 2>&1" "must not contain credentials"
 assert_not_contains "mise bootstrap dotfiles origin set https://user:secret@example.invalid/setup.git --yes 2>&1 || true" "user:secret"
 assert_succeed "mise bootstrap dotfiles origin set file://$origin --yes"
-mkdir -p "$B/.local/state/mise/history"
-git clone -q --bare "$origin" "$B/.local/state/mise/history/repo.git"
-assert_succeed "$b bootstrap dotfiles origin set file://$origin --yes"
-assert_succeed "$b bootstrap dotfiles pull --take-remote $B/.config/mise/config.toml --yes"
+assert_succeed "$b bootstrap --from-git file://$origin --yes"
 assert "cat $B/.zshrc" "initial"
 
 case "$(uname -s)" in
@@ -133,9 +129,6 @@ git -C editor add config/config.toml config/conf.d/invalid.toml
 git -C editor -c user.name=test -c user.email=test@example.com commit -qm invalid-conf-d
 git -C editor push -q origin main
 explicit_config="$B/.config/mise/config.toml"
-if [[ -f "$B/.config/mise/config.local.toml" ]]; then
-  explicit_config="$B/.config/mise/config.local.toml"
-fi
 assert_succeed "MISE_GLOBAL_CONFIG_FILE=$explicit_config $b bootstrap dotfiles sync"
 assert_contains "$b bootstrap dotfiles status" "unknown dotfile mode"
 assert_fail "test -e $B/.config/mise/conf.d/invalid.toml"

--- a/e2e/cli/test_dotfiles_sync_preflight
+++ b/e2e/cli/test_dotfiles_sync_preflight
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Discover new variant streams and required sources before applying any
+# incoming config or publishing otherwise clean local changes.
+require_cmd git
+
+origin="$PWD/origin.git"
+git init -q --bare -b main "$origin"
+B="$(dirname "$HOME")/b-home"
+mkdir -p "$B/.config/mise"
+printf '[env]\nB_ONLY = "yes"\n' >"$B/.config/mise/config.toml"
+cat <<EOF >"$PWD/b"
+#!/usr/bin/env bash
+export HOME="$B" XDG_CONFIG_HOME="$B/.config" MISE_CONFIG_DIR="$B/.config/mise" \\
+  MISE_STATE_DIR="$B/.local/state/mise" MISE_DATA_DIR="$B/.local/share/mise" \\
+  MISE_CACHE_DIR="$B/.cache/mise" MISE_TRUSTED_CONFIG_PATHS="$B"
+cd "\$HOME" && exec mise "\$@"
+EOF
+chmod +x "$PWD/b"
+b="$PWD/b"
+echo initial >~/.zshrc
+assert_succeed "mise bootstrap dotfiles track ~/.zshrc"
+assert_succeed 'mise bootstrap dotfiles track ~/.config/mise/config.toml'
+mkdir -p "$MISE_CONFIG_DIR/conf.d"
+assert_succeed 'mise bootstrap dotfiles track ~/.config/mise/conf.d'
+assert_fail "mise bootstrap dotfiles origin set https://user:secret@example.invalid/setup.git --yes 2>&1" "must not contain credentials"
+assert_not_contains "mise bootstrap dotfiles origin set https://user:secret@example.invalid/setup.git --yes 2>&1 || true" "user:secret"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --yes"
+mkdir -p "$B/.local/state/mise/history"
+git clone -q --bare "$origin" "$B/.local/state/mise/history/repo.git"
+assert_succeed "$b bootstrap dotfiles origin set file://$origin --yes"
+assert_succeed "$b bootstrap dotfiles pull --take-remote $B/.config/mise/config.toml --yes"
+assert "cat $B/.zshrc" "initial"
+
+case "$(uname -s)" in
+  Darwin) platform=macos ;;
+  *) platform=linux ;;
+esac
+echo incoming >~/.platform.conf
+echo local-untracked >"$B/.platform.conf"
+assert_succeed "mise bootstrap dotfiles track ~/.platform.conf --os $platform"
+echo incoming-zsh >~/.zshrc
+assert_succeed "mise bootstrap dotfiles sync"
+before="$(cat "$B/.config/mise/config.toml")"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_contains "$b bootstrap dotfiles status" ".platform.conf"
+assert_fail "$b bootstrap dotfiles pull --yes 2>&1" "sync paused"
+assert "cat $B/.platform.conf" "local-untracked"
+assert "cat $B/.zshrc" "initial"
+assert "cat $B/.config/mise/config.toml" "$before"
+assert_succeed "$b bootstrap dotfiles pull --take-remote $B/.platform.conf --yes"
+assert "cat $B/.platform.conf" "incoming"
+assert "cat $B/.zshrc" "incoming-zsh"
+
+# A template declaration must not land before its missing source is fixed.
+cat <<'EOF' >>"$MISE_CONFIG_DIR/config.toml"
+
+[dotfiles."~/.rendered"]
+mode = "template"
+source = "templates/required.tera"
+EOF
+assert_succeed "mise bootstrap dotfiles sync"
+before="$(cat "$B/.config/mise/config.toml")"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_contains "$b bootstrap dotfiles status" "missing required source"
+assert_fail "$b bootstrap dotfiles pull --yes 2>&1" "sync paused"
+assert "cat $B/.config/mise/config.toml" "$before"
+mkdir -p "$MISE_CONFIG_DIR/templates"
+echo 'name = {{ env.USER }}' >"$MISE_CONFIG_DIR/templates/required.tera"
+assert_succeed 'mise bootstrap dotfiles track ~/.config/mise/templates'
+assert_succeed "mise bootstrap dotfiles sync"
+assert_succeed "$b bootstrap dotfiles sync"
+assert_succeed "$b bootstrap dotfiles pull --yes"
+assert_contains "cat $B/.config/mise/config.toml" "required.tera"
+assert "cat $B/.config/mise/templates/required.tera" 'name = {{ env.USER }}'
+assert_fail "test -e $B/.rendered"
+
+# A config edited directly in Git must also pass typed declaration validation.
+git clone -q "$origin" editor
+cp editor/config/config.toml valid-config.toml
+before="$(cat "$B/.config/mise/config.toml")"
+cat <<'EOF' >>editor/config/config.toml
+
+[dotfiles."~/.invalid"]
+mode = "typo"
+EOF
+git -C editor add config/config.toml
+git -C editor -c user.name=test -c user.email=test@example.com commit -qm invalid
+git -C editor push -q origin main
+assert_succeed "$b bootstrap dotfiles sync"
+assert_contains "$b bootstrap dotfiles status" "unknown dotfile mode"
+assert_fail "$b bootstrap dotfiles pull --yes 2>&1" "sync paused"
+assert "cat $B/.config/mise/config.toml" "$before"
+
+# Lossy parser warnings must be rejected before any incoming file is written.
+cp valid-config.toml editor/config/config.toml
+cat <<'EOF' >>editor/config/config.toml
+
+[dotfiles."~/.invalid"]
+content = "inline"
+mode = "copy"
+EOF
+git -C editor add config/config.toml
+git -C editor -c user.name=test -c user.email=test@example.com commit -qm invalid-inline
+git -C editor push -q origin main
+assert_succeed "$b bootstrap dotfiles sync"
+assert_contains "$b bootstrap dotfiles status" "inline content does not support"
+assert "cat $B/.config/mise/config.toml" "$before"
+
+# A misspelled capture policy must not silently fall back to autosave=true.
+cp valid-config.toml editor/config/config.toml
+cat <<'EOF' >>editor/config/config.toml
+
+[dotfiles."~/.private"]
+source = "private-config"
+autsoave = false
+EOF
+git -C editor add config/config.toml
+git -C editor -c user.name=test -c user.email=test@example.com commit -qm misspelled-capture-policy
+git -C editor push -q origin main
+assert_succeed "$b bootstrap dotfiles sync"
+assert_contains "$b bootstrap dotfiles status" 'unknown dotfile key "autsoave"'
+assert_fail "$b bootstrap dotfiles pull --yes 2>&1" "sync paused"
+assert "cat $B/.config/mise/config.toml" "$before"
+
+# An explicit global file must not hide invalid incoming conf.d bodies.
+cp valid-config.toml editor/config/config.toml
+mkdir -p editor/config/conf.d
+cat <<'EOF' >editor/config/conf.d/invalid.toml
+[dotfiles."~/.invalid"]
+mode = "typo"
+EOF
+git -C editor add config/config.toml config/conf.d/invalid.toml
+git -C editor -c user.name=test -c user.email=test@example.com commit -qm invalid-conf-d
+git -C editor push -q origin main
+explicit_config="$B/.config/mise/config.toml"
+if [[ -f "$B/.config/mise/config.local.toml" ]]; then
+  explicit_config="$B/.config/mise/config.local.toml"
+fi
+assert_succeed "MISE_GLOBAL_CONFIG_FILE=$explicit_config $b bootstrap dotfiles sync"
+assert_contains "$b bootstrap dotfiles status" "unknown dotfile mode"
+assert_fail "test -e $B/.config/mise/conf.d/invalid.toml"
+
+# Explicit local global-config overrides are also the write destination.
+override="$PWD/config.local.toml"
+echo '' >"$override"
+assert_succeed "MISE_GLOBAL_CONFIG_FILE=$override mise bootstrap dotfiles exclude '~/.noise'"
+assert_contains "cat $override" "~/.noise"
+
+# Damaged status must block sync/pull rather than discard pending decisions.
+git -C editor rm -q config/conf.d/invalid.toml
+printf '\n[history.origin]\nurl = "https://example.invalid/other.git"\n' >>editor/config/config.toml
+git -C editor add config/config.toml
+git -C editor -c user.name=test -c user.email=test@example.com commit -qm shared-origin
+git -C editor push -q origin main
+assert_succeed "$b bootstrap dotfiles sync"
+assert_contains "$b bootstrap dotfiles status" 'history.origin is machine-local'
+assert_not_contains "cat $B/.config/mise/config.toml" 'example.invalid/other.git'
+
+state_file="$B/.local/state/mise/history/sync.json"
+assert_succeed "test -f $state_file"
+printf '{"resolutions": broken' >"$state_file"
+assert_fail "$b bootstrap dotfiles sync 2>&1" "invalid sync state"
+assert_fail "$b bootstrap dotfiles pull --yes 2>&1" "invalid sync state"
+assert_contains "$b doctor 2>&1 || true" "invalid sync state"
+assert "cat $state_file" '{"resolutions": broken'

--- a/e2e/cli/test_dotfiles_sync_stable
+++ b/e2e/cli/test_dotfiles_sync_stable
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Sharing works without experimental opt-in.
+export MISE_EXPERIMENTAL=0
+git init -q --bare -b main "$PWD/origin.git"
+echo original >"$HOME/.native"
+assert_succeed "mise bootstrap dotfiles track ~/.native --no-autosave"
+assert_succeed "mise bootstrap dotfiles origin set file://$PWD/origin.git --sync manual --yes"
+assert_succeed "mise bootstrap dotfiles sync"
+assert_succeed "mise bootstrap dotfiles machines"
+assert_succeed "mise bootstrap dotfiles pull --yes"
+assert_succeed "mise bootstrap dotfiles watch --once"
+assert_not_contains "mise doctor 2>&1 || true" 'tracking is experimental and disabled'

--- a/e2e/cli/test_dotfiles_sync_stable
+++ b/e2e/cli/test_dotfiles_sync_stable
@@ -6,7 +6,7 @@ echo original >"$HOME/.native"
 assert_succeed "mise bootstrap dotfiles track ~/.native --no-autosave"
 assert_succeed "mise bootstrap dotfiles origin set file://$PWD/origin.git --sync manual --yes"
 assert_succeed "mise bootstrap dotfiles sync"
-assert_succeed "mise bootstrap dotfiles machines"
+assert_succeed "mise bootstrap dotfiles status"
 assert_succeed "mise bootstrap dotfiles pull --yes"
 assert_succeed "mise bootstrap dotfiles watch --once"
 assert_not_contains "mise doctor 2>&1 || true" 'tracking is experimental and disabled'

--- a/e2e/cli/test_dotfiles_track
+++ b/e2e/cli/test_dotfiles_track
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+require_cmd git
+repository="$MISE_STATE_DIR/history/repo.git"
+mkdir -p "$MISE_CONFIG_DIR/templates" ~/native
+echo original >~/.zshrc
+echo native >~/native/config
+printf '[user]\nname = "{{ vars.name }}"\n' >"$MISE_CONFIG_DIR/templates/gitconfig.tera"
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[vars]
+name = "test"
+[dotfiles]
+"~/.gitconfig" = { mode = "template", source = "templates/gitconfig.tera" }
+"~/.zshrc/activate" = { block = 'eval "$(mise activate zsh)"' }
+TOML
+assert_succeed 'mise bootstrap dotfiles track ~/.zshrc ~/native'
+assert_fail 'test -L ~/.zshrc'
+assert_succeed 'mise bootstrap dotfiles apply --yes'
+assert_contains 'cat ~/.zshrc' 'mise activate zsh'
+assert_contains 'cat ~/.gitconfig' 'name = "test"'
+assert "mise bootstrap dotfiles paths --json | jq '[.entries[] | select(.path == \"~/.gitconfig\")] | length'" 0
+assert_succeed 'mise bootstrap dotfiles track ~/.gitconfig'
+assert_contains "git --git-dir=$repository show HEAD:home/.gitconfig" 'name = "test"'
+assert_succeed 'mise bootstrap dotfiles untrack ~/.gitconfig'
+assert_contains 'cat ~/.gitconfig' 'name = "test"'
+assert_contains 'cat "$MISE_CONFIG_DIR/config.toml"' 'mode = "template"'
+assert_fail 'mise bootstrap dotfiles add --mode track ~/.newrc --dry-run'
+assert_succeed 'mise bootstrap dotfiles unapply --yes ~/native'
+assert 'cat ~/native/config' native
+
+# Platform choices stay in one declaration; another platform is not captured.
+case "$(uname -s)" in
+  Darwin) this_os=macos other_os=linux ;;
+  *) this_os=linux other_os=macos ;;
+esac
+assert_succeed "mise bootstrap dotfiles track ~/.zshrc --os $this_os"
+assert_succeed "mise bootstrap dotfiles track ~/.zshrc --os $other_os"
+assert "mise bootstrap dotfiles paths --json | jq -r '.entries[] | select(.path == \"~/.zshrc\") | .variant'" "$this_os"
+assert_contains "git --git-dir=$repository ls-tree -r --name-only HEAD" "home@$this_os/.zshrc"
+
+# Defaults exclude credentials entirely, including explicit enrollment.
+echo synthetic-secret >~/.netrc
+assert_succeed 'mise bootstrap dotfiles track ~/.netrc'
+assert_fail "git --git-dir=$repository cat-file -e HEAD:home/.netrc"
+mkdir -p ~/native/sub
+echo keep >~/native/sub/keep.conf
+echo excluded >~/native/sub/drop.conf
+assert_succeed "mise bootstrap dotfiles exclude '~/native/sub/**'"
+assert_succeed "mise bootstrap dotfiles exclude '!~/native/sub/keep.conf'"
+assert_succeed 'mise bootstrap dotfiles save'
+assert "git --git-dir=$repository show HEAD:home/native/sub/keep.conf" keep
+assert_fail "git --git-dir=$repository cat-file -e HEAD:home/native/sub/drop.conf"
+
+# Symlinks are observed without enrolling targets or traversing them.
+mkdir -p ~/target-dir
+echo outside >~/target-dir/config
+ln -s "$HOME/target-dir" ~/native/link
+assert_succeed 'mise bootstrap dotfiles save'
+assert_contains "git --git-dir=$repository ls-tree HEAD home/native/link" 120000
+assert_fail "git --git-dir=$repository cat-file -e HEAD:home/target-dir/config"
+
+# Project-local declarations cannot enroll global files implicitly.
+mkdir -p ~/project
+printf '[dotfiles]\n"~/.project-file" = { mode = "track" }\n' >~/project/mise.toml
+echo project >~/.project-file
+assert_succeed 'cd ~/project && mise trust -q'
+assert "cd ~/project && mise bootstrap dotfiles paths --json | jq '[.entries[] | select(.path == \"~/.project-file\")] | length'" 0
+assert_succeed 'mise bootstrap dotfiles untrack ~/native'
+assert 'cat ~/native/config' native
+assert_fail "git --git-dir=$repository cat-file -e HEAD:home/native/config"
+
+if [[ $(uname -s) == Linux ]]; then
+  mkdir -p ~/.raw-names
+  echo ordinary >~/.raw-names/ordinary
+  assert_succeed 'mise bootstrap dotfiles track ~/.raw-names'
+  before=$(git --git-dir="$repository" rev-parse HEAD)
+  raw_path="$HOME/.raw-names/"$'\xff'
+  echo untouched >"$raw_path"
+  assert_fail 'mise bootstrap dotfiles save' 'non-UTF-8 filename'
+  assert "git --git-dir=$repository rev-parse HEAD" "$before"
+  [[ $(<"$raw_path") == untouched ]]
+fi

--- a/e2e/cli/test_dotfiles_track_stable
+++ b/e2e/cli/test_dotfiles_track_stable
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Native tracking and source-managed files work without experimental opt-in.
+export MISE_EXPERIMENTAL=0
+mkdir -p "$MISE_CONFIG_DIR/dotfiles"
+echo original >"$HOME/.native"
+echo copied >"$MISE_CONFIG_DIR/dotfiles/source"
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[dotfiles]
+"~/.copied" = { mode = "copy", source = "dotfiles/source" }
+EOF
+assert_succeed "mise bootstrap dotfiles track ~/.native --no-autosave"
+assert_succeed "mise bootstrap dotfiles save"
+assert_succeed "mise bootstrap dotfiles history"
+assert_succeed "mise bootstrap dotfiles paths"
+assert_succeed "mise bootstrap dotfiles apply --yes"
+assert "cat ~/.copied" copied
+assert "cat ~/.native" original
+assert_succeed "mise bootstrap dotfiles status"
+
+# Disabled history does not open an unavailable store merely to report status.
+touch "$PWD/not-a-state-directory"
+assert_contains "MISE_STATE_DIR=$PWD/not-a-state-directory MISE_HISTORY_ENABLED=0 mise bootstrap dotfiles status" "History: disabled"

--- a/e2e/cli/test_dotfiles_watch
+++ b/e2e/cli/test_dotfiles_watch
@@ -57,7 +57,7 @@ echo 'monitor=DP-2' >~/.config/hypr/monitors.lua
 assert_succeed "mise bootstrap dotfiles watch --once"
 assert "$count" "2"
 assert "mise bootstrap dotfiles history --json | jq -r '.[0].trigger'" "edit"
-assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edited hypr/monitors.lua, mise/config.toml"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edited hypr/monitors.lua"
 
 # the foreground watcher saves an edit once the file is quiet
 mise bootstrap dotfiles watch --json >watch.log 2>&1 &
@@ -85,7 +85,7 @@ assert_contains "cat watch.log" '"event":"captured"'
 assert_succeed "mise bootstrap dotfiles exclude '~/.config/hypr/bindings.lua'"
 wait_for_count 4
 assert_contains "cat watch.log" '"event":"replan"'
-assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edited mise/config.toml; removed hypr/bindings.lua"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "removed hypr/bindings.lua"
 echo 'bind = SUPER, W' >~/.config/hypr/bindings.lua
 echo 'monitor=DP-4' >~/.config/hypr/monitors.lua
 wait_for_count 5
@@ -102,8 +102,8 @@ assert "cat ~/.config/hypr/monitors.lua" "monitor=DP-3"
 assert "$count" "$((n + 2))"
 
 # a description command names the checkpoints the watcher saves from what it
-# is told: the changed paths that are not private and a diff of the files
-# that are backed up; the checkpoint is saved before it runs
+# is told: changed tracked paths and their diffs; the checkpoint is saved
+# before the description command runs
 cat <<'EOF' >"$PWD/describe"
 #!/usr/bin/env bash
 input="$(cat)"

--- a/e2e/cli/test_dotfiles_watch
+++ b/e2e/cli/test_dotfiles_watch
@@ -36,6 +36,18 @@ wait_until() {
   return 1
 }
 
+# With no enrollment the service still watches policy changes, but creates
+# no file-history commits or implicit config enrollment.
+mkdir -p "$MISE_CONFIG_DIR"
+mise bootstrap dotfiles watch --json >watch.log 2>&1 &
+empty_watcher=$!
+trap 'kill "$empty_watcher" 2>/dev/null || true; wait "$empty_watcher" 2>/dev/null || true' EXIT
+wait_until "grep -q '\"event\":\"started\"' watch.log"
+kill -TERM "$empty_watcher"
+wait "$empty_watcher"
+trap - EXIT
+assert "$count" "0"
+
 mkdir -p ~/.config/hypr
 echo 'monitor=DP-1' >~/.config/hypr/monitors.lua
 assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
@@ -141,7 +153,6 @@ assert_succeed "mise bootstrap dotfiles history diff --path ~/.config/hypr/monit
 assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edited hypr/monitors.lua"
 assert_contains "mise bootstrap dotfiles status" "declared but not running"
 
-# the watcher is a no-op when history is disabled, and fails clearly when
-# nothing can be watched
+# The watcher is a no-op when history is disabled.
 assert_contains "MISE_HISTORY_ENABLED=0 mise bootstrap dotfiles watch --json" '"event":"disabled"'
 assert_succeed "MISE_HISTORY_ENABLED=0 mise bootstrap dotfiles watch"

--- a/e2e/cli/test_dotfiles_watch
+++ b/e2e/cli/test_dotfiles_watch
@@ -132,11 +132,12 @@ assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edit
 assert "mise bootstrap dotfiles history --json | jq -r '.[0].description_source'" "computed"
 
 # stopping saves what is still pending
-echo 'monitor=DP-5' >~/.config/hypr/monitors.lua
+echo 'monitor=DP-6' >~/.config/hypr/monitors.lua
 sleep 0.3
 kill -TERM "$watcher"
 wait "$watcher" || true
 assert_contains "cat watch.log" '"event":"stopped"'
+assert_succeed "mise bootstrap dotfiles history diff --path ~/.config/hypr/monitors.lua --exit-code"
 assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edited hypr/monitors.lua"
 assert_contains "mise bootstrap dotfiles status" "declared but not running"
 

--- a/e2e/cli/test_dotfiles_watch
+++ b/e2e/cli/test_dotfiles_watch
@@ -123,12 +123,13 @@ printf '%s\n' "$input" >>"$HOME/describe-input"
 printf 'agent: %s\n' "$(printf '%s' "$input" | jq -r '(.added + .modified + .removed) | join(",")')"
 EOF
 chmod +x "$PWD/describe"
+replans="$(grep -c 'configuration changed; watching' watch.log || true)"
 cat <<EOF >>"$MISE_CONFIG_DIR/config.toml"
 
 [settings]
 history.describe_command = "$PWD/describe"
 EOF
-wait_until "grep -q 'configuration changed' watch.log"
+wait_until "[[ \$(grep -c 'configuration changed; watching' watch.log) -gt $replans ]]"
 echo 'token = "s3cret"' >"$MISE_CONFIG_DIR/github_tokens.toml"
 echo 'monitor=DP-4' >~/.config/hypr/monitors.lua
 wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description_source == \"command\" and (.[0].description | test(\"^agent: .*monitors.lua\"))'"

--- a/e2e/cli/test_dotfiles_watch
+++ b/e2e/cli/test_dotfiles_watch
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# `mise bootstrap dotfiles watch`: edits to tracked files are saved automatically once
+# they are quiet, configuration changes replan the watches, one watcher runs
+# per store, and `--once` reconciles for timers.
+# shellcheck disable=SC2016
+
+require_cmd git
+
+export MISE_HISTORY_WATCH_DEBOUNCE=1s
+export MISE_HISTORY_WATCH_MAX_INTERVAL=5s
+
+count="mise bootstrap dotfiles history --json -n 0 | jq length"
+
+# waits until the checkpoint count reaches $1 (or fails after ~10s)
+wait_for_count() {
+  for _ in $(seq 1 50); do
+    if [[ "$(eval "$count")" -ge $1 ]]; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "expected at least $1 checkpoints, found $(eval "$count")" >&2
+  [[ -f watch.log ]] && cat watch.log >&2
+  return 1
+}
+
+wait_until() {
+  for _ in $(seq 1 100); do
+    if eval "$1" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for: $1" >&2
+  [[ -f watch.log ]] && cat watch.log >&2
+  return 1
+}
+
+mkdir -p ~/.config/hypr
+echo 'monitor=DP-1' >~/.config/hypr/monitors.lua
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+assert "$count" "1"
+assert_contains "mise bootstrap dotfiles status" "automatic capture: not declared"
+
+# a declared but not running watcher is reported with the next command
+cat <<'EOF' >>"$MISE_CONFIG_DIR/config.toml"
+
+[bootstrap.services.mise-history]
+builtin = "history-watch"
+EOF
+assert_contains "mise bootstrap dotfiles status" "declared but not running"
+assert_contains "mise bootstrap dotfiles status" "mise bootstrap services apply"
+assert "mise bootstrap dotfiles status --json | jq -r .history.watcher" "declared-not-running"
+
+# --once reconciles and exits: an edit made while nothing watched is saved
+echo 'monitor=DP-2' >~/.config/hypr/monitors.lua
+assert_succeed "mise bootstrap dotfiles watch --once"
+assert "$count" "2"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].trigger'" "edit"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edited hypr/monitors.lua, mise/config.toml"
+
+# the foreground watcher saves an edit once the file is quiet
+mise bootstrap dotfiles watch --json >watch.log 2>&1 &
+watcher=$!
+cleanup() { kill "$watcher" 2>/dev/null || true; }
+trap cleanup EXIT
+for _ in $(seq 1 50); do
+  grep -q '"event":"started"' watch.log && break
+  sleep 0.2
+done
+assert_contains "cat watch.log" '"event":"started"'
+assert "mise bootstrap dotfiles status --json | jq -r .history.watcher" "running"
+assert_contains "mise bootstrap dotfiles status" "automatic capture: running"
+
+# one watcher per store: a second one exits 0 immediately
+assert_contains "mise bootstrap dotfiles watch --json" '"event":"already-running"'
+
+echo 'monitor=DP-3' >~/.config/hypr/monitors.lua
+echo 'bind = SUPER, Q' >~/.config/hypr/bindings.lua
+wait_for_count 3
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edited hypr/monitors.lua; added hypr/bindings.lua"
+assert_contains "cat watch.log" '"event":"captured"'
+
+# a configuration change replans: an excluded file stops being captured
+assert_succeed "mise bootstrap dotfiles exclude '~/.config/hypr/bindings.lua'"
+wait_for_count 4
+assert_contains "cat watch.log" '"event":"replan"'
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edited mise/config.toml; removed hypr/bindings.lua"
+echo 'bind = SUPER, W' >~/.config/hypr/bindings.lua
+echo 'monitor=DP-4' >~/.config/hypr/monitors.lua
+wait_for_count 5
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edited hypr/monitors.lua"
+assert_succeed "mise bootstrap dotfiles include '~/.config/hypr/bindings.lua'"
+wait_for_count 6
+
+# a running history operation defers the watcher instead of racing it: the
+# rollback records its own pair and the watcher saves nothing extra
+n="$(eval "$count")"
+assert_succeed "mise bootstrap dotfiles rollback ~/.config/hypr/monitors.lua --yes"
+sleep 2.5
+assert "cat ~/.config/hypr/monitors.lua" "monitor=DP-3"
+assert "$count" "$((n + 2))"
+
+# a description command names the checkpoints the watcher saves from what it
+# is told: the changed paths that are not private and a diff of the files
+# that are backed up; the checkpoint is saved before it runs
+cat <<'EOF' >"$PWD/describe"
+#!/usr/bin/env bash
+input="$(cat)"
+printf '%s\n' "$input" >>"$HOME/describe-input"
+printf 'agent: %s\n' "$(printf '%s' "$input" | jq -r '(.added + .modified + .removed) | join(",")')"
+EOF
+chmod +x "$PWD/describe"
+cat <<EOF >>"$MISE_CONFIG_DIR/config.toml"
+
+[settings]
+history.describe_command = "$PWD/describe"
+EOF
+wait_until "grep -q 'configuration changed' watch.log"
+echo 'token = "s3cret"' >"$MISE_CONFIG_DIR/github_tokens.toml"
+echo 'monitor=DP-4' >~/.config/hypr/monitors.lua
+wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description_source == \"command\" and (.[0].description | test(\"^agent: .*monitors.lua\"))'"
+assert_contains "cat ~/describe-input" "monitors.lua"
+assert_contains "cat ~/describe-input" "DP-4"
+assert_not_contains "cat ~/describe-input" "github_tokens"
+assert_not_contains "cat ~/describe-input" "s3cret"
+# a failing command keeps the computed description
+printf '#!/usr/bin/env bash\nexit 3\n' >"$PWD/describe"
+echo 'monitor=DP-5' >~/.config/hypr/monitors.lua
+wait_until "grep -q '\"event\":\"describe-error\"' watch.log"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edited hypr/monitors.lua"
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].description_source'" "computed"
+
+# stopping saves what is still pending
+echo 'monitor=DP-5' >~/.config/hypr/monitors.lua
+sleep 0.3
+kill -TERM "$watcher"
+wait "$watcher" || true
+assert_contains "cat watch.log" '"event":"stopped"'
+assert "mise bootstrap dotfiles history --json | jq -r '.[0].description'" "edited hypr/monitors.lua"
+assert_contains "mise bootstrap dotfiles status" "declared but not running"
+
+# the watcher is a no-op when history is disabled, and fails clearly when
+# nothing can be watched
+assert_contains "MISE_HISTORY_ENABLED=0 mise bootstrap dotfiles watch --json" '"event":"disabled"'
+assert_succeed "MISE_HISTORY_ENABLED=0 mise bootstrap dotfiles watch"

--- a/e2e/cli/test_dotfiles_watch_pending
+++ b/e2e/cli/test_dotfiles_watch_pending
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# A populated tree moved into a missing tracked path is captured without a
+# periodic scan or a later edit inside the tree.
+require_cmd git
+export MISE_EXPERIMENTAL=0
+export MISE_HISTORY_WATCH_RECONCILE=0
+export MISE_HISTORY_WATCH_DEBOUNCE=100ms
+
+mkdir -p ~/parent "$PWD/staged-tree"
+printf 'already populated\n' >"$PWD/staged-tree/config"
+assert_succeed 'mise bootstrap dotfiles track ~/parent/incoming'
+mise bootstrap dotfiles watch --json >watch.log 2>&1 &
+watcher=$!
+cleanup() {
+  kill "$watcher" 2>/dev/null || true
+  wait "$watcher" || true
+}
+trap cleanup EXIT
+
+wait_until() {
+  for _ in $(seq 1 100); do
+    if eval "$1" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  cat watch.log >&2
+  return 1
+}
+
+wait_until 'grep -q '\''"event":"started"'\'' watch.log'
+mv "$PWD/staged-tree" ~/parent/incoming
+wait_until 'mise bootstrap dotfiles history show latest --files | grep -q parent/incoming/config'
+assert_contains 'mise bootstrap dotfiles history show latest --files' 'parent/incoming/config'

--- a/e2e/cli/test_dotfiles_watch_throttle
+++ b/e2e/cli/test_dotfiles_watch_throttle
@@ -136,7 +136,8 @@ wait_until "grep -q 'configuration changed' watch.log"
 wait_until "[[ \$(mise bootstrap dotfiles status --json | jq -r '.history.health.throttled | length') -eq 0 ]]"
 assert_not_contains "cat $MISE_STATE_DIR/history/watch-schedule.json" "state.json"
 echo 'monitor=DP-9' >~/.config/hypr/monitors.lua
-wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description | test(\"monitors.lua\")'"
+wait_until "mise bootstrap dotfiles history diff --path ~/.config/hypr/monitors.lua --exit-code"
+assert "$snapshot_of latest .config/hypr/monitors.lua" "monitor=DP-9"
 assert_not_contains "mise bootstrap dotfiles history show latest --files" "state.json"
 assert_succeed "mise bootstrap dotfiles include '~/.config/hypr/state.json'"
 wait_until "[[ \$($throttled) -ge 2 ]]"
@@ -180,7 +181,7 @@ EOF
 wait_until "grep -q 'configuration changed' watch.log"
 mise bootstrap dotfiles apply --yes >apply.log 2>&1 &
 applying=$!
-sleep 1
+wait_until 'test -s ~/applying'
 echo 'monitor=DP-3' >~/.config/hypr/monitors.lua
 wait_until "grep -q '\"event\":\"deferred\"' watch.log"
 wait "$applying" || true

--- a/e2e/cli/test_dotfiles_watch_throttle
+++ b/e2e/cli/test_dotfiles_watch_throttle
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Adaptive autosaving: a constantly rewritten file is saved ever more rarely
+# (never excluded, never switched to manual saving), never delays an ordinary
+# edit, is captured promptly once it settles, keeps its throttling across a
+# watcher restart, and is reported by `mise doctor` and `dotfiles status`
+# without either of them changing anything.
+# shellcheck disable=SC2016
+
+require_cmd git
+export MISE_EXPERIMENTAL=0
+
+# A previously installed service must stop cleanly when history is disabled.
+assert_contains "MISE_HISTORY_ENABLED=0 mise bootstrap dotfiles watch --json" '"event":"disabled"'
+assert_directory_not_exists "$MISE_STATE_DIR/history"
+assert_succeed "MISE_HISTORY_ENABLED=0 mise bootstrap dotfiles watch --once"
+
+count="mise bootstrap dotfiles history --json -n 0 | jq length"
+throttled="mise bootstrap dotfiles status --json | jq -r '.history.health.throttled[0].interval_secs // 0'"
+repo="$MISE_STATE_DIR/history/repo.git"
+# the content of a path inside a checkpoint's snapshot (a script: assertions
+# run in a subshell where shell functions are not available)
+snapshot_of="$PWD/snapshot_of"
+cat <<EOF2 >"$snapshot_of"
+#!/usr/bin/env bash
+git --git-dir="$repo" show "\$(mise bootstrap dotfiles history show "\$1" --json | jq -r .uuid):home/\$2"
+EOF2
+chmod +x "$snapshot_of"
+
+wait_until() {
+  for _ in $(seq 1 100); do
+    if eval "$1" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for: $1" >&2
+  [[ -f watch.log ]] && cat watch.log >&2
+  return 1
+}
+
+mkdir -p ~/.config/hypr
+echo 'monitor=DP-1' >~/.config/hypr/monitors.lua
+echo '{"n":0}' >~/.config/hypr/state.json
+assert_succeed "mise bootstrap dotfiles track ~/.config/hypr"
+# the timing settings live in the configuration so a change to them can be
+# observed while the watcher runs; reconciliation is off, so only events and
+# retries save anything
+cat <<'EOF' >>"$MISE_CONFIG_DIR/config.toml"
+
+[settings]
+history.watch.debounce = "2s"
+history.watch.max_interval = "8s"
+history.watch.reconcile = "0"
+
+[bootstrap.services.mise-history]
+builtin = "history-watch"
+EOF
+
+# doctor reports the declared-but-not-running watcher without touching anything
+n="$(eval "$count")"
+assert_contains "mise doctor 2>&1 || true" "the history watcher is declared but not running"
+assert_contains "mise doctor 2>&1 || true" "mise bootstrap services apply"
+assert "mise doctor --json 2>/dev/null | jq -r .dotfiles.watcher" "declared but not running"
+assert "$count" "$n"
+
+mise bootstrap dotfiles watch --json >watch.log 2>&1 &
+watcher=$!
+churn=""
+cleanup() {
+  kill "$churn" 2>/dev/null || true
+  kill "$watcher" 2>/dev/null || true
+}
+trap cleanup EXIT
+wait_until "grep -q '\"event\":\"started\"' watch.log"
+
+# a loop rewrites state.json ten times a second
+(
+  i=0
+  while :; do
+    i=$((i + 1))
+    echo "{\"n\":$i}" >~/.config/hypr/state.json
+    sleep 0.1
+  done
+) &
+churn=$!
+
+# the churning file is throttled: its interval grows past the base
+wait_until "[[ \$($throttled) -ge 8 ]]"
+assert_contains "cat watch.log" '"event":"throttled"'
+assert_contains "mise bootstrap dotfiles paths --noisy" "state.json"
+assert_contains "mise bootstrap dotfiles status" "throttled: ~/.config/hypr/state.json changes constantly"
+assert_contains "mise doctor 2>&1 || true" "state.json changes constantly"
+assert_not_contains "mise doctor 2>&1 || true" "warning"
+# never excluded, never switched to manual saving
+assert_not_contains "cat $MISE_CONFIG_DIR/config.toml" "exclude"
+assert_not_contains "cat $MISE_CONFIG_DIR/config.toml" "autosave"
+
+# an ordinary edit is still saved promptly while the churn goes on, and the
+# checkpoint it makes does not carry the churning file's live content (the
+# edit lands right after a save of the churning file, so its next save is a
+# whole interval away)
+captured="grep -c '\"event\":\"captured\"' watch.log"
+n="$(eval "$captured")"
+wait_until "[[ \$($captured) -gt $n ]]"
+churn_checkpoint="$(jq -r 'select(.event == "captured") | .uuid' watch.log | tail -1)"
+echo 'monitor=DP-2' >~/.config/hypr/monitors.lua
+wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description | test(\"monitors.lua\")'"
+# Pin the actual edit checkpoint: another scheduled save may become latest
+# while these assertions run. Compare snapshot contents, not display lines.
+monitor_checkpoint="$(jq -r 'select(.event == "captured" and (.description | contains("monitors.lua"))) | .uuid' watch.log | tail -1)"
+assert "$snapshot_of $monitor_checkpoint .config/hypr/state.json" "$($snapshot_of "$churn_checkpoint" .config/hypr/state.json)"
+
+# unsaved changes to the throttled file are visible as they happen
+wait_until "[[ \$(mise bootstrap dotfiles status --json | jq -r '.history.health.throttled[0].pending_changes // 0') -ge 1 ]]"
+
+# the throttling survives a restart of the watcher while the churn goes on:
+# the startup capture holds the throttled file at its saved version instead
+# of saving it early, and its pending changes are still reported
+kill -TERM "$watcher"
+wait "$watcher" || true
+assert_contains "cat $MISE_STATE_DIR/history/watch-schedule.json" "state.json"
+cp "$MISE_STATE_DIR/history/watch-schedule.json" schedule.saved
+saved_before="$($snapshot_of latest .config/hypr/state.json)"
+sleep 1.2
+mise bootstrap dotfiles watch --json >watch.log 2>&1 &
+watcher=$!
+wait_until "grep -q '\"event\":\"started\"' watch.log"
+assert "$snapshot_of latest .config/hypr/state.json" "$saved_before"
+assert "mise bootstrap dotfiles status --json | jq -r '.history.health.throttled | length'" "1"
+wait_until "[[ \$(mise bootstrap dotfiles status --json | jq -r '.history.health.throttled[0].pending_changes // 0') -ge 1 ]]"
+
+# excluding the churning file while it is throttled takes it out of the
+# schedule at once: no later capture holds it or carries its old version
+assert_succeed "mise bootstrap dotfiles exclude '~/.config/hypr/state.json'"
+wait_until "grep -q 'configuration changed' watch.log"
+wait_until "[[ \$(mise bootstrap dotfiles status --json | jq -r '.history.health.throttled | length') -eq 0 ]]"
+assert_not_contains "cat $MISE_STATE_DIR/history/watch-schedule.json" "state.json"
+echo 'monitor=DP-9' >~/.config/hypr/monitors.lua
+wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description | test(\"monitors.lua\")'"
+assert_not_contains "mise bootstrap dotfiles history show latest --files" "state.json"
+assert_succeed "mise bootstrap dotfiles include '~/.config/hypr/state.json'"
+wait_until "[[ \$($throttled) -ge 2 ]]"
+
+# a timing setting changed while running takes effect: the interval is
+# clamped to the new maximum
+sed -i.bak 's/max_interval = "8s"/max_interval = "2s"/' "$MISE_CONFIG_DIR/config.toml"
+wait_until "[[ \$($throttled) -le 2 ]]"
+
+# the churn stops: the final state is captured promptly
+kill "$churn"
+churn=""
+sleep 0.3
+final="$(cat ~/.config/hypr/state.json)"
+wait_until "mise bootstrap dotfiles history diff --path ~/.config/hypr/state.json --exit-code"
+# and nothing else is saved once everything is quiet
+n="$(eval "$count")"
+sleep 3
+assert "$count" "$n"
+
+# the target of a symlink inside a tracked directory is watched too, even
+# outside every declared root and with reconciliation off
+echo 'outside' >~/outside.conf
+ln -s ~/outside.conf ~/.config/hypr/link.conf
+wait_until "grep -q 'a tracked path appeared' watch.log"
+echo 'outside2' >~/outside.conf
+wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description | test(\"outside.conf\")'"
+
+# a capture deferred by a running history operation is retried once the
+# operation finished (nothing else could save it: reconciliation is off).
+# The operation is an apply whose pre-dotfiles hook holds the operation lock
+# for a while
+cat <<'EOF' >>"$MISE_CONFIG_DIR/config.toml"
+
+[bootstrap.hooks.pre-dotfiles]
+run = "date +%s%N >>$HOME/applying && sleep 4"
+EOF
+wait_until "grep -q 'configuration changed' watch.log"
+mise bootstrap dotfiles apply --yes >apply.log 2>&1 &
+applying=$!
+sleep 1
+echo 'monitor=DP-3' >~/.config/hypr/monitors.lua
+wait_until "grep -q '\"event\":\"deferred\"' watch.log"
+wait "$applying" || true
+
+wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description | test(\"monitors.lua\")'"
+
+# Replacing an anchor together with a config edit must reinstall the
+# retained path's watch, not keep a watch attached to its old inode.
+replans="$(grep -c 'configuration changed; watching' watch.log)"
+mv ~/.config/hypr ~/.config/hypr.old
+cp -R ~/.config/hypr.old ~/.config/hypr
+printf '\n# replan with a replaced root\n' >>"$MISE_CONFIG_DIR/config.toml"
+wait_until "[[ \$(grep -c 'configuration changed; watching' watch.log) -gt $replans ]]"
+echo 'monitor=replaced-root' >~/.config/hypr/monitors.lua
+wait_until "mise bootstrap dotfiles history diff --path ~/.config/hypr/monitors.lua --exit-code"
+
+kill -TERM "$watcher"
+wait "$watcher" || true
+assert "cat ~/.config/hypr/state.json" "$final"
+
+# `--once` reports that nothing was saved while an operation holds the lock
+# (the hook's marker says the lock is held; a slow start would let `--once`
+# run first)
+mise bootstrap dotfiles apply --yes >apply.log 2>&1 &
+applying=$!
+wait_until 'test "$(wc -l <~/applying)" -ge 2'
+assert_fail "mise bootstrap dotfiles watch --once --json 2>&1" '"reason":"deferred"'
+wait "$applying" || true
+
+# Stopped watcher diagnostics are historical, and a successful one-shot
+# capture clears old watch-installation degradation.
+health="$MISE_STATE_DIR/history/health.json"
+jq '.watcher.last_error = "old capture failure" | .watcher.consecutive_failures = 1 | .watcher.degraded = ["old watch unavailable"]' "$health" >health.updated
+mv health.updated "$health"
+assert_not_contains "mise doctor 2>&1 || true" "Edits since then are not protected"
+assert_not_contains "mise doctor 2>&1 || true" "Changes there are saved by reconciliation only"
+assert_succeed "mise bootstrap dotfiles watch --once --json"
+assert "jq '.watcher.degraded | length' $health" "0"
+assert "jq '.watcher.last_error // \"cleared\"' -r $health" "cleared"
+
+# Exclusions made while stopped prune the restored schedule before even
+# a one-shot startup capture can carry the excluded file forward.
+assert_succeed "mise bootstrap dotfiles exclude '~/.config/hypr/state.json'"
+cp schedule.saved "$MISE_STATE_DIR/history/watch-schedule.json"
+assert_succeed "mise bootstrap dotfiles watch --once --json"
+assert_not_contains "cat $MISE_STATE_DIR/history/watch-schedule.json" "state.json"
+latest_uuid="$(mise bootstrap dotfiles history show latest --json | jq -r .uuid)"
+assert_not_contains "git --git-dir=$repo ls-tree -r --name-only $latest_uuid" "state.json"

--- a/e2e/cli/test_dotfiles_watch_throttle
+++ b/e2e/cli/test_dotfiles_watch_throttle
@@ -157,11 +157,13 @@ n="$(eval "$count")"
 sleep 3
 assert "$count" "$n"
 
-# the target of a symlink inside a tracked directory is watched too, even
-# outside every declared root and with reconciliation off
+# A symlink records only the link. Its target needs explicit enrollment.
 echo 'outside' >~/outside.conf
 ln -s ~/outside.conf ~/.config/hypr/link.conf
 wait_until "grep -q 'a tracked path appeared' watch.log"
+wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description | test(\"link.conf\")'"
+assert_not_contains "mise bootstrap dotfiles history show latest --files" "outside.conf"
+assert_succeed "mise bootstrap dotfiles track ~/outside.conf"
 echo 'outside2' >~/outside.conf
 wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description | test(\"outside.conf\")'"
 

--- a/e2e/cli/test_dotfiles_watch_throttle
+++ b/e2e/cli/test_dotfiles_watch_throttle
@@ -131,8 +131,9 @@ wait_until "[[ \$(mise bootstrap dotfiles status --json | jq -r '.history.health
 
 # excluding the churning file while it is throttled takes it out of the
 # schedule at once: no later capture holds it or carries its old version
+replans="$(grep -c 'configuration changed; watching' watch.log || true)"
 assert_succeed "mise bootstrap dotfiles exclude '~/.config/hypr/state.json'"
-wait_until "grep -q 'configuration changed' watch.log"
+wait_until "[[ \$(grep -c 'configuration changed; watching' watch.log) -gt $replans ]]"
 wait_until "[[ \$(mise bootstrap dotfiles status --json | jq -r '.history.health.throttled | length') -eq 0 ]]"
 assert_not_contains "cat $MISE_STATE_DIR/history/watch-schedule.json" "state.json"
 echo 'monitor=DP-9' >~/.config/hypr/monitors.lua
@@ -173,12 +174,13 @@ wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description | t
 # case the watcher correctly finds nothing more to commit.
 # The operation is an apply whose pre-dotfiles hook holds the operation lock
 # for a while
+replans="$(grep -c 'configuration changed; watching' watch.log || true)"
 cat <<'EOF' >>"$MISE_CONFIG_DIR/config.toml"
 
 [bootstrap.hooks.pre-dotfiles]
 run = "date +%s%N >>$HOME/applying && sleep 4"
 EOF
-wait_until "grep -q 'configuration changed' watch.log"
+wait_until "[[ \$(grep -c 'configuration changed; watching' watch.log) -gt $replans ]]"
 mise bootstrap dotfiles apply --yes >apply.log 2>&1 &
 applying=$!
 wait_until 'test -s ~/applying'

--- a/e2e/cli/test_dotfiles_watch_throttle
+++ b/e2e/cli/test_dotfiles_watch_throttle
@@ -167,8 +167,9 @@ assert_succeed "mise bootstrap dotfiles track ~/outside.conf"
 echo 'outside2' >~/outside.conf
 wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description | test(\"outside.conf\")'"
 
-# a capture deferred by a running history operation is retried once the
-# operation finished (nothing else could save it: reconciliation is off).
+# A capture deferred by a running history operation is retried once the
+# operation finishes. Its after boundary may already save the edit, in which
+# case the watcher correctly finds nothing more to commit.
 # The operation is an apply whose pre-dotfiles hook holds the operation lock
 # for a while
 cat <<'EOF' >>"$MISE_CONFIG_DIR/config.toml"
@@ -184,7 +185,8 @@ echo 'monitor=DP-3' >~/.config/hypr/monitors.lua
 wait_until "grep -q '\"event\":\"deferred\"' watch.log"
 wait "$applying" || true
 
-wait_until "mise bootstrap dotfiles history --json | jq -e '.[0].description | test(\"monitors.lua\")'"
+wait_until "mise bootstrap dotfiles history diff --path ~/.config/hypr/monitors.lua --exit-code"
+assert "$snapshot_of latest .config/hypr/monitors.lua" "monitor=DP-3"
 
 # Replacing an anchor together with a config edit must reinstall the
 # retained path's watch, not keep a watch attached to its old inode.

--- a/e2e/config/test_schema_dotfiles_encryption
+++ b/e2e/config/test_schema_dotfiles_encryption
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+TOMBI_VERSION="0.9.22"
+mise use -g tombi@$TOMBI_VERSION
+TOMBI_LINT="mise x tombi@$TOMBI_VERSION -- tombi lint --offline --no-cache --error-on-warnings --quiet"
+cat >"$HOME/tombi.toml" <<TOML
+[schema]
+enabled = true
+strict = true
+[[schemas]]
+path = "file://$ROOT/schema/mise.json"
+include = ["encrypted-valid.toml", "encrypted-invalid.toml"]
+TOML
+cat >encrypted-valid.toml <<'TOML'
+[history.encryption]
+recipients = ["public-recipient"]
+[dotfiles]
+"~/.app" = { mode = "template", source = "secret.tera", encrypt = true }
+TOML
+assert_succeed "$TOMBI_LINT encrypted-valid.toml"
+for field in content block line template; do
+  printf '[dotfiles]\n"~/.app" = { %s = "inline", encrypt = false }\n' "$field" >encrypted-valid.toml
+  assert_succeed "$TOMBI_LINT encrypted-valid.toml"
+  printf '[dotfiles]\n"~/.app" = { %s = "inline", encrypt = true }\n' "$field" >encrypted-invalid.toml
+  assert_fail "$TOMBI_LINT encrypted-invalid.toml"
+done

--- a/e2e/run_test
+++ b/e2e/run_test
@@ -105,6 +105,7 @@ within_isolated_env() {
         LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE:-}" \
         ${proxy_vars[@]+"${proxy_vars[@]}"} \
         MISE_CACHE_DIR="$MISE_CACHE_DIR" \
+        MISE_HISTORY_NOTIFY=0 \
         MISE_URL_REPLACEMENTS="${MISE_URL_REPLACEMENTS:-}" \
         MISE_CACHE_PRUNE_AGE="0" \
         MISE_CONFIG_DIR="$MISE_CONFIG_DIR" \


### PR DESCRIPTION
## Summary
Acceptance-test layer on #12918 for the replacement dotfiles stack.

Cover explicit enrollment without implicit configuration/source capture; ordinary commits and delayed publication; two-machine fast-forward and divergent synchronization; whole-setup conflict pauses and stale-plan protection; rollback, undo, command boundaries and interrupted writes; shared encryption before Git storage and historical plaintext rejection; directory permissions; watcher throttling; and fresh-machine/remote bootstrap. Include Windows coverage and macOS CI execution.

## Verification
Repository lint-fix, including shell formatting/checks and cargo check, passed before commit. Focused tests already passing on the integration branch include history, explicit tracking, onboarding, manual-save policies, ordinary two-machine sync, rollback, crash recovery, encrypted sync/diff/restore, and directory permissions.

The broader sweep is still running. Fixture corrections for explicit enrollment and credential exclusions are included; a watcher configuration-reload fix is being verified in the parent PR. CI and review feedback will be addressed across both PRs before declaring the stack settled.

This replaces the acceptance portions of the old unreleased stack. No migration from disposable development stores is provided. Do not merge until the complete stack is validated.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to e2e tests, Windows Pester suites, and CI job steps; no production code paths are modified in this diff.
> 
> **Overview**
> Adds a broad **acceptance-test layer** for the replacement bootstrap dotfiles/history stack: explicit tracking, ordinary Git commits, sync/onboarding, capture and rollback, encryption, permissions, watchers, user services, and `--from-git` / remote bootstrap flows.
> 
> **CI and harness:** macOS runners now execute a filtered subset of dotfiles e2e scripts (git/Xcode-dependent history cases). The shared e2e runner sets `MISE_HISTORY_NOTIFY=0` to avoid desktop notification noise. **Windows** gains new Pester suites for dotfiles apply/history ACLs, `dotfiles watch`, and bootstrap user services (scheduled tasks).
> 
> **Existing tests extended:** `test_bootstrap_from` asserts checkout reuse does not inflate history checkpoints and that `--update` does; tombi schema lint covers `history.encryption` + dotfile `encrypt` rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110a220d20591a6f7869a1f998d1ef68c8c29f0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for dotfile tracking, capture, history, synchronization, onboarding, rollback, recovery, encryption, permissions, and watcher behavior.
  * Added cross-machine and cross-platform coverage, including Windows service lifecycles and macOS workflows.
  * Added validation for Git-based, remote, and HTTP bootstrap, conflict handling, template preflight, and permission preservation.
  * Verified encrypted content protection, service configuration validation, and safe recovery after interruptions.
  * Confirmed stable operation without experimental flags and rejection of unsupported backup-related commands and options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->