### PR TITLE
registry: add cargo-deny, kingfisher, nushell, shellharden, sherif, and tauri-cli

### DIFF
--- a/registry/cargo-deny.toml
+++ b/registry/cargo-deny.toml
@@ -1,0 +1,4 @@
+backends = ["aqua:EmbarkStudios/cargo-deny"]
+description = "Cargo plugin for linting your dependencies"
+test = { cmd = "cargo-deny --version", expected = "cargo-deny {{version}}" }
+version_order = "semver"

--- a/registry/kingfisher.toml
+++ b/registry/kingfisher.toml
@@ -1,0 +1,5 @@
+backends = ["github:mongodb/kingfisher"]
+bins = ["kingfisher"]
+description = "Secret scanner with live validation and blast radius analysis"
+test = { cmd = "kingfisher --version", expected = "kingfisher {{version}}" }
+version_order = "semver"

--- a/registry/nushell.toml
+++ b/registry/nushell.toml
@@ -1,0 +1,5 @@
+aliases = ["nu"]
+backends = ["aqua:nushell/nushell"]
+description = "A new type of shell"
+test = { cmd = "nu --version", expected = "{{version}}" }
+version_order = "semver"

--- a/registry/shellharden.toml
+++ b/registry/shellharden.toml
@@ -1,0 +1,4 @@
+backends = ["aqua:anordal/shellharden"]
+description = "The corrective bash syntax highlighter"
+test = { cmd = "shellharden --version", expected = "{{version}}" }
+version_order = "semver"

--- a/registry/sherif.toml
+++ b/registry/sherif.toml
@@ -1,0 +1,5 @@
+backends = ["github:QuiiBz/sherif"]
+bins = ["sherif"]
+description = "Opinionated, zero-config linter for TypeScript and JavaScript monorepos"
+test = { cmd = "sherif --version", expected = "sherif {{version}}" }
+version_order = "source"

--- a/registry/tauri-cli.toml
+++ b/registry/tauri-cli.toml
@@ -1,0 +1,4 @@
+backends = ["aqua:tauri-apps/tauri/cargo-tauri"]
+description = "Build smaller, faster, and more secure desktop and mobile applications with a web frontend"
+test = { cmd = "cargo-tauri --version", expected = "tauri-cli {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
Adds native-binary registry shorthands for Cargo Deny, Kingfisher, Nushell (including `nu`), Shellharden, Sherif, and Tauri CLI. Each entry includes an executable version test.

The four tools already described by the vendored Aqua catalog use their existing Aqua packages. Kingfisher and Sherif use GitHub release binaries. Nushell has one canonical entry with a `nu` alias. Tauri CLI uses Aqua's `tauri-apps/tauri/cargo-tauri` package so version discovery selects the CLI release stream and installs `cargo-tauri`. Sherif keeps source version order because its release history includes the moving `v1` tag.

## Popularity

GitHub counts checked on September 7, 2026. Release dates refer to the tested CLI release.

| Tool | GitHub stars | Forks | Tested release | Release date |
| --- | ---: | ---: | --- | --- |
| [Cargo Deny](https://github.com/EmbarkStudios/cargo-deny) | 2,416 | 129 | 0.20.2 | 2026-07-09 |
| [Kingfisher](https://github.com/mongodb/kingfisher) | 1,222 | 116 | 2.1.0 | 2026-08-30 |
| [Nushell](https://github.com/nushell/nushell) | 40,440 | 2,244 | 0.115.1 | 2026-08-23 |
| [Shellharden](https://github.com/anordal/shellharden) | 4,803 | 133 | 4.3.2 | 2026-06-27 |
| [Sherif](https://github.com/QuiiBz/sherif) | 1,184 | 23 | 1.13.0 | 2026-07-04 |
| [Tauri](https://github.com/tauri-apps/tauri) | 110,898 | 3,921 | tauri-cli 2.11.4 | 2026-06-28 |

Examples of independent adoption and ecosystem support:

- Cargo Deny runs in [Tokio's audit workflow](https://github.com/tokio-rs/tokio/blob/13d4800fb72ccb9677117d9668bdbed9df4c725e/.github/workflows/audit.yml).
- Kingfisher is integrated into [MegaLinter](https://megalinter.io/latest/descriptors/repository_kingfisher/).
- Nushell is supported by [Starship](https://github.com/starship/starship/blob/864500b26904cd3cc01fc2a19d3ad068bd1517a2/docs/README.md).
- Shellharden is packaged by [Nixpkgs](https://github.com/NixOS/nixpkgs/blob/644590cbf4436a9b9e40446816b01963f91ddc6e/pkgs/by-name/sh/shellharden/package.nix).
- Sherif is documented by [Turborepo](https://github.com/vercel/turborepo/blob/63797e490d44cd63e86b6dc1d7ac87c59b884c41/apps/docs/content/docs/crafting-your-repository/managing-dependencies.mdx) and had [325,039 npm downloads](https://api.npmjs.org/downloads/point/last-week/sherif) during August 31–September 6, 2026; this entry installs its native release binary.
- GitButler uses Tauri CLI in its [release workflow](https://github.com/gitbutlerapp/gitbutler/blob/059076bbe9f107d0307cac86c4418b66794382d5/scripts/release.sh).

## Validation

Performed on macOS arm64:

- `mise ls-remote` returned installable versions for all six full backend identifiers.
- `mise exec mr-boxington@1.8.3 -- cargo build --all-features --locked` passed.
- Scoped `hk fix --safe --files0-from … --format json` passed: Taplo format and registry-schema validation for all six files.
- The newly built binary's `registry --json` exposes all seven names with the expected backends and executable hints.
- `target/debug/mise test-tool cargo-deny kingfisher nushell shellharden sherif tauri-cli` passed all six real install-and-execute tests in isolated mise data/cache/config/state directories.
- `target/debug/mise exec nu@latest -- nu --version` installed through the alias and returned `0.115.1`.

The development build reports the macOS linker's large `__eh_frame` warning and a future-compatibility notice from the existing `proc-macro-error2` dependency. The tool tests fall back successfully from the mise-versions service to GitHub because these repositories are not yet in the deployed registry.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry support for cargo-deny, Kingfisher, Nushell, Shellharden, Sherif, and the Tauri CLI.
  * Added version detection and ordering configuration for each newly registered tool.
  * Added executable aliases where applicable, including `nu` for Nushell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->