### PR TITLE
fix(java): fold version verification into install progress

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -120,6 +120,7 @@ pub(crate) struct CmdLineRunner<'a> {
     pass_signals: bool,
     on_stdout: Option<Box<dyn Fn(String) + Send + 'a>>,
     on_stderr: Option<Box<dyn Fn(String) + Send + 'a>>,
+    stderr_as_stdout: bool,
     observe_stdout: Option<OutputObserver<'a>>,
     observe_stderr: Option<OutputObserver<'a>>,
     timeout: Option<Duration>,
@@ -569,6 +570,7 @@ impl<'a> CmdLineRunner<'a> {
             pass_signals: false,
             on_stdout: None,
             on_stderr: None,
+            stderr_as_stdout: false,
             observe_stdout: None,
             observe_stderr: None,
             timeout: None,
@@ -656,6 +658,11 @@ impl<'a> CmdLineRunner<'a> {
 
     pub(crate) fn with_on_stderr<F: Fn(String) + Send + 'a>(mut self, on_stderr: F) -> Self {
         self.on_stderr = Some(Box::new(on_stderr));
+        self
+    }
+
+    pub(crate) fn stderr_as_stdout(mut self) -> Self {
+        self.stderr_as_stdout = true;
         self
     }
 
@@ -950,7 +957,14 @@ impl<'a> CmdLineRunner<'a> {
                 }
                 ChildProcessOutput::Stderr(line) => {
                     let line = self.redactor.redact(&line);
-                    self.on_stderr(line);
+                    if self.stderr_as_stdout
+                        && let Some(output) = &mut failure_output
+                    {
+                        self.on_stderr(line.clone());
+                        output.push(line);
+                    } else {
+                        self.on_stderr(line);
+                    }
                 }
                 ChildProcessOutput::ExitStatus(s) => {
                     status = Some(s);
@@ -1135,7 +1149,14 @@ impl<'a> CmdLineRunner<'a> {
                         }
                         ChildProcessOutput::Stderr(line) => {
                             let line = self.redactor.redact(&line);
-                            self.on_stderr(line);
+                            if self.stderr_as_stdout
+                                && let Some(output) = &mut failure_output
+                            {
+                                self.on_stderr(line.clone());
+                                output.push(line);
+                            } else {
+                                self.on_stderr(line);
+                            }
                         }
                         ChildProcessOutput::ExitStatus(_) => {}
                         #[cfg(not(any(test, windows)))]
@@ -1183,7 +1204,14 @@ impl<'a> CmdLineRunner<'a> {
                 }
                 ChildProcessOutput::Stderr(line) => {
                     let line = self.redactor.redact(&line);
-                    self.on_stderr(line);
+                    if self.stderr_as_stdout
+                        && let Some(output) = &mut failure_output
+                    {
+                        self.on_stderr(line.clone());
+                        output.push(line);
+                    } else {
+                        self.on_stderr(line);
+                    }
                 }
                 ChildProcessOutput::ExitStatus(_) => {}
                 #[cfg(not(any(test, windows)))]
@@ -1789,6 +1817,20 @@ impl<'a> CmdLineRunner<'a> {
             on_stderr(line);
             return;
         }
+        if self.stderr_as_stdout {
+            if let Some(pr) = self
+                .pr
+                .or(self.pr_arc.as_ref().map(|arc| arc.as_ref().as_ref()))
+            {
+                if !line.trim().is_empty() {
+                    pr.set_process_output(line);
+                }
+            } else {
+                let mut stdout = std::io::stdout().lock();
+                let _ = writeln!(stdout, "{line}");
+            }
+            return;
+        }
         match self
             .pr
             .or(self.pr_arc.as_ref().map(|arc| arc.as_ref().as_ref()))
@@ -2024,12 +2066,50 @@ mod tests {
     #[derive(Debug, Default)]
     struct RecordingReport {
         lines: Mutex<Vec<String>>,
+        messages: Mutex<Vec<String>>,
     }
 
     impl SingleReport for RecordingReport {
         fn println(&self, message: String) {
             self.lines.lock().unwrap().push(message);
         }
+
+        fn set_message(&self, message: String) {
+            self.messages.lock().unwrap().push(message);
+        }
+    }
+
+    #[test]
+    fn test_stderr_as_stdout_routes_through_process_output() {
+        let report = RecordingReport::default();
+        let _ = super::CmdLineRunner::new("sh")
+            .args(["-c", "printf 'version banner\\n' >&2"])
+            .with_pr(&report)
+            .stderr_as_stdout()
+            .execute()
+            .unwrap();
+
+        assert!(report.lines.lock().unwrap().is_empty());
+        assert_eq!(
+            *report.messages.lock().unwrap(),
+            vec!["version banner".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_stderr_as_stdout_replays_hidden_output_on_failure() {
+        let report = RecordingReport::default();
+        let _ = super::CmdLineRunner::new("sh")
+            .args(["-c", "printf 'verification failed\\n' >&2; exit 1"])
+            .with_pr(&report)
+            .stderr_as_stdout()
+            .execute()
+            .unwrap_err();
+
+        assert_eq!(
+            *report.lines.lock().unwrap(),
+            vec!["verification failed".to_string()]
+        );
     }
 
     #[test]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -958,6 +958,7 @@ impl<'a> CmdLineRunner<'a> {
                 ChildProcessOutput::Stderr(line) => {
                     let line = self.redactor.redact(&line);
                     if self.stderr_as_stdout
+                        && self.on_stderr.is_none()
                         && let Some(output) = &mut failure_output
                     {
                         self.on_stderr(line.clone());
@@ -1150,6 +1151,7 @@ impl<'a> CmdLineRunner<'a> {
                         ChildProcessOutput::Stderr(line) => {
                             let line = self.redactor.redact(&line);
                             if self.stderr_as_stdout
+                                && self.on_stderr.is_none()
                                 && let Some(output) = &mut failure_output
                             {
                                 self.on_stderr(line.clone());
@@ -1205,6 +1207,7 @@ impl<'a> CmdLineRunner<'a> {
                 ChildProcessOutput::Stderr(line) => {
                     let line = self.redactor.redact(&line);
                     if self.stderr_as_stdout
+                        && self.on_stderr.is_none()
                         && let Some(output) = &mut failure_output
                     {
                         self.on_stderr(line.clone());
@@ -2082,7 +2085,7 @@ mod tests {
     #[test]
     fn test_stderr_as_stdout_routes_through_process_output() {
         let report = RecordingReport::default();
-        let _ = super::CmdLineRunner::new("sh")
+        super::CmdLineRunner::new("sh")
             .args(["-c", "printf 'version banner\\n' >&2"])
             .with_pr(&report)
             .stderr_as_stdout()
@@ -2099,16 +2102,40 @@ mod tests {
     #[test]
     fn test_stderr_as_stdout_replays_hidden_output_on_failure() {
         let report = RecordingReport::default();
-        let _ = super::CmdLineRunner::new("sh")
-            .args(["-c", "printf 'verification failed\\n' >&2; exit 1"])
-            .with_pr(&report)
-            .stderr_as_stdout()
-            .execute()
-            .unwrap_err();
+        drop(
+            super::CmdLineRunner::new("sh")
+                .args(["-c", "printf 'verification failed\\n' >&2; exit 1"])
+                .with_pr(&report)
+                .stderr_as_stdout()
+                .execute()
+                .unwrap_err(),
+        );
 
         assert_eq!(
             *report.lines.lock().unwrap(),
             vec!["verification failed".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_stderr_callback_is_not_replayed_on_failure() {
+        let report = RecordingReport::default();
+        let callback_lines = Arc::new(Mutex::new(Vec::new()));
+        let callback_lines_ref = Arc::clone(&callback_lines);
+        drop(
+            super::CmdLineRunner::new("sh")
+                .args(["-c", "printf 'callback failure\n' >&2; exit 1"])
+                .with_pr(&report)
+                .stderr_as_stdout()
+                .with_on_stderr(move |line| callback_lines_ref.lock().unwrap().push(line))
+                .execute()
+                .unwrap_err(),
+        );
+
+        assert!(report.lines.lock().unwrap().is_empty());
+        assert_eq!(
+            *callback_lines.lock().unwrap(),
+            vec!["callback failure".to_string()]
         );
     }
 

--- a/src/plugins/core/java.rs
+++ b/src/plugins/core/java.rs
@@ -188,6 +188,10 @@ impl JavaPlugin {
     fn test_java(&self, tv: &ToolVersion, pr: &dyn SingleReport) -> Result<()> {
         CmdLineRunner::new(self.java_bin(tv))
             .with_pr(pr)
+            // `java -version` writes its normal version banner to stderr. Treat
+            // it as ordinary process output so an interactive install can fold
+            // it into the tool's progress row instead of printing three lines.
+            .stderr_as_stdout()
             .env("JAVA_HOME", tv.install_path())
             .env_values(tv.install_env())
             .arg("-version")


### PR DESCRIPTION
## Summary
- add a command-runner option that treats stderr as ordinary process output
- use it for `java -version` verification so the normal three-line banner stays inside interactive install progress
- preserve failure replay when a reporter hides successful process output

## Tests
- `cargo test --locked --bin mise test_stderr_as_stdout`
- `cargo check --locked --all-features`
- `mise run test:e2e e2e/cli/test_install_text_progress`
- changed-file `hk run check --safe --format json`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to command output routing and Java install verification; behavior is unchanged unless callers opt in via `stderr_as_stdout()`.
> 
> **Overview**
> Adds a **`stderr_as_stdout()`** option on **`CmdLineRunner`** so stderr can be handled like stdout for progress UIs: with a reporter attached, lines go through **`set_process_output`** instead of **`println`** on stderr.
> 
> When output is hidden behind a progress row, stderr is included in the failure tail (unless **`with_on_stderr`** is set) so verification errors still replay on non-zero exit. **`JavaPlugin::test_java`** enables this for **`java -version`**, keeping the usual three-line banner in the install progress row instead of spamming the terminal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47d3c81363677db87f91f532fb52021a4ca93d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->