### PR TITLE
feat(activate): add an explicit tool shims opt-out

### DIFF
--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -182,13 +182,9 @@ To explicitly keep tool shims out of full shell activation, including when auto-
 lazy tools are enabled, run `mise settings set activate_shims false` and restart your shell.
 See [`activate_shims`](/configuration/settings.html#activate_shims) for the tradeoffs.
 Shims serve several purposes: installing missing configured versions, bootstrapping lazy tools,
-and dispatching configured command wrappers. Wrappers such as `cargo` through mr-boxington
+and dispatching configured command wrappers. Wrappers such as `cargo` through [mr-boxington](https://github.com/jdx/mr-boxington)
 use their own `command-wrappers/bin` directory, which remains active with this setting disabled.
 Explicit `mise activate --shims` also continues to work.
-
-If shims cause unexpected command resolution, please report the command, expected and actual
-executable, and `mise doctor` output. The opt-out is available, but the underlying resolution
-problem should still be investigated and fixed.
 
 ::: info
 When a shim cannot resolve a mise-managed tool (for example, a version pinned in `mise.toml` that hasn't

--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -178,6 +178,18 @@ explicit `lazy = true` declaration.
 
 :::
 
+To explicitly keep tool shims out of full shell activation, including when auto-install or
+lazy tools are enabled, run `mise settings set activate_shims false` and restart your shell.
+See [`activate_shims`](/configuration/settings.html#activate_shims) for the tradeoffs.
+Shims serve several purposes: installing missing configured versions, bootstrapping lazy tools,
+and dispatching configured command wrappers. Wrappers such as `cargo` through mr-boxington
+use their own `command-wrappers/bin` directory, which remains active with this setting disabled.
+Explicit `mise activate --shims` also continues to work.
+
+If shims cause unexpected command resolution, please report the command, expected and actual
+executable, and `mise doctor` output. The opt-out is available, but the underlying resolution
+problem should still be investigated and fixed.
+
 ::: info
 When a shim cannot resolve a mise-managed tool (for example, a version pinned in `mise.toml` that hasn't
 been installed and [`not_found_auto_install`](/configuration/settings.html#not_found_auto_install) is

--- a/e2e/cli/test_command_wrappers
+++ b/e2e/cli/test_command_wrappers
@@ -32,6 +32,17 @@ system-cargo"
 assert "cargo check" "mbx:1
 system-cargo"
 
+# Disabling tool shim activation preserves configured wrappers.
+export MISE_ACTIVATE_SHIMS=false
+eval "$(mise activate bash --no-hook-env)"
+eval "$(mise hook-env -s bash --force)"
+case ":$PATH:" in
+  *":$MISE_DATA_DIR/shims:"*) exit 1 ;;
+esac
+assert "cargo check" "mbx:1
+system-cargo"
+unset MISE_ACTIVATE_SHIMS
+
 mise install dummy@1.0.0
 managed_bin="$MISE_DATA_DIR/installs/dummy/1.0.0/bin"
 cat >"$managed_bin/cargo" <<'EOF'

--- a/e2e/shell/test_shims_activation_conditional
+++ b/e2e/shell/test_shims_activation_conditional
@@ -60,3 +60,38 @@ not_found_auto_install = true
 EOF
 eval "$(mise hook-env --force --shell bash)"
 assert_shims_present
+
+# The explicit opt-out overrides auto-install and lazy declarations, and removes both farms.
+mkdir -p "$MISE_SYSTEM_SHIMS_DIR"
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[settings]
+activate_shims = false
+not_found_auto_install = true
+
+[tools]
+dummy = { version = "1.0.0", lazy = true, lazy_bins = ["dummy"] }
+EOF
+export PATH="$MISE_SYSTEM_SHIMS_DIR:$PATH"
+eval "$(mise activate bash --no-hook-env)"
+assert_shims_absent
+case ":$PATH:" in
+  *":$MISE_SYSTEM_SHIMS_DIR:"*) exit 1 ;;
+esac
+eval "$(mise hook-env --force --shell bash)"
+assert_shims_absent
+case ":$PATH:" in
+  *":$MISE_SYSTEM_SHIMS_DIR:"*) exit 1 ;;
+esac
+
+# Fish activation and its subsequent hook honor the same setting.
+assert "fish -c 'mise activate fish | source; mise hook-env --force --shell fish | source; contains -- \"\$MISE_SHIMS_DIR\" \$PATH; echo \$status'" "1"
+
+# Explicit shim-only activation still means what it says.
+eval "$(mise activate bash --shims)"
+assert_shims_present
+
+# An environment override can re-enable normal activation without editing config.
+export MISE_ACTIVATE_SHIMS=true
+eval "$(mise hook-env --force --shell bash)"
+assert_shims_present
+unset MISE_ACTIVATE_SHIMS

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -521,6 +521,11 @@
           "description": "Pushes tools' bin-paths to the front of PATH instead of allowing modifications of PATH after activation to take precedence.",
           "type": "boolean"
         },
+        "activate_shims": {
+          "default": true,
+          "description": "Allow full shell activation to add tool shims to PATH.",
+          "type": "boolean"
+        },
         "age": {
           "type": "object",
           "unevaluatedProperties": false,

--- a/settings.toml
+++ b/settings.toml
@@ -48,13 +48,9 @@ Shims support missing-version auto-installation and first-use installation of la
 Disabling them can prevent these commands from being found; use `mise install` or `mise exec`
 explicitly instead. Installed tools still get their real bin directories added to `PATH`.
 
-Configured command wrappers, such as `cargo` through mr-boxington, use a separate
+Configured command wrappers, such as `cargo` through [mr-boxington](https://github.com/jdx/mr-boxington), use a separate
 `command-wrappers/bin` directory and remain active. Explicit `mise activate --shims` also
 continues to add shims regardless of this setting.
-
-Unexpected command resolution with shims enabled should be reported with a concrete command,
-the expected and actual executable, and `mise doctor` output so the underlying problem can
-be fixed.
 """
 env = "MISE_ACTIVATE_SHIMS"
 type = "Bool"

--- a/settings.toml
+++ b/settings.toml
@@ -29,6 +29,36 @@ In that case, using this example again, `/some/other/python` will be after mise'
 env = "MISE_ACTIVATE_AGGRESSIVE"
 type = "Bool"
 
+[activate_shims]
+default = true
+description = "Allow full shell activation to add tool shims to PATH."
+docs = """
+Set to false to keep the user and system tool shim directories out of `PATH` during
+`mise activate` and subsequent shell hooks, even when automatic installation or lazy tools
+would otherwise add them:
+
+```sh
+mise settings set activate_shims false
+```
+
+Restart your shell after changing this setting. For an environment-variable override, set
+`MISE_ACTIVATE_SHIMS=false` before running `mise activate`.
+
+Shims support missing-version auto-installation and first-use installation of lazy tools.
+Disabling them can prevent these commands from being found; use `mise install` or `mise exec`
+explicitly instead. Installed tools still get their real bin directories added to `PATH`.
+
+Configured command wrappers, such as `cargo` through mr-boxington, use a separate
+`command-wrappers/bin` directory and remain active. Explicit `mise activate --shims` also
+continues to add shims regardless of this setting.
+
+Unexpected command resolution with shims enabled should be reported with a concrete command,
+the expected and actual executable, and `mise doctor` output so the underlying problem can
+be fixed.
+"""
+env = "MISE_ACTIVATE_SHIMS"
+type = "Bool"
+
 [age.identity_files]
 description = "[experimental] List of age identity files to use for decryption."
 env = "MISE_AGE_IDENTITY_FILES"

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -173,11 +173,12 @@ impl Activate {
                 path.to_string_lossy().to_string(),
             ));
         }
-        let shim_path_update = if Settings::get().not_found_auto_install {
-            position_shims_before_path()?
-        } else {
-            remove_shims_from_path()?
-        };
+        let shim_path_update =
+            if Settings::get().activate_shims && Settings::get().not_found_auto_install {
+                position_shims_before_path()?
+            } else {
+                remove_shims_from_path()?
+            };
         if let Some(set_path) = shim_path_update {
             prelude.push(set_path);
         }

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -194,7 +194,8 @@ impl HookEnv {
             .chain(env_watch_files.iter().map(|p| p.as_path().into()))
             .collect();
 
-        let retain_shims = Settings::get().not_found_auto_install || ts.has_lazy_declarations();
+        let retain_shims = Settings::get().activate_shims
+            && (Settings::get().not_found_auto_install || ts.has_lazy_declarations());
         patches.extend(self.build_path_operations(
             &user_paths,
             &tool_paths,


### PR DESCRIPTION
Full activation uses shims for missing configured versions and lazy tool bootstrap, but there is no independent way to keep the tool shim directories off PATH while leaving those settings alone. Add `activate_shims = false` (`MISE_ACTIVATE_SHIMS=false`) to remove user and system tool shim directories during activation and subsequent shell hooks. The default remains unchanged.

Configured command wrappers such as cargo through [mr-boxington](https://github.com/jdx/mr-boxington) keep their separate `command-wrappers/bin` dispatch directory. Explicit `mise activate --shims` also remains explicit opt-in. Document these uses and the tradeoffs of disabling tool shims.

Related to https://github.com/jdx/mise/discussions/12924.

Validation:
- `mise run --skip-deps test:e2e e2e/shell/test_shims_activation_conditional e2e/cli/test_command_wrappers` (after the full build passed).
- `mise run build`.
- `mise run lint-fix`.
- `mise run render:schema`.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when shim farms appear on PATH during activation and hooks, which can affect lazy bootstrap and missing-version auto-install unless users use `mise install`/`mise exec`; default remains enabled and explicit `--shims` is preserved.
> 
> **Overview**
> Adds **`activate_shims`** (default **`true`**, override **`MISE_ACTIVATE_SHIMS`**) so full shell activation and **`hook-env`** can keep user and system **tool** shim directories off **`PATH`** even when **`not_found_auto_install`** or lazy tools would normally retain them.
> 
> **`mise activate`** only prepends shims when both **`activate_shims`** and **`not_found_auto_install`** are enabled; **`hook-env`** applies the same gate before retaining shims for auto-install or lazy declarations. Installed tool bin paths are unchanged.
> 
> **`mise activate --shims`** and **`command-wrappers/bin`** (e.g. mr-boxington **`cargo`**) stay active when shims are disabled. Docs, JSON schema, and e2e tests cover Fish, env override, and wrapper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f379e0c5baf3db84d91c08e4b7c5f1019e5e32f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `activate_shims` setting, enabled by default, to control whether shell activation adds tool shims to `PATH`.
  - Added support for the `MISE_ACTIVATE_SHIMS` environment variable to override this setting.
  - Explicit shim activation remains available when automatic activation is disabled.
  - Configured command wrappers continue working without shim directories in `PATH`.

- **Documentation**
  - Added guidance on disabling shim activation and its effects on lazy tools and automatic installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->