### PR TITLE
fix(sandbox): allow metadata access to macOS private directory

### DIFF
--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -172,7 +172,9 @@ control when `--allow-net` cannot express it.
 
 When reads are restricted, Seatbelt requires data access to the root directory for process startup.
 Sandboxed processes can enumerate names directly under `/`, but cannot read unallowed entries or
-their descendants.
+their descendants. Mise also permits metadata access to `/private` so portable executables can
+resolve paths through macOS's private filesystem hierarchy; this does not permit listing that
+directory or reading its descendants.
 
 ### Windows
 

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -54,6 +54,9 @@ pub(crate) async fn generate_seatbelt_profile(
         // Seatbelt requires data access to the root vnode for process startup and getcwd.
         // This exposes names directly under `/`, but descendants still obey the read rules.
         rules.push("(allow file-read-data (literal \"/\"))".to_string());
+        // Portable executables may resolve paths through macOS's `/private` hierarchy
+        // during startup (for example, Ruby built with --enable-load-relative).
+        rules.push("(allow file-read-metadata (literal \"/private\"))".to_string());
         for path in SYSTEM_READ_PATHS {
             rules.push(format!("(allow file-read* (subpath \"{path}\"))"));
         }
@@ -244,6 +247,31 @@ mod tests {
             String::from_utf8_lossy(&allowed.stderr)
         );
         assert!(!read(&denied_file).status.success());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn test_private_metadata_does_not_expose_directory_contents() {
+        let config = SandboxConfig {
+            deny_read: true,
+            ..Default::default()
+        };
+        let profile = generate_seatbelt_profile(&config, None).await;
+        let run = |program: &str, args: &[&str]| {
+            Command::new("sandbox-exec")
+                .args(["-p", &profile, "--", program])
+                .args(args)
+                .output()
+                .unwrap()
+        };
+
+        let metadata = run("/usr/bin/stat", &["-f", "%N", "/private"]);
+        assert!(
+            metadata.status.success(),
+            "sandboxed stat failed: {}",
+            String::from_utf8_lossy(&metadata.stderr)
+        );
+        assert!(!run("/bin/ls", &["/private"]).status.success());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- allow metadata access to the literal /private directory in read-restricted macOS Seatbelt profiles
- preserve denial of directory listings and descendant reads
- document the narrow implicit permission

## Context

Fixes the Ruby 4.0.6 startup failure reported in discussion #12937. The precompiled Ruby uses --enable-load-relative and resolves its executable path during startup. When the executable is under /private/tmp, Seatbelt permits the configured subtree but denies the metadata lookup on its parent /private, causing rb_check_realpath_internal to raise Errno::EPERM.

The new permission is metadata-only. A macOS runtime regression test verifies that stat /private succeeds while ls /private remains denied.

## Validation

- cargo test --locked sandbox::macos::tests
- mise run lint-fix

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Slightly widens read-restricted macOS sandbox policy for `/private` metadata only; behavior is regression-tested but still a security-sensitive Seatbelt change.
> 
> **Overview**
> Fixes startup failures for portable macOS binaries (e.g. load-relative Ruby under `/private/tmp`) when `--deny-read` is active by adding a Seatbelt rule that allows **metadata-only** access to the literal `/private` path, alongside the existing root `/` data exception.
> 
> **Docs** now state that this narrow permission does not allow listing `/private` or reading its descendants. A **macOS integration test** runs the generated profile through `sandbox-exec` and asserts `stat /private` succeeds while `ls /private` stays denied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a6b16c48e2741de64df9c9940a0844d77d81bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS sandbox compatibility for portable executables by allowing required metadata access within the system’s private filesystem hierarchy.
  * Access remains restricted: applications cannot list or read the contents of protected directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->