### PR TITLE
feat(bootstrap): allow prepending managed dotfile lines

### DIFF
--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -322,6 +322,7 @@ alias ll='ls -l'
 alias la='ls -la'
 ''' }
 "/etc/hosts/dev" = { line = "127.0.0.1 dev.local" }
+"/etc/zshrc/zdotdir" = { line = 'ZDOTDIR=$HOME/.config/zsh/', position = "prepend" }
 "~/.gitconfig/identity" = { source = "snippets/git-identity.tmpl", template = "tera" }
 ```
 
@@ -349,10 +350,11 @@ be overridden with `comment = "..."`. Files that can't hold line comments
 at all (strict JSON, XML) aren't a fit for blocks — use a whole-file entry
 instead.
 
-A `line` ensures an exact line exists somewhere in the file, appending it at
-the end if absent. It never modifies or removes other lines, which is what
-makes it safely idempotent. The value must be a single line; use a block for
-multi-line content.
+A `line` ensures an exact line exists somewhere in the file. A missing line is
+appended by default; set `position = "prepend"` to put it at the beginning
+instead. An existing exact match is left wherever it is. Applying a line edit
+preserves all other bytes, including the file's existing line endings. The
+value must be a single line; use a block for multi-line content.
 
 ## Semantics
 
@@ -388,7 +390,7 @@ the target file's content without `--force` — that is the declared intent of
 those modes. Existing symlinks can be repointed; inspect the diff before changing which source a target uses.
 
 Edit entries never need `--force`: a block owns only what's between its
-markers, and a line only ever appends. Two cases are refused with an error
+markers, and a line only inserts when its exact content is absent. Two cases are refused with an error
 instead of guessed at: corrupted markers and targets that are symlinks. An
 edit through a symlink would modify whatever the link points at, often a
 `[dotfiles]` source, so point the edit at the real file instead.

--- a/e2e/cli/test_dotfiles_edits
+++ b/e2e/cli/test_dotfiles_edits
@@ -11,6 +11,8 @@ alias la='ls -la'
 ''' }
 "~/hosts/dev" = { line = "127.0.0.1 dev.local" }
 "~/prepend.conf/first" = { line = "managed first", position = "prepend" }
+"~/bom-existing.conf/existing" = { line = "already there", position = "prepend" }
+"~/bom-only.conf/append" = { line = "appended" }
 "~/init.lua/mise" = { block = "require('mise')" }
 "~/rendered.conf/sum" = { block = "sum = {{ 1 + 1 }}", template = "tera" }
 "~/execd.conf/execd" = { block = '{{ exec(command="touch $HOME/exec-ran") }}ok', template = "tera" }
@@ -35,6 +37,8 @@ assert_fail "cat ~/exec-ran"
 # line edits append to existing files without touching other content
 echo "preexisting content" >~/hosts
 printf 'untouched first\r\nuntouched last\r\n' >~/prepend.conf
+printf '\357\273\277already there\n' >~/bom-existing.conf
+printf '\357\273\277' >~/bom-only.conf
 
 assert_succeed "mise dotfiles apply --yes"
 
@@ -51,6 +55,10 @@ assert_contains "cat ~/hosts" "127.0.0.1 dev.local"
 # prepending preserves every existing byte, including CRLF line endings
 printf 'managed first\r\nuntouched first\r\nuntouched last\r\n' >expected-prepend.conf
 assert_succeed "cmp expected-prepend.conf ~/prepend.conf"
+# a BOM is not part of the first logical line and remains at byte zero
+printf '\357\273\277appended\n' >expected-bom.conf
+assert_succeed "cmp expected-bom.conf ~/bom-only.conf"
+assert "grep -c 'already there' ~/bom-existing.conf" "1"
 # comment prefix inferred from extension
 assert_contains "cat ~/init.lua" "-- >>> mise:mise >>>"
 # template rendered

--- a/e2e/cli/test_dotfiles_edits
+++ b/e2e/cli/test_dotfiles_edits
@@ -10,6 +10,7 @@ alias ll='ls -l'
 alias la='ls -la'
 ''' }
 "~/hosts/dev" = { line = "127.0.0.1 dev.local" }
+"~/prepend.conf/first" = { line = "managed first", position = "prepend" }
 "~/init.lua/mise" = { block = "require('mise')" }
 "~/rendered.conf/sum" = { block = "sum = {{ 1 + 1 }}", template = "tera" }
 "~/execd.conf/execd" = { block = '{{ exec(command="touch $HOME/exec-ran") }}ok', template = "tera" }
@@ -33,6 +34,7 @@ assert_fail "cat ~/exec-ran"
 
 # line edits append to existing files without touching other content
 echo "preexisting content" >~/hosts
+printf 'untouched first\r\nuntouched last\r\n' >~/prepend.conf
 
 assert_succeed "mise dotfiles apply --yes"
 
@@ -46,6 +48,9 @@ assert_contains "cat ~/.zshrc" "alias la='ls -la'"
 # line was appended, existing content kept
 assert "head -1 ~/hosts" "preexisting content"
 assert_contains "cat ~/hosts" "127.0.0.1 dev.local"
+# prepending preserves every existing byte, including CRLF line endings
+printf 'managed first\r\nuntouched first\r\nuntouched last\r\n' >expected-prepend.conf
+assert_succeed "cmp expected-prepend.conf ~/prepend.conf"
 # comment prefix inferred from extension
 assert_contains "cat ~/init.lua" "-- >>> mise:mise >>>"
 # template rendered
@@ -67,6 +72,7 @@ assert_contains "mise dotfiles apply --yes 2>&1" "all edits are applied"
 assert_contains "mise bootstrap dotfiles diff ~/rendered.conf/sum 2>&1" "all edits are applied"
 assert_not_contains "mise bootstrap dotfiles diff ~/rendered.conf/sum 2>&1" "(if changed)"
 assert "grep -c 'dev.local' ~/hosts" "1"
+assert "grep -c 'managed first' ~/prepend.conf" "1"
 assert "grep -c 'mise:activate >>>' ~/.zshrc" "1"
 
 # content changes are detected and replace only the block, preserving
@@ -203,6 +209,20 @@ cat <<'EOF' >mise.toml
 EOF
 assert_succeed "mise dotfiles status"
 assert_contains "mise dotfiles status 2>&1" "line may not contain a newline"
+
+cat <<'EOF' >mise.toml
+[dotfiles]
+"~/x.conf/position" = { line = "x", position = "middle" }
+EOF
+assert_succeed "mise dotfiles status"
+assert_contains "mise dotfiles status 2>&1" "unknown line position"
+
+cat <<'EOF' >mise.toml
+[dotfiles]
+"~/x.conf/position" = { block = "x", position = "prepend" }
+EOF
+assert_succeed "mise dotfiles status"
+assert_contains "mise dotfiles status 2>&1" "position is only valid with line"
 
 cat <<'EOF' >mise.toml
 [dotfiles]

--- a/e2e/cli/test_dotfiles_unapply
+++ b/e2e/cli/test_dotfiles_unapply
@@ -26,10 +26,12 @@ cat <<EOF >mise.toml
 "~/.managed-copydir" = { source = "dotfiles/copydir", mode = "copy" }
 "~/.managed-rc/block" = { block = "managed block" }
 "~/.managed-lines/line" = { line = "possibly preexisting" }
+"~/.managed-bom/line" = { line = "managed first", position = "prepend" }
 EOF
 
 # A line edit cannot prove it created an already-present line.
 echo "possibly preexisting" >~/.managed-lines
+printf '\357\273\277keep me\r\n' >~/.managed-bom
 printf 'before\n\n' >~/.managed-rc
 assert_succeed "mise bootstrap dotfiles apply --yes"
 assert_succeed "test -L $HOME/.managed-link"
@@ -89,6 +91,12 @@ printf 'after-no-newline' >>~/.managed-rc
 assert_succeed "mise bootstrap dotfiles unapply ~/.managed-rc/block --yes"
 assert_not_contains "cat ~/.managed-rc" "mise:block"
 assert "od -An -tx1 ~/.managed-rc | tr -d ' \n'" "6265666f72650d0a0d0a61667465722d6e6f2d6e65776c696e65"
+
+# Removing a first-line edit preserves a leading BOM and all following bytes.
+assert_fail "mise bootstrap dotfiles unapply ~/.managed-bom/line --yes"
+assert_succeed "mise bootstrap dotfiles unapply ~/.managed-bom/line --force --yes"
+printf '\357\273\277keep me\r\n' >expected-bom-unapply
+assert_succeed "cmp expected-bom-unapply ~/.managed-bom"
 
 # symlink-each removes path-equivalent and stale exact mappings, but preserves
 # unrelated and excluded user-created links and their containing directory.

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -283,7 +283,17 @@ TOML
   assert_fail "$TOMBI_LINT mise-bad-dotfiles.toml"
 done
 
-# Edit placement only applies to exact-line edits.
+# Line edits cannot also declare a block or source, and edit placement only
+# applies to exact-line edits.
+for conflicting_field in 'block = "managed block"' 'source = "dotfiles/snippet"'; do
+  cat >"$HOME/workdir/mise-bad-dotfiles-position.toml" <<TOML
+[dotfiles]
+"~/.invalid/partial" = { line = "managed line", $conflicting_field, position = "prepend" }
+TOML
+
+  assert_fail "$TOMBI_LINT mise-bad-dotfiles-position.toml"
+done
+
 cat >"$HOME/workdir/mise-bad-dotfiles-position.toml" <<'TOML'
 [dotfiles]
 "~/.invalid/partial" = { block = "managed block", position = "prepend" }

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -229,7 +229,7 @@ strict = true
 
 [[schemas]]
 path = "file://$SCHEMA_PATH"
-include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
+include = ["mise-bad.toml", "mise-bad-age.toml", "mise-bad-dotfiles.toml", "mise-bad-dotfiles-position.toml", "mise-bad-env-default.toml", "mise-bad-env-directive.toml", "mise-bad-env-float.toml", "mise-bad-install-env-float.toml", "mise-bad-minimum-release-age-array.toml", "mise-bad-minimum-release-age-table.toml", "mise-bad-package-state.toml", "mise-bad-postinstall.toml", "mise-bad-vars.toml", "mise-bad-tmpl.toml", "mise-bad-tmpl-output-flag.toml", "mise-bad-os.toml", "mise-bad-watch-files.toml", "mise-bad-launchd-calendar.toml", "mise-bad-launchd-queue.toml", "mise-bad-launchd-throttle.toml", "mise-bad-systemd.toml", "mise-bad-oci-copy.toml", "mise-bad-shell-activate.toml"]
 
 [[schemas]]
 path = "file://$TASK_SCHEMA_PATH"
@@ -282,6 +282,14 @@ TOML
 
   assert_fail "$TOMBI_LINT mise-bad-dotfiles.toml"
 done
+
+# Edit placement only applies to exact-line edits.
+cat >"$HOME/workdir/mise-bad-dotfiles-position.toml" <<'TOML'
+[dotfiles]
+"~/.invalid/partial" = { block = "managed block", position = "prepend" }
+TOML
+
+assert_fail "$TOMBI_LINT mise-bad-dotfiles-position.toml"
 
 cat >"$HOME/workdir/mise-bad-env-default.toml" <<'TOML'
 [env]

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -283,9 +283,15 @@ TOML
   assert_fail "$TOMBI_LINT mise-bad-dotfiles.toml"
 done
 
-# Line edits cannot also declare a block or source, and edit placement only
-# applies to exact-line edits.
-for conflicting_field in 'block = "managed block"' 'source = "dotfiles/snippet"'; do
+# Line edits cannot also declare whole-file or block-only fields, and edit
+# placement only applies to exact-line edits.
+for conflicting_field in \
+  'block = "managed block"' \
+  'source = "dotfiles/snippet"' \
+  'mode = "copy"' \
+  'exclude = ["*.tmp"]' \
+  'template = "tera"' \
+  'comment = "#"'; do
   cat >"$HOME/workdir/mise-bad-dotfiles-position.toml" <<TOML
 [dotfiles]
 "~/.invalid/partial" = { line = "managed line", $conflicting_field, position = "prepend" }

--- a/e2e/config/test_schema_tombi
+++ b/e2e/config/test_schema_tombi
@@ -272,6 +272,7 @@ for other_field in \
   'exclude = ["*.tmp"]' \
   'block = "managed block"' \
   'line = "managed line"' \
+  'position = "prepend"' \
   'template = "tera"' \
   'comment = "#"'; do
   cat >"$HOME/workdir/mise-bad-dotfiles.toml" <<TOML

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4209,8 +4209,16 @@
                 }
               },
               {
+                "required": ["line"],
                 "properties": {
                   "content": false
+                }
+              },
+              {
+                "properties": {
+                  "content": false,
+                  "line": false,
+                  "position": false
                 }
               }
             ],

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4212,8 +4212,12 @@
                 "required": ["line"],
                 "properties": {
                   "content": false,
+                  "mode": false,
+                  "exclude": false,
                   "source": false,
-                  "block": false
+                  "block": false,
+                  "template": false,
+                  "comment": false
                 }
               },
               {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4211,7 +4211,9 @@
               {
                 "required": ["line"],
                 "properties": {
-                  "content": false
+                  "content": false,
+                  "source": false,
+                  "block": false
                 }
               },
               {

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4173,7 +4173,20 @@
               },
               "line": {
                 "type": "string",
-                "description": "exact line to ensure exists (appended if absent)"
+                "description": "exact line to ensure exists"
+              },
+              "position": {
+                "type": "string",
+                "default": "append",
+                "description": "where to insert a missing line",
+                "anyOf": [
+                  {
+                    "enum": ["append", "prepend"]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "comment": {
                 "type": "string",
@@ -4190,6 +4203,7 @@
                   "exclude": false,
                   "block": false,
                   "line": false,
+                  "position": false,
                   "template": false,
                   "comment": false
                 }

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -1089,11 +1089,11 @@ fn text_lines(text: &str) -> Vec<TextLine<'_>> {
             offset += raw.len();
             let content = raw.strip_suffix('\n').unwrap_or(raw);
             let mut content = content.strip_suffix('\r').unwrap_or(content);
-            if start == 0 {
-                if let Some(without_bom) = content.strip_prefix('\u{feff}') {
-                    start += '\u{feff}'.len_utf8();
-                    content = without_bom;
-                }
+            if start == 0
+                && let Some(without_bom) = content.strip_prefix('\u{feff}')
+            {
+                start += '\u{feff}'.len_utf8();
+                content = without_bom;
             }
             TextLine {
                 content,

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -18,7 +18,8 @@
 //! `# >>> mise:activate >>>` / `# <<< mise:activate <<<` — which double as
 //! the ownership record: apply replaces only what's between them, so the
 //! design stays stateless like the rest of `[dotfiles]`. A `line` ensures an
-//! exact line exists, appending it if absent.
+//! exact line exists, appending it if absent by default or prepending it when
+//! `position = "prepend"`.
 //!
 //! Entries merge across the config hierarchy as a union keyed by
 //! `(path, id)` — a more local config overrides an edit with the same id,
@@ -67,6 +68,9 @@ pub(crate) struct EditTomlTable {
     /// exact line to ensure exists
     #[serde(default)]
     pub line: Option<String>,
+    /// where to insert a missing line; `"append"` (the default) or `"prepend"`
+    #[serde(default)]
+    pub position: Option<String>,
     /// comment prefix for the markers; inferred from the file extension
     /// when omitted
     #[serde(default)]
@@ -90,7 +94,15 @@ pub(crate) enum EditOp {
     },
     Line {
         line: String,
+        position: LinePosition,
     },
+}
+
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub(crate) enum LinePosition {
+    Prepend,
+    #[default]
+    Append,
 }
 
 /// one edit, resolved against the config file that declared it
@@ -219,7 +231,8 @@ fn edit_entry_from_toml(path_and_id: &str, value: toml::Value) -> Option<EditTom
                     && !table.contains_key("block")
                     && !table.contains_key("line")
                     && !table.contains_key("template")
-                    && !table.contains_key("comment");
+                    && !table.contains_key("comment")
+                    && !table.contains_key("position");
             if is_whole_file_table {
                 return None;
             }
@@ -273,6 +286,7 @@ fn resolve_entry(
             source: None,
             template: None,
             line: None,
+            position: None,
             comment: None,
         },
         EditTomlEntry::Table(table) => table,
@@ -290,6 +304,9 @@ fn resolve_entry(
             )
         }
         (true, None) => {
+            if entry.position.is_some() {
+                bail!("\"{path_raw}\".{id}: position is only valid with line, ignoring entry")
+            }
             let source = match (entry.block, entry.source) {
                 (Some(_), Some(_)) => {
                     bail!(
@@ -336,7 +353,19 @@ fn resolve_entry(
                     "\"{path_raw}\".{id}: line may not contain a newline; use a block for multi-line content, ignoring entry"
                 )
             }
-            EditOp::Line { line: line.clone() }
+            let position = match entry.position.as_deref() {
+                None | Some("append") => LinePosition::Append,
+                Some("prepend") => LinePosition::Prepend,
+                Some(other) => {
+                    bail!(
+                        "\"{path_raw}\".{id}: unknown line position '{other}' (expected \"append\" or \"prepend\"), ignoring entry"
+                    )
+                }
+            };
+            EditOp::Line {
+                line: line.clone(),
+                position,
+            }
         }
     };
     Ok(EditRequest {
@@ -526,11 +555,13 @@ fn precheck(req: &EditRequest) -> Result<Option<EditCheck>> {
             Ok(None) => Ok(Some(EditCheck::State(FileState::Missing))),
             Ok(Some(_)) => Ok(None),
         },
-        EditOp::Line { line } => Ok(Some(EditCheck::State(if lines.contains(&line.as_str()) {
-            FileState::Applied
-        } else {
-            FileState::Missing
-        }))),
+        EditOp::Line { line, .. } => {
+            Ok(Some(EditCheck::State(if lines.contains(&line.as_str()) {
+                FileState::Applied
+            } else {
+                FileState::Missing
+            })))
+        }
     }
 }
 
@@ -883,7 +914,7 @@ pub(crate) fn plan_unapply<'a>(
                     req.describe_op()
                 )),
             },
-            EditOp::Line { line } if lines.contains(&line.as_str()) => {
+            EditOp::Line { line, .. } if lines.contains(&line.as_str()) => {
                 if !opts.force {
                     problems.push(format!(
                         "  \"{}\" ({}): line edits have no ownership marker; use --force to remove the line",
@@ -1012,10 +1043,14 @@ fn unapply_one(req: &EditRequest) -> Result<()> {
                 ),
             }
         }
-        EditOp::Line { line } => {
-            // Apply appends a missing line, so the last matching occurrence is
-            // the best stateless approximation of the one it added.
-            if let Some(found) = lines.iter().rfind(|candidate| candidate.content == line) {
+        EditOp::Line { line, position } => {
+            // Use the occurrence nearest the configured insertion edge as the
+            // best stateless approximation of the line mise added.
+            let found = match position {
+                LinePosition::Prepend => lines.iter().find(|candidate| candidate.content == line),
+                LinePosition::Append => lines.iter().rfind(|candidate| candidate.content == line),
+            };
+            if let Some(found) = found {
                 found.start..found.end
             } else {
                 return Ok(());
@@ -1096,9 +1131,9 @@ fn apply_one(req: &EditRequest, desired: Option<&str>) -> Result<()> {
 }
 
 fn apply_to_string(req: &EditRequest, desired: Option<&str>, text: &str) -> Result<String> {
-    let mut lines: Vec<String> = text.lines().map(|l| l.to_string()).collect();
     match &req.op {
         EditOp::Block { comment, .. } => {
+            let mut lines: Vec<String> = text.lines().map(|l| l.to_string()).collect();
             let id = &req.id;
             let desired = desired.expect("resolved block content");
             let mut block = vec![begin_marker(comment, id)];
@@ -1123,19 +1158,34 @@ fn apply_to_string(req: &EditRequest, desired: Option<&str>, text: &str) -> Resu
                     req.path_raw
                 ),
             }
+            let mut out = lines.join("\n");
+            out.push('\n');
+            Ok(out)
         }
-        EditOp::Line { line } => {
+        EditOp::Line { line, position } => {
             // an earlier entry in the same batch may have just written an
             // identical line (two ids, same text) — stay idempotent against
             // the file's current content, not the state at plan time
-            if !lines.iter().any(|l| l == line) {
-                lines.push(line.clone());
+            let (bom, body) = text
+                .strip_prefix('\u{feff}')
+                .map_or(("", text), |body| ("\u{feff}", body));
+            if body.lines().any(|candidate| candidate == line) {
+                return Ok(text.to_string());
             }
+            let newline = body
+                .find('\n')
+                .filter(|&i| i.checked_sub(1).and_then(|i| body.as_bytes().get(i)) == Some(&b'\r'))
+                .map_or("\n", |_| "\r\n");
+            let out = match position {
+                LinePosition::Prepend if body.is_empty() => format!("{bom}{line}{newline}"),
+                LinePosition::Prepend => format!("{bom}{line}{newline}{body}"),
+                LinePosition::Append if text.is_empty() => format!("{line}{newline}"),
+                LinePosition::Append if text.ends_with('\n') => format!("{text}{line}{newline}"),
+                LinePosition::Append => format!("{text}{newline}{line}{newline}"),
+            };
+            Ok(out)
         }
     }
-    let mut out = lines.join("\n");
-    out.push('\n');
-    Ok(out)
 }
 
 #[cfg(test)]

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -909,7 +909,11 @@ pub(crate) fn plan_unapply<'a>(
                 continue;
             }
         };
-        let lines = text.lines().collect::<Vec<_>>();
+        let lines = text
+            .strip_prefix('\u{feff}')
+            .unwrap_or(&text)
+            .lines()
+            .collect::<Vec<_>>();
         match &req.op {
             EditOp::Block { comment, .. } => match find_block(&lines, &req.id, comment) {
                 Ok(Some(_)) => todo.push(UnapplyPlan { req, text }),
@@ -1081,10 +1085,16 @@ fn text_lines(text: &str) -> Vec<TextLine<'_>> {
     let mut offset = 0;
     text.split_inclusive('\n')
         .map(|raw| {
-            let start = offset;
+            let mut start = offset;
             offset += raw.len();
             let content = raw.strip_suffix('\n').unwrap_or(raw);
-            let content = content.strip_suffix('\r').unwrap_or(content);
+            let mut content = content.strip_suffix('\r').unwrap_or(content);
+            if start == 0 {
+                if let Some(without_bom) = content.strip_prefix('\u{feff}') {
+                    start += '\u{feff}'.len_utf8();
+                    content = without_bom;
+                }
+            }
             TextLine {
                 content,
                 start,

--- a/src/system/edits.rs
+++ b/src/system/edits.rs
@@ -548,20 +548,26 @@ fn precheck(req: &EditRequest) -> Result<Option<EditCheck>> {
         return Ok(Some(EditCheck::State(FileState::Missing)));
     }
     let text = file::read_to_string(&req.path)?;
-    let lines: Vec<&str> = text.lines().collect();
     match &req.op {
-        EditOp::Block { comment, .. } => match find_block(&lines, &req.id, comment) {
-            Err(reason) => Ok(Some(EditCheck::Blocked(reason))),
-            Ok(None) => Ok(Some(EditCheck::State(FileState::Missing))),
-            Ok(Some(_)) => Ok(None),
-        },
-        EditOp::Line { line, .. } => {
-            Ok(Some(EditCheck::State(if lines.contains(&line.as_str()) {
+        EditOp::Block { comment, .. } => {
+            match find_block(&text.lines().collect::<Vec<_>>(), &req.id, comment) {
+                Err(reason) => Ok(Some(EditCheck::Blocked(reason))),
+                Ok(None) => Ok(Some(EditCheck::State(FileState::Missing))),
+                Ok(Some(_)) => Ok(None),
+            }
+        }
+        EditOp::Line { line, .. } => Ok(Some(EditCheck::State(
+            if text
+                .strip_prefix('\u{feff}')
+                .unwrap_or(&text)
+                .lines()
+                .any(|candidate| candidate == line)
+            {
                 FileState::Applied
             } else {
                 FileState::Missing
-            })))
-        }
+            },
+        ))),
     }
 }
 
@@ -1179,7 +1185,7 @@ fn apply_to_string(req: &EditRequest, desired: Option<&str>, text: &str) -> Resu
             let out = match position {
                 LinePosition::Prepend if body.is_empty() => format!("{bom}{line}{newline}"),
                 LinePosition::Prepend => format!("{bom}{line}{newline}{body}"),
-                LinePosition::Append if text.is_empty() => format!("{line}{newline}"),
+                LinePosition::Append if body.is_empty() => format!("{bom}{line}{newline}"),
                 LinePosition::Append if text.ends_with('\n') => format!("{text}{line}{newline}"),
                 LinePosition::Append => format!("{text}{newline}{line}{newline}"),
             };

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -548,7 +548,7 @@ pub(crate) fn validate_incoming_files(config_files: &ConfigMap) -> Result<()> {
                 // Managed line/block edits are handled by the edit engine,
                 // not by this whole-file declaration parser.
                 if value.as_table().is_some_and(|table| {
-                    ["block", "line", "template", "comment"]
+                    ["block", "line", "template", "comment", "position"]
                         .iter()
                         .any(|key| table.contains_key(*key))
                 }) {


### PR DESCRIPTION
## Summary

- Add `position = "prepend"` for exact-line dotfile edits while keeping `append` as the default.
- Leave an existing exact match in place instead of moving or duplicating it.
- Preserve all unrelated target bytes, including CRLF line endings and a UTF-8 BOM.
- Document the `/etc/zshrc` use case and validate the new field in the schema.

## Example

```toml
[dotfiles]
"/etc/zshrc/zdotdir" = { line = 'ZDOTDIR=$HOME/.config/zsh/', position = "prepend" }
```

## Verification

- `MBX_DISABLE=1 cargo test --locked --bin mise system::edits::tests`
- `MBX_DISABLE=1 mise run test:e2e e2e/cli/test_dotfiles_edits e2e/config/test_schema_tombi`
- `MBX_DISABLE=1 mise run lint`

The Cargo wrapper emitted action-prediction warnings and stalled around the final test-binary handoff during the initial run. The exact checks passed with the repository-documented `MBX_DISABLE=1` bypass.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `position = "prepend"` support for dotfile line edits.
  * Missing lines can be inserted at the beginning or end of a file; appending remains the default.
  * Insertion preserves newline styles and leading file markers.

* **Bug Fixes**
  * Improved handling of BOM-prefixed and BOM-only files.
  * Line insertion occurs only when exact content is absent.
  * Added validation for unsupported placement options and edit types.

* **Documentation**
  * Updated dotfile editing documentation and configuration schema to describe line placement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes byte-level file editing for dotfile line inserts (BOM/CRLF), which can affect bootstrap-managed config files if edge cases are wrong, but scope is limited to the edit engine with strong e2e tests.
> 
> **Overview**
> Dotfile **line** edits gain optional **`position = "prepend"`** (default **`append`**) so a missing exact line can be inserted at the start of the file—documented for cases like setting `ZDOTDIR` in `/etc/zshrc/zdotdir`.
> 
> Line apply/unapply in `edits.rs` was reworked so insertion only happens when the line is absent, existing matches are not moved or duplicated, and unrelated bytes stay intact (**CRLF** endings, leading **UTF-8 BOM**). Unapply picks the first or last matching line depending on prepend vs append. Config parsing rejects **`position`** on blocks and unknown placement values; the JSON schema and tombi tests enforce **`position`** only on line entries.
> 
> E2E coverage adds prepend/BOM scenarios and updates dotfiles docs for the new semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff37ecffba8b5d8f817fa47ef6292e933bd2ec15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->