### PR TITLE
fix(activate): forward PowerShell pipeline input

### DIFF
--- a/e2e-win/activate_pipeline.Tests.ps1
+++ b/e2e-win/activate_pipeline.Tests.ps1
@@ -5,7 +5,10 @@ Describe 'mise activate pwsh pipeline input' {
         $config = Join-Path $TestDrive 'mise.toml'
         $reader = Join-Path $TestDrive 'read-stdin.ps1'
 
-        '[Console]::In.ReadToEnd()' | Set-Content $reader
+        @(
+            '[Console]::In.ReadToEnd()'
+            "`$args -join '|'"
+        ) | Set-Content $reader
         @(
             '[tasks.read-stdin]'
             "run = 'pwsh -NoProfile -File `"$reader`"'"
@@ -27,10 +30,11 @@ Describe 'mise activate pwsh pipeline input' {
     }
 
     It 'forwards pipeline input to a task' {
-        $output = 'data' | mise run read-stdin 2>&1 | Out-String
+        $output = @('alpha', 'beta') | mise run read-stdin -pipelineInput value 2>&1 | Out-String
 
         $LASTEXITCODE | Should -BeExactly 0
-        $output | Should -Match '(?m)^\uFEFF?data\r?$'
+        $output | Should -Match '(?m)^\uFEFF?alpha\r?\nbeta\r?$'
+        $output | Should -Match '(?m)^-pipelineInput\|value\r?$'
         $output | Should -Not -Match 'cannot be bound to any parameters'
     }
 }

--- a/e2e-win/activate_pipeline.Tests.ps1
+++ b/e2e-win/activate_pipeline.Tests.ps1
@@ -33,7 +33,7 @@ Describe 'mise activate pwsh pipeline input' {
         $output = @('alpha', 'beta') | mise run read-stdin -pipelineInput value 2>&1 | Out-String
 
         $LASTEXITCODE | Should -BeExactly 0
-        $output | Should -Match '(?m)^\uFEFF?alpha\r?\nbeta\r?$'
+        $output | Should -Match '(?m)^alpha\r?\nbeta\r?$'
         $output | Should -Match '(?m)^-pipelineInput\|value\r?$'
         $output | Should -Not -Match 'cannot be bound to any parameters'
     }

--- a/e2e-win/activate_pipeline.Tests.ps1
+++ b/e2e-win/activate_pipeline.Tests.ps1
@@ -8,6 +8,8 @@ Describe 'mise activate pwsh pipeline input' {
         @(
             '[Console]::In.ReadToEnd()'
             "`$args -join '|'"
+            '$nativePath = & cmd.exe /d /c ''echo %PATH%'''
+            '"native-path=$nativePath"'
         ) | Set-Content $reader
         @(
             '[tasks.read-stdin]'
@@ -35,6 +37,7 @@ Describe 'mise activate pwsh pipeline input' {
         $LASTEXITCODE | Should -BeExactly 0
         $output | Should -Match '(?m)^alpha\r?\nbeta\r?$'
         $output | Should -Match '(?m)^-pipelineInput\|value\r?$'
+        $output | Should -Match '(?m)^native-path=[^\r\n]*;[^\r\n]*\r?$'
         $output | Should -Not -Match 'cannot be bound to any parameters'
     }
 }

--- a/e2e-win/activate_pipeline.Tests.ps1
+++ b/e2e-win/activate_pipeline.Tests.ps1
@@ -1,0 +1,36 @@
+Describe 'mise activate pwsh pipeline input' {
+    BeforeAll {
+        $originalPath = $PWD
+        $originalMiseConfigFile = [Environment]::GetEnvironmentVariable('MISE_CONFIG_FILE', 'Process')
+        $config = Join-Path $TestDrive 'mise.toml'
+        $reader = Join-Path $TestDrive 'read-stdin.ps1'
+
+        '[Console]::In.ReadToEnd()' | Set-Content $reader
+        @(
+            '[tasks.read-stdin]'
+            "run = 'pwsh -NoProfile -File `"$reader`"'"
+        ) | Set-Content $config
+
+        Set-Location TestDrive:
+        $env:MISE_CONFIG_FILE = $config
+        mise activate pwsh | Out-String | Invoke-Expression
+    }
+
+    AfterAll {
+        mise deactivate
+        Set-Location $originalPath
+        if ($null -eq $originalMiseConfigFile) {
+            Remove-Item Env:MISE_CONFIG_FILE -ErrorAction SilentlyContinue
+        } else {
+            $env:MISE_CONFIG_FILE = $originalMiseConfigFile
+        }
+    }
+
+    It 'forwards pipeline input to a task' {
+        $output = 'data' | mise run read-stdin 2>&1 | Out-String
+
+        $LASTEXITCODE | Should -BeExactly 0
+        $output | Should -Match '(?m)^\uFEFF?data\r?$'
+        $output | Should -Not -Match 'cannot be bound to any parameters'
+    }
+}

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -38,7 +38,7 @@ impl Shell for Pwsh {
 
                 $previous_out_encoding = $OutputEncoding
                 $previous_console_out_encoding = [Console]::OutputEncoding
-                $OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
+                $OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
 
                 function _reset_output_encoding {{
                     $OutputEncoding = $previous_out_encoding

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -34,13 +34,7 @@ impl Shell for Pwsh {
             }}
 
             function mise {{
-                [CmdletBinding(PositionalBinding=$false)]
-                param(
-                    [Parameter(ValueFromPipeline=$true)]
-                    [object] $pipelineInput,
-                    [Parameter(ValueFromRemainingArguments=$true, Position=0)]  # Allow any number of arguments, including none
-                    [string[]] $arguments = @()  # defaults to an empty array: a bare `mise` binds $null, which Set-StrictMode rejects on .count
-                )
+                $arguments = $args
 
                 $previous_out_encoding = $OutputEncoding
                 $previous_console_out_encoding = [Console]::OutputEncoding

--- a/src/shell/pwsh.rs
+++ b/src/shell/pwsh.rs
@@ -34,9 +34,11 @@ impl Shell for Pwsh {
             }}
 
             function mise {{
-                [CmdletBinding()]
+                [CmdletBinding(PositionalBinding=$false)]
                 param(
-                    [Parameter(ValueFromRemainingArguments=$true)]  # Allow any number of arguments, including none
+                    [Parameter(ValueFromPipeline=$true)]
+                    [object] $pipelineInput,
+                    [Parameter(ValueFromRemainingArguments=$true, Position=0)]  # Allow any number of arguments, including none
                     [string[]] $arguments = @()  # defaults to an empty array: a bare `mise` binds $null, which Set-StrictMode rejects on .count
                 )
 
@@ -50,11 +52,19 @@ impl Shell for Pwsh {
                 }}
 
                 if ($arguments.count -eq 0) {{
-                    & '{exe}'
+                    if ($MyInvocation.ExpectingInput) {{
+                        $input | & '{exe}'
+                    }} else {{
+                        & '{exe}'
+                    }}
                     _reset_output_encoding
                     return
                 }} elseif ($arguments -contains '-h' -or $arguments -contains '--help') {{
-                    & '{exe}' @arguments
+                    if ($MyInvocation.ExpectingInput) {{
+                        $input | & '{exe}' @arguments
+                    }} else {{
+                        & '{exe}' @arguments
+                    }}
                     _reset_output_encoding
                     return
                 }}
@@ -68,11 +78,19 @@ impl Shell for Pwsh {
 
                 switch ($command) {{
                     {{ $_ -in 'deactivate', 'shell', 'sh' }} {{
-                        & '{exe}' $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
+                        if ($MyInvocation.ExpectingInput) {{
+                            $input | & '{exe}' $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
+                        }} else {{
+                            & '{exe}' $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
+                        }}
                         _reset_output_encoding
                     }}
                     default {{
-                        & '{exe}' $command @remainingArgs
+                        if ($MyInvocation.ExpectingInput) {{
+                            $input | & '{exe}' $command @remainingArgs
+                        }} else {{
+                            & '{exe}' $command @remainingArgs
+                        }}
                         if ($(Test-Path -Path Function:\_mise_hook)){{
                             _mise_hook
                         }}

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -12,7 +12,7 @@ function mise {
 
     $previous_out_encoding = $OutputEncoding
     $previous_console_out_encoding = [Console]::OutputEncoding
-    $OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
+    $OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
 
     function _reset_output_encoding {
         $OutputEncoding = $previous_out_encoding

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -8,9 +8,11 @@ if (-not (Test-Path -Path Env:/__MISE_ORIG_PATH)) {
 }
 
 function mise {
-    [CmdletBinding()]
+    [CmdletBinding(PositionalBinding=$false)]
     param(
-        [Parameter(ValueFromRemainingArguments=$true)]  # Allow any number of arguments, including none
+        [Parameter(ValueFromPipeline=$true)]
+        [object] $pipelineInput,
+        [Parameter(ValueFromRemainingArguments=$true, Position=0)]  # Allow any number of arguments, including none
         [string[]] $arguments = @()  # defaults to an empty array: a bare `mise` binds $null, which Set-StrictMode rejects on .count
     )
 
@@ -24,11 +26,19 @@ function mise {
     }
 
     if ($arguments.count -eq 0) {
-        & '/some/dir/mise'
+        if ($MyInvocation.ExpectingInput) {
+            $input | & '/some/dir/mise'
+        } else {
+            & '/some/dir/mise'
+        }
         _reset_output_encoding
         return
     } elseif ($arguments -contains '-h' -or $arguments -contains '--help') {
-        & '/some/dir/mise' @arguments
+        if ($MyInvocation.ExpectingInput) {
+            $input | & '/some/dir/mise' @arguments
+        } else {
+            & '/some/dir/mise' @arguments
+        }
         _reset_output_encoding
         return
     }
@@ -42,11 +52,19 @@ function mise {
 
     switch ($command) {
         { $_ -in 'deactivate', 'shell', 'sh' } {
-            & '/some/dir/mise' $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
+            if ($MyInvocation.ExpectingInput) {
+                $input | & '/some/dir/mise' $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
+            } else {
+                & '/some/dir/mise' $command @remainingArgs | Out-String | Invoke-Expression -ErrorAction SilentlyContinue
+            }
             _reset_output_encoding
         }
         default {
-            & '/some/dir/mise' $command @remainingArgs
+            if ($MyInvocation.ExpectingInput) {
+                $input | & '/some/dir/mise' $command @remainingArgs
+            } else {
+                & '/some/dir/mise' $command @remainingArgs
+            }
             if ($(Test-Path -Path Function:\_mise_hook)){
                 _mise_hook
             }

--- a/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
+++ b/src/shell/snapshots/mise__shell__pwsh__tests__activate.snap
@@ -8,13 +8,7 @@ if (-not (Test-Path -Path Env:/__MISE_ORIG_PATH)) {
 }
 
 function mise {
-    [CmdletBinding(PositionalBinding=$false)]
-    param(
-        [Parameter(ValueFromPipeline=$true)]
-        [object] $pipelineInput,
-        [Parameter(ValueFromRemainingArguments=$true, Position=0)]  # Allow any number of arguments, including none
-        [string[]] $arguments = @()  # defaults to an empty array: a bare `mise` binds $null, which Set-StrictMode rejects on .count
-    )
+    $arguments = $args
 
     $previous_out_encoding = $OutputEncoding
     $previous_console_out_encoding = [Console]::OutputEncoding


### PR DESCRIPTION
## Summary

- allow the PowerShell activation function to bind pipeline objects without consuming positional mise arguments
- forward stdin only when the function is actually receiving pipeline input, preserving interactive stdin otherwise
- add a Windows Pester regression test that pipes data through `mise run`

Addresses the bug reported in [discussion #12922](https://github.com/jdx/mise/discussions/12922).

## Testing

- `INSTA_UPDATE=always mise run test:unit shell::pwsh::tests::test_activate`
- `mise run lint-fix`
- parsed `e2e-win/activate_pipeline.Tests.ps1` with the PowerShell parser
- manually verified activated PowerShell 7.6.5 forwards a two-line pipeline through `mise run` and preserves non-pipeline invocation

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the PowerShell activation wrapper used on every `mise` invocation in pwsh; behavior change is gated on pipeline input but affects all command paths (run, help, shell/deactivate).
> 
> **Overview**
> Fixes PowerShell activation so **piped input** (e.g. `@('a','b') | mise run task`) reaches mise tasks without parameter-binding errors.
> 
> The generated `mise` wrapper **drops** `[CmdletBinding]` / `ValueFromRemainingArguments` in favor of `$arguments = $args`, and **pipes `$input` into the real binary only when** `$MyInvocation.ExpectingInput` is true—so interactive stdin and normal CLI args stay unchanged. Output encoding is set via `[Text.UTF8Encoding]::new($false)` instead of the previous UTF8 constructor.
> 
> Adds a **Windows Pester e2e** that pipes two lines through `mise run` and asserts stdin, forwarded flags, and PATH behavior; the activate snapshot is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d73741e89618e5c344902904b01450f9ea62c031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PowerShell commands now support forwarding piped input to mise tasks while preserving command-line arguments.

- **Bug Fixes**
  - Fixed PowerShell activation behavior so pipeline data is passed through correctly across supported command modes.
  - Improved PowerShell output encoding for more consistent UTF-8 handling.

- **Tests**
  - Added end-to-end coverage verifying that multiple pipeline lines and forwarded arguments reach tasks successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->