### PR TITLE
fix(backend): exclude disabled plugins from shorthand resolution

### DIFF
--- a/docs/dev-tools/backend_architecture.md
+++ b/docs/dev-tools/backend_architecture.md
@@ -159,8 +159,8 @@ Use the global settings file to prevent installation through selected backends:
 disable_backends = ["asdf", "vfox"]
 ```
 
-This is an installation restriction, not an uninstall operation. Existing tools
-can still report the backend that installed them.
+Disabled backends are excluded from tool resolution and new installs. Existing
+installations are left on disk and become available again if the backend is re-enabled.
 
 ### Force Backend for Tool
 

--- a/e2e/backend/test_disable_backends
+++ b/e2e/backend/test_disable_backends
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 export MISE_EXPERIMENTAL=1
 
+detect_platform
+
 assert_fail "MISE_DISABLE_BACKENDS=ubi mise install ubi:example/example@1.0.0" "backend ubi is disabled by disable_backends"
 assert_fail "MISE_DISABLE_BACKENDS=ubi mise use -g ubi:example/example@1.0.0" "backend ubi is disabled by disable_backends"
 assert_fail "MISE_DISABLE_BACKENDS=asdf mise install asdf:dummy@1.0.0" "backend asdf is disabled by disable_backends"
@@ -11,12 +13,23 @@ mise install age
 assert_fail "ls $MISE_DATA_DIR/plugins/age"
 mise uninstall age
 
-MISE_DISABLE_BACKENDS=aqua mise install age
+MISE_DISABLE_BACKENDS=aqua mise install age@1.2.1
 ls "$MISE_DATA_DIR/plugins/age"
-assert "MISE_DISABLE_BACKENDS=asdf mise tool age --backend" "asdf:age"
+assert "MISE_DISABLE_BACKENDS=asdf mise tool age --backend" "aqua:FiloSottile/age"
 eval "$(mise activate bash)" && _mise_hook
 assert_contains "MISE_DISABLE_BACKENDS=asdf mise doctor 2>&1 || true" "age"
 assert_contains "MISE_DISABLE_BACKENDS=asdf mise doctor -J 2>&1 || true" '"age"'
+
+# a disabled plugin never overrides an enabled registry backend, even when the requested
+# version was installed through that plugin
+cat <<EOF >mise.toml
+[tools]
+age = "1.2.1"
+EOF
+assert "MISE_DISABLE_BACKENDS=asdf mise tool age --backend" "aqua:FiloSottile/age"
+MISE_DISABLE_BACKENDS=asdf mise install --dry-run
+MISE_DISABLE_BACKENDS=asdf mise lock --platform "$MISE_PLATFORM"
+assert_contains "cat mise.lock" 'backend = "aqua:FiloSottile/age"'
 
 # the backends section marks disabled backends instead of listing them as if enabled
 assert_contains "MISE_DISABLE_BACKENDS=asdf,vfox mise doctor 2>&1 || true" "asdf (disabled)"

--- a/e2e/cli/test_settings_ls
+++ b/e2e/cli/test_settings_ls
@@ -30,7 +30,7 @@ assert_contains "mise settings --json-extended" "{
       \"java\"
     ],
     \"type\": \"array\",
-    \"description\": \"Backends to disable for new installs, such as \`asdf\`, \`pipx\`, or a vfox-backend plugin name. This does not uninstall or disable tools already installed with those backends.\",
+    \"description\": \"Backends to exclude from tool resolution and new installs, such as \`asdf\`, \`pipx\`, or a vfox-backend plugin name. Existing installations are left on disk and become available again if the backend is re-enabled.\",
     \"source\": \"$HOME/workdir/mise.toml\"
   }
 }"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -740,7 +740,7 @@
         },
         "disable_backends": {
           "default": [],
-          "description": "Backends to disable for new installs, such as `asdf`, `pipx`, or a vfox-backend plugin name. This does not uninstall or disable tools already installed with those backends.",
+          "description": "Backends to exclude from tool resolution and new installs, such as `asdf`, `pipx`, or a vfox-backend plugin name. Existing installations are left on disk and become available again if the backend is re-enabled.",
           "type": "array",
           "items": {
             "type": "string"

--- a/settings.toml
+++ b/settings.toml
@@ -506,7 +506,7 @@ type = "String"
 
 [disable_backends]
 default = []
-description = "Backends to disable for new installs, such as `asdf`, `pipx`, or a vfox-backend plugin name. This does not uninstall or disable tools already installed with those backends."
+description = "Backends to exclude from tool resolution and new installs, such as `asdf`, `pipx`, or a vfox-backend plugin name. Existing installations are left on disk and become available again if the backend is re-enabled."
 env = "MISE_DISABLE_BACKENDS"
 parse_env = "list_by_comma"
 rust_type = "Vec<String>"

--- a/src/cli/args/backend_arg.rs
+++ b/src/cli/args/backend_arg.rs
@@ -164,11 +164,9 @@ pub(crate) fn strip_opts(s: &str) -> String {
 
 /// Whether a plugin installed under `short` takes precedence over the registry entry.
 ///
-/// A plugin whose backend is disabled by `disable_backends` does not, unless a version is
-/// already installed through that same backend. `disable_backends` is an install-time guard
-/// that intentionally keeps reporting the recorded backend of an installed tool, but a
-/// leftover plugin must not route a registry shorthand to a disabled backend and turn the
-/// install into an error when the registry offers an enabled backend (discussions/6021).
+/// A plugin whose backend is disabled by `disable_backends` does not. Existing installations
+/// are left on disk, but a disabled backend must not participate in shorthand resolution
+/// (discussions/6021, discussions/12921).
 fn plugin_overrides_registry(short: &str) -> bool {
     let Some(plugin_type) = install_state::get_plugin_type(short) else {
         return false;
@@ -179,14 +177,7 @@ fn plugin_overrides_registry(short: &str) -> bool {
         PluginType::VfoxBackend => BackendType::VfoxBackend(short.to_string()),
         PluginType::Package => return true,
     };
-    if !backend::is_disabled_backend_type(&backend_type) {
-        return true;
-    }
-    // Versions are recorded per shorthand, so check the backend they were installed with:
-    // a version that came from an enabled registry backend must not keep the disabled
-    // plugin authoritative.
-    !install_state::list_versions(short).is_empty()
-        && install_state::backend_type(short).ok().flatten() == Some(backend_type)
+    !backend::is_disabled_backend_type(&backend_type)
 }
 
 fn parse_backend_components(


### PR DESCRIPTION
## Summary
- exclude installed plugin backends from shorthand resolution whenever their backend is disabled
- leave existing installations on disk so they become available again when the backend is re-enabled
- clarify the `disable_backends` setting in the architecture docs and generated schema
- verify an exact version already installed through asdf resolves and locks through Aqua while asdf is disabled

Discussion: https://github.com/jdx/mise/discussions/12921

## Tests
- `MBX_DISABLE=1 mise run lint-fix`
- `MBX_DISABLE=1 mise exec -- cargo test --bin mise cli::args::backend_arg::tests`
- `MBX_DISABLE=1 mise run test:e2e e2e/backend/test_disable_backends`

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled backends are now excluded from tool version resolution and new installations.
  * Existing installations from disabled backends remain on disk but are not selected until the backend is re-enabled.
  * Tool versions now resolve through enabled registry backends when appropriate.
  * Lock files more accurately record the selected backend and platform during installation previews and lock updates.

* **Documentation**
  * Clarified the behavior of disabled backends in configuration and backend documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core shorthand-to-backend resolution for tools with installed plugins; wrong behavior could route installs or locks to unexpected backends, though scope is limited to the `disable_backends` setting.
> 
> **Overview**
> **Disabled backends no longer win shorthand tool resolution** when a leftover plugin directory exists. `plugin_overrides_registry` now treats any disabled plugin backend as non-authoritative, instead of still routing to that plugin when versions on disk were installed through it.
> 
> **`disable_backends` is documented and described consistently** as excluding backends from resolution and new installs while leaving existing installs on disk (docs, `settings.toml`, and JSON schema).
> 
> **E2E coverage** pins `age` to a specific Aqua install, asserts `--backend`, dry-run, and `mise.lock` use Aqua when ASDF is disabled, and tightens related disable-backend scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d05f03abcb38892a9c7daf570f846127bd838d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->