### PR TITLE
ci(release): skip e2e tests when publishing tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,7 +288,9 @@ jobs:
           if-no-files-found: error
   e2e-linux:
     needs: [gate, build-tarball-linux]
-    if: needs.gate.outputs.build == 'true'
+    # The auto-merge-enabled release PR already tests this exact release
+    # candidate. Do not repeat the full suite when its tag is published.
+    if: needs.gate.outputs.build == 'true' && !startsWith(github.ref, 'refs/tags/v')
     name: e2e-linux-${{matrix.tranche}}
     runs-on: ubuntu-latest
     #container: ghcr.io/jdx/mise:github-actions
@@ -411,19 +413,25 @@ jobs:
             "${{ needs.build-tarball-linux.result }}" \
             "${{ needs.build-tarball-macos.result }}" \
             "${{ needs.build-tarball-windows.result }}" \
-            "${{ needs.e2e-linux.result }}" \
             "${{ needs.rpm.result }}" \
             "${{ needs.deb.result }}"; do
             if [ "$result" != "success" ]; then
               failed="true"
             fi
           done
+          expected_e2e=success
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            expected_e2e=skipped
+          fi
+          if [ "${{ needs.e2e-linux.result }}" != "$expected_e2e" ]; then
+            failed="true"
+          fi
           if [ -n "$failed" ]; then
             echo "::error::One or more required jobs did not succeed:"
             echo "  build-tarball-linux: ${{ needs.build-tarball-linux.result }}"
             echo "  build-tarball-macos: ${{ needs.build-tarball-macos.result }}"
             echo "  build-tarball-windows: ${{ needs.build-tarball-windows.result }}"
-            echo "  e2e-linux: ${{ needs.e2e-linux.result }}"
+            echo "  e2e-linux: ${{ needs.e2e-linux.result }} (expected $expected_e2e)"
             echo "  rpm: ${{ needs.rpm.result }}"
             echo "  deb: ${{ needs.deb.result }}"
             exit 1


### PR DESCRIPTION
## Summary
- run the packaged-release e2e suite on the auto-merge release PR and manual dry runs
- skip the redundant e2e matrix when publishing a version tag
- require the release gate to observe the expected e2e result for each trigger

## Testing
- `hk check --safe --format json .github/workflows/release.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to when e2e runs and how the release job interprets skipped jobs; no application or release artifact logic changes.
> 
> **Overview**
> **Skips the Linux packaged-release e2e matrix on version tag pushes** so publish workflows do not rerun the full suite after the auto-merge release PR already validated the same candidate.
> 
> The `e2e-linux` job now runs only when `build` is armed and the ref is **not** a `refs/tags/v*` tag. The release gate’s “verify all build targets” step treats e2e separately: it still requires **success** on dry-run/PR paths, but on tag publishes it expects **skipped** and fails if e2e ran or did not skip as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 144a3cc8380fb2b60c297c7caa1cef545cab37b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated release verification to skip Linux end-to-end tests for version-tagged releases.
  - Non-tagged runs continue to require successful Linux end-to-end testing.
  - Build and packaging checks remain required for all releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->