### PR TITLE
chore: release 2026.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## [2026.9.3](https://github.com/jdx/mise/compare/v2026.9.2..v2026.9.3) - 2026-09-08
+
+### 🚀 Features
+
+- **(bootstrap)** add winget package manager support by @jdx in [#12928](https://github.com/jdx/mise/pull/12928)
+- **(bootstrap)** allow prepending managed dotfile lines by @jdx in [#12941](https://github.com/jdx/mise/pull/12941)
+- **(bootstrap)** support typed plist collections by @jdx in [#12947](https://github.com/jdx/mise/pull/12947)
+- **(bootstrap)** name configuration adoption explicitly by @jdx in [#12953](https://github.com/jdx/mise/pull/12953)
+- **(vfox)** install plugins from signed packslip archives by @jdx in [#12948](https://github.com/jdx/mise/pull/12948)
+
+### 🐛 Bug Fixes
+
+- **(bootstrap)** handle pacman file advisories for missing packages by @nettlesh in [#12932](https://github.com/jdx/mise/pull/12932)
+- **(bootstrap)** sign macOS notification helper in releases by @jdx in [#12946](https://github.com/jdx/mise/pull/12946)
+- **(config)** make default inline shell portable by @jdx in [#12949](https://github.com/jdx/mise/pull/12949)
+- **(github)** authenticate git operations with mise credentials by @jdx in [#12945](https://github.com/jdx/mise/pull/12945)
+- **(java)** fold version verification into install progress by @jdx in [#12943](https://github.com/jdx/mise/pull/12943)
+- **(sandbox)** allow metadata access to macOS private directory by @jdx in [#12940](https://github.com/jdx/mise/pull/12940)
+- **(version)** use = syntax in auto_update hint by @jdx in [#12957](https://github.com/jdx/mise/pull/12957)
+- **(vfox)** route install phases through progress reporter by @jdx in [#12944](https://github.com/jdx/mise/pull/12944)
+- **(windows)** repair ARM64 project tooling by @jdx in [#12931](https://github.com/jdx/mise/pull/12931)
+
+### 📚 Documentation
+
+- restore prominent homepage name and pronunciation by @jdx in [#12936](https://github.com/jdx/mise/pull/12936)
+- drop the "you need Git installed" prerequisite by @jdx in [#12958](https://github.com/jdx/mise/pull/12958)
+
+### ⚡ Performance
+
+- bypass the shell for simple inline commands by @jdx in [#12950](https://github.com/jdx/mise/pull/12950)
+
+### 🧪 Testing
+
+- **(bootstrap)** cover ordinary dotfile history and recovery by @jdx in [#12919](https://github.com/jdx/mise/pull/12919)
+
+### 📦️ Dependency Updates
+
+- bump mbx to fix cmake compiler transitions by @jdx in [#12951](https://github.com/jdx/mise/pull/12951)
+
+### 📦 Registry
+
+- add cargo-deny, kingfisher, nushell, shellharden, sherif, and tauri-cli by @jrandolf in [#12938](https://github.com/jdx/mise/pull/12938)
+
+### Ci
+
+- **(release)** publish when tag e2e is skipped by @jdx in [#12933](https://github.com/jdx/mise/pull/12933)
+
 ## [2026.9.2](https://github.com/jdx/mise/compare/v2026.9.1..v2026.9.2) - 2026-09-07
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6271,7 +6271,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.9.2"
+version = "2026.9.3"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.9.2"
+version = "2026.9.3"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/crates/vfox/embedded-plugins/vfox-gcloud/hooks/post_install.lua
+++ b/crates/vfox/embedded-plugins/vfox-gcloud/hooks/post_install.lua
@@ -3,6 +3,7 @@
 --- @field ctx.rootPath string The installation directory
 
 local file = require("file")
+local cmd = require("cmd")
 local os = require("os")
 local log = require("log")
 local strings = require("strings")
@@ -86,10 +87,10 @@ local function install_default_components(gcloud_bin)
         return
     end
 
-    local cmd = string.format('"%s" --quiet components install %s', gcloud_bin, table.concat(components, " "))
-    local status = os.execute(cmd)
-    if status ~= 0 and status ~= true then
-        log.error("Failed to install default Cloud SDK components")
+    local command = string.format('"%s" --quiet components install %s', gcloud_bin, table.concat(components, " "))
+    local ok, err = pcall(cmd.exec, command)
+    if not ok then
+        log.error("Failed to install default Cloud SDK components: " .. tostring(err))
         return
     end
     log.info("Default Cloud SDK components installed successfully")
@@ -140,9 +141,9 @@ function PLUGIN:PostInstall(ctx)
         cmd_str = 'sh "' .. install_script .. '" ' .. table.concat(args, " ")
     end
 
-    local status = os.execute(cmd_str)
-    if status ~= 0 and status ~= true then
-        error("Failed to run gcloud install script")
+    local ok, err = pcall(cmd.exec, cmd_str)
+    if not ok then
+        error("Failed to run gcloud install script: " .. tostring(err))
     end
 
     -- Install default SDK components

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.9.2";
+  version = "2026.9.3";
 
   src = lib.cleanSource ./.;
 

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.9.2
+Version: 2026.9.3
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.9.2"
+version: "2026.9.3"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "66fcd35225f63e49cd7f9522e96ed645390bdc28"
+  "tag": "81ac7994fd26546c92d697e328423fbafe3692a9"
 }


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** add winget package manager support by @jdx in [#12928](https://github.com/jdx/mise/pull/12928)
- **(bootstrap)** allow prepending managed dotfile lines by @jdx in [#12941](https://github.com/jdx/mise/pull/12941)
- **(bootstrap)** support typed plist collections by @jdx in [#12947](https://github.com/jdx/mise/pull/12947)
- **(bootstrap)** name configuration adoption explicitly by @jdx in [#12953](https://github.com/jdx/mise/pull/12953)
- **(vfox)** install plugins from signed packslip archives by @jdx in [#12948](https://github.com/jdx/mise/pull/12948)

### 🐛 Bug Fixes

- **(bootstrap)** handle pacman file advisories for missing packages by @nettlesh in [#12932](https://github.com/jdx/mise/pull/12932)
- **(bootstrap)** sign macOS notification helper in releases by @jdx in [#12946](https://github.com/jdx/mise/pull/12946)
- **(config)** make default inline shell portable by @jdx in [#12949](https://github.com/jdx/mise/pull/12949)
- **(github)** authenticate git operations with mise credentials by @jdx in [#12945](https://github.com/jdx/mise/pull/12945)
- **(java)** fold version verification into install progress by @jdx in [#12943](https://github.com/jdx/mise/pull/12943)
- **(sandbox)** allow metadata access to macOS private directory by @jdx in [#12940](https://github.com/jdx/mise/pull/12940)
- **(version)** use = syntax in auto_update hint by @jdx in [#12957](https://github.com/jdx/mise/pull/12957)
- **(vfox)** route install phases through progress reporter by @jdx in [#12944](https://github.com/jdx/mise/pull/12944)
- **(windows)** repair ARM64 project tooling by @jdx in [#12931](https://github.com/jdx/mise/pull/12931)

### 📚 Documentation

- restore prominent homepage name and pronunciation by @jdx in [#12936](https://github.com/jdx/mise/pull/12936)
- drop the "you need Git installed" prerequisite by @jdx in [#12958](https://github.com/jdx/mise/pull/12958)

### ⚡ Performance

- bypass the shell for simple inline commands by @jdx in [#12950](https://github.com/jdx/mise/pull/12950)

### 🧪 Testing

- **(bootstrap)** cover ordinary dotfile history and recovery by @jdx in [#12919](https://github.com/jdx/mise/pull/12919)

### 📦️ Dependency Updates

- bump mbx to fix cmake compiler transitions by @jdx in [#12951](https://github.com/jdx/mise/pull/12951)

### 📦 Registry

- add cargo-deny, kingfisher, nushell, shellharden, sherif, and tauri-cli by @jrandolf in [#12938](https://github.com/jdx/mise/pull/12938)

### Ci

- **(release)** publish when tag e2e is skipped by @jdx in [#12933](https://github.com/jdx/mise/pull/12933)