### PR TITLE
docs: restore prominent homepage name and pronunciation

### DIFF
--- a/docs/.vitepress/theme/HomeHero.vue
+++ b/docs/.vitepress/theme/HomeHero.vue
@@ -101,9 +101,11 @@ onUnmounted(() => clearTimeout(copyTimeout));
 <template>
   <section class="home-hero" aria-labelledby="home-title">
     <div class="hero-copy">
-      <h1 id="home-title" class="hero-eyebrow">
-        mise-en-place / everything in its place
-      </h1>
+      <h1 id="home-title" class="hero-title">mise-en-place</h1>
+      <p class="hero-meaning">Everything in its place.</p>
+      <p class="hero-pronunciation">
+        mise is pronounced <strong>“meez”</strong>
+      </p>
       <p class="hero-lede">
         Declare your tool versions, environment variables, and commands in
         <code>mise.toml</code>. Use them in your shell, editor, and CI. Add

--- a/docs/.vitepress/theme/landing.css
+++ b/docs/.vitepress/theme/landing.css
@@ -744,12 +744,31 @@ a:hover > div + .card-link::after {
 .hero-copy {
   min-width: 0;
 }
-.hero-eyebrow {
-  margin: 0 0 24px;
-  font-family: var(--vp-font-family-mono);
-  font-size: 0.75rem;
+.hero-title {
+  margin: 0;
   color: var(--vp-c-brand-1);
-  line-height: 1.7;
+  font-size: clamp(2.5rem, 4.5vw, 3.75rem);
+  font-weight: 700;
+  letter-spacing: -0.05em;
+  line-height: 1.1;
+}
+.hero-meaning {
+  margin: 12px 0 0;
+  color: var(--vp-c-text-1);
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  line-height: 1.25;
+}
+.hero-pronunciation {
+  margin: 16px 0 0;
+  color: var(--vp-c-text-2);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+.hero-pronunciation strong {
+  color: var(--vp-c-brand-1);
+  font-weight: 600;
 }
 .hero-lede {
   max-width: 42ch;
@@ -1039,9 +1058,6 @@ a:hover > div + .card-link::after {
   .home-hero {
     padding: 40px 24px;
     gap: 32px;
-  }
-  .hero-eyebrow {
-    margin-bottom: 20px;
   }
   .hero-lede {
     font-size: 1rem;


### PR DESCRIPTION
The redesigned homepage reduced the name and translation to a small monospace line and omitted the pronunciation guide. Give “mise-en-place” a prominent responsive heading, set “Everything in its place.” on its own line, and restore “mise is pronounced ‘meez’” immediately below it.

Validation: production docs build passed, including 8 social-image tests and metadata checks for 356 pages. Scoped hk/Prettier formatting passed. Visually checked desktop dark/light themes and the 375px mobile layout.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only VitePress hero markup and CSS; no runtime or API impact.
> 
> **Overview**
> **Restores a clearer homepage hero** after the redesign had collapsed the product name, tagline, and pronunciation into one small monospace line.
> 
> In `HomeHero.vue`, the single `h1.hero-eyebrow` (“mise-en-place / everything in its place”) is split into a prominent **`mise-en-place`** heading, a separate **“Everything in its place.”** line, and a restored pronunciation note (**mise** is pronounced **“meez”**). `landing.css` replaces `.hero-eyebrow` with responsive `.hero-title`, `.hero-meaning`, and `.hero-pronunciation` styles (larger brand heading, secondary tagline, highlighted pronunciation) and drops the mobile-only eyebrow margin tweak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b68bb04fd2375781328574c4439a802fbc1b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the homepage hero layout by separating the product title from its tagline.
  - Added a pronunciation note for “mise” (“meez”).
  - Updated responsive typography and emphasis for the hero title, tagline, and pronunciation note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->