### PR TITLE
fix(windows): repair ARM64 project tooling

### DIFF
--- a/crates/aqua-registry/src/types.rs
+++ b/crates/aqua-registry/src/types.rs
@@ -691,7 +691,13 @@ impl AquaPackage {
         } else if os == "windows" {
             let mut ctx = HashMap::default();
             if arch == "arm64" {
-                ctx.insert("Arch".to_string(), "amd64".to_string());
+                let fallback_arch = self
+                    .replacements
+                    .get("amd64")
+                    .cloned()
+                    .unwrap_or_else(|| "amd64".to_string());
+                ctx.insert("Arch".to_string(), fallback_arch.clone());
+                ctx.insert("GOARCH".to_string(), fallback_arch);
                 let asset = self.asset_without_appended_ext(v, &ctx, os, arch)?;
                 strs.insert(self.finish_asset(asset.clone(), v, os)?);
                 strs.insert(asset);
@@ -2697,6 +2703,25 @@ packages:
                 "Asset string should not have double .exe, got: {s}"
             );
         }
+    }
+
+    #[test]
+    fn test_windows_arm64_fallback_applies_amd64_replacement() {
+        let pkg = AquaPackage {
+            asset: "tool-{{.OS}}-{{.Arch}}-{{.GOARCH}}.zip".to_string(),
+            format: "zip".to_string(),
+            replacements: HashMap::from([
+                ("windows".to_string(), "win32".to_string()),
+                ("amd64".to_string(), "x64".to_string()),
+            ]),
+            ..Default::default()
+        };
+
+        let strs = pkg.asset_strs("1.0.0", "windows", "arm64").unwrap();
+
+        assert!(strs.contains("tool-win32-arm64-arm64.zip"));
+        assert!(strs.contains("tool-win32-x64-x64.zip"));
+        assert!(!strs.iter().any(|asset| asset.contains("amd64")));
     }
 
     #[test]

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -450,7 +450,7 @@ pub(crate) fn ensure_lazy_shims(missing: &[ToolVersion]) -> Result<()> {
                 .iter()
                 .flat_map(|bin| platform_shim_names(&mise_bin, bin))
                 .collect::<BTreeSet<String>>();
-            match write_bootstrap_shims(&mise_bin, &shims_dir, &shims)? {
+            match write_bootstrap_shims(&mise_bin, &shims_dir, &shims, false)? {
                 None => {}
                 // A shared farm such as `/usr/local/bin` may belong to root. No
                 // command can write a bootstrap shim there for this user, so
@@ -477,6 +477,7 @@ fn write_bootstrap_shims(
     mise_bin: &Path,
     shims_dir: &Path,
     shims: &BTreeSet<String>,
+    _prune_stale_windows_variants: bool,
 ) -> Result<Option<eyre::Report>> {
     if let Err(err) = file::create_dir_all(shims_dir) {
         if is_permission_denied(&err) {
@@ -487,6 +488,11 @@ fn write_bootstrap_shims(
     // Lock failures come from the cache rather than the target farm and must
     // remain visible to the user.
     let _lock = LockFile::new(shims_dir).lock()?;
+
+    #[cfg(windows)]
+    if _prune_stale_windows_variants {
+        remove_stale_windows_shim_variants(shims_dir, shims)?;
+    }
 
     #[cfg(windows)]
     validate_windows_shim_source(mise_bin)?;
@@ -503,6 +509,27 @@ fn write_bootstrap_shims(
         }
     }
     Ok(None)
+}
+
+#[cfg(windows)]
+fn remove_stale_windows_shim_variants(shims_dir: &Path, desired: &BTreeSet<String>) -> Result<()> {
+    let stems = desired
+        .iter()
+        .map(|shim| {
+            Path::new(shim)
+                .with_extension("")
+                .to_string_lossy()
+                .to_string()
+        })
+        .collect::<BTreeSet<_>>();
+    for stem in stems {
+        for variant in [stem.clone(), format!("{stem}.cmd"), format!("{stem}.exe")] {
+            if !desired.contains(&variant) {
+                remove_shim_with_rename_fallback(&shims_dir.join(variant))?;
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(windows)]
@@ -1019,7 +1046,9 @@ pub(crate) fn ensure_command_wrapper_shims(config: &Config, ts: &Toolset) -> Res
         .keys()
         .flat_map(|name| platform_shim_names(&mise_bin, name))
         .collect();
-    if let Some(error) = write_bootstrap_shims(&mise_bin, &dirs::COMMAND_WRAPPERS, &shims)? {
+    if let Some(error) =
+        write_bootstrap_shims(&mise_bin, &dirs::COMMAND_WRAPPERS, &shims, cfg!(windows))?
+    {
         return Err(error);
     }
     Ok(())
@@ -1958,6 +1987,23 @@ mod tests {
             old_shim_path(Path::new("foo.cmd")),
             PathBuf::from("foo.cmd.old")
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn command_wrappers_remove_stale_windows_shim_variants() {
+        let dir = tempfile::tempdir().unwrap();
+        for shim in ["cargo", "cargo.cmd", "cargo.exe", "cargo.exe.old"] {
+            fs::write(dir.path().join(shim), "shim").unwrap();
+        }
+
+        let desired = BTreeSet::from(["cargo".to_string(), "cargo.cmd".to_string()]);
+        remove_stale_windows_shim_variants(dir.path(), &desired).unwrap();
+
+        assert!(dir.path().join("cargo").exists());
+        assert!(dir.path().join("cargo.cmd").exists());
+        assert!(!dir.path().join("cargo.exe").exists());
+        assert!(!dir.path().join("cargo.exe.old").exists());
     }
 
     #[cfg(macos)]


### PR DESCRIPTION
## Summary
- remove stale Windows command-wrapper variants before ensuring the active shim mode, preventing `.exe`/`.cmd` recursion after mode changes
- apply Aqua's `amd64` replacement when generating Windows ARM64 emulation candidates, including both `Arch` and `GOARCH`
- add focused regressions for stale Cargo wrappers and LuaLS-style `win32-x64` asset names

## Reproduction
On Windows ARM64, a stale `cargo.exe` beside current file-mode wrappers caused `mise x -- cargo` to alternate between `cargo.exe` and `cargo.cmd` indefinitely. LuaLS installation separately generated `win32-arm64` and `win32-amd64`, although its Aqua metadata maps `amd64` to `x64` and the release publishes `win32-x64`.

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p aqua-registry test_windows_arm64_fallback_applies_amd64_replacement`
- `cargo test --bin mise command_wrappers_remove_stale_windows_shim_variants`
- verified `mise reshim --force` removes the stale wrapper and `mise exec -- cargo -vV` terminates normally

`MISE_AUTO_INSTALL=0` was used while testing because the released mise binary cannot yet resolve the LuaLS Windows ARM64 fallback asset.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Windows shim deletion during wrapper sync and Aqua asset candidate generation for ARM64 installs; localized but affects command resolution and package downloads on Windows ARM64.
> 
> **Overview**
> Fixes two Windows ARM64 issues: **stale command-wrapper shims** after shim-mode changes, and **wrong Aqua fallback asset names** when registry metadata remaps `amd64`.
> 
> On Windows, syncing **command wrappers** now optionally **prunes stale shim variants** (`<stem>`, `<stem>.cmd`, `<stem>.exe`, including `.exe.old`) before creating the desired set. Pruning runs only for `ensure_command_wrapper_shims` (enabled on Windows); lazy bootstrap shims still pass `false`, so they only add missing files. That stops leftover `cargo.exe` from fighting file-mode `cargo` / `cargo.cmd` and causing recursive dispatch.
> 
> In **aqua-registry**, Windows **arm64** emulation candidates no longer hardcode `Arch`/`GOARCH` as `amd64`. They use the package `replacements` entry for `amd64` (defaulting to `amd64`), so templates like `win32-x64` match published assets (e.g. LuaLS). Regressions cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95890344eefb5b39fda61eb64c82c96bd273e4a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Windows ARM64 package handling so architecture-specific substitutions use the configured fallback value.
  - Prevented outdated Windows command-wrapper variants from lingering after switching shim modes, reducing conflicts from stale `.cmd`, `.exe`, or extensionless files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->