### PR TITLE
fix(bootstrap): sign macOS notification helper in releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ include = [
   "/zipsign.pub",
   "/src/**/*.rs",
   "/src/system/history/notify/macos.m",
+  "/src/system/history/notify/macos.plist",
   "/src/assets/**",
   "/src/plugins/core/assets/**",
   "/src/system/packages/brew/cask_shim.rb",

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ use indexmap::IndexMap;
 use serde::Serialize as _;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::{env, fs};
 
 use aqua_registry::encode_package_rkyv;
@@ -35,11 +36,20 @@ fn main() -> Result<()> {
 
 fn build_notification_helper() -> Result<()> {
     let source = "src/system/history/notify/macos.m";
+    let info = "src/system/history/notify/macos.plist";
+    let icon = "docs/public/android-chrome-512x512.png";
     println!("cargo:rerun-if-changed={source}");
+    println!("cargo:rerun-if-changed={info}");
+    println!("cargo:rerun-if-changed={icon}");
+    println!("cargo:rerun-if-env-changed=MISE_NOTIFICATION_SIGN_IDENTITY");
     if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
         return Ok(());
     }
-    let output = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("mise-notify");
+    let app = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("mise-notify.app");
+    let contents = app.join("Contents");
+    let output = contents.join("MacOS/mise-notify");
+    fs::create_dir_all(contents.join("MacOS"))?;
+    fs::create_dir_all(contents.join("Resources"))?;
     let status = cc::Build::new()
         .get_compiler()
         .to_command()
@@ -54,10 +64,47 @@ fn build_notification_helper() -> Result<()> {
         ])
         .arg(source)
         .arg("-o")
-        .arg(output)
+        .arg(&output)
         .status()?;
     if !status.success() {
         return Err(eyre!("failed to build the macOS notification helper"));
+    }
+    // The compiler may place a debug-symbol bundle beside the executable.
+    // It is not needed at runtime and must not become part of the app's seal,
+    // because only the runtime bundle is embedded in mise.
+    let debug_symbols = output.with_extension("dSYM");
+    if debug_symbols.exists() {
+        fs::remove_dir_all(debug_symbols)?;
+    }
+    fs::copy(info, contents.join("Info.plist"))?;
+    let png = fs::read(icon)?;
+    let mut icns = Vec::with_capacity(png.len() + 16);
+    icns.extend_from_slice(b"icns");
+    icns.extend_from_slice(&u32::try_from(png.len() + 16)?.to_be_bytes());
+    icns.extend_from_slice(b"ic09");
+    icns.extend_from_slice(&u32::try_from(png.len() + 8)?.to_be_bytes());
+    icns.extend_from_slice(&png);
+    fs::write(contents.join("Resources/mise.icns"), icns)?;
+
+    let identity = env::var("MISE_NOTIFICATION_SIGN_IDENTITY").unwrap_or_else(|_| "-".into());
+    println!(
+        "cargo:rustc-env=MISE_NOTIFICATION_RELEASE_SIGNED={}",
+        if identity == "-" { "0" } else { "1" }
+    );
+    let mut codesign = Command::new("/usr/bin/codesign");
+    codesign
+        .args(["--force", "--sign"])
+        .arg(&identity)
+        .args(["--identifier", "dev.jdx.mise.notifications"]);
+    if identity != "-" {
+        codesign.args(["--options", "runtime", "--timestamp"]);
+    }
+    let signed = codesign.arg(&app).output()?;
+    if !signed.status.success() {
+        return Err(eyre!(
+            "failed to sign the macOS notification helper: {}",
+            String::from_utf8_lossy(&signed.stderr).trim()
+        ));
     }
     Ok(())
 }

--- a/docs/history.md
+++ b/docs/history.md
@@ -432,11 +432,10 @@ silent; a later pause can notify again after recovery. Set
 `settings.history.notify = false` to opt out. Missing or failing notifiers
 never hold up history or sync.
 
-Linux and macOS notifications use the mise logo. On macOS, allow notifications
-for mise when asked; change that later in System Settings → Notifications → mise.
-Builds without notification support warn when a setup repository is connected.
-Notification failures never block sync. Alerts name the conflicting file and
-point to `mise bootstrap dotfiles status` for resolution steps.
+On macOS, allow notifications for mise when prompted; change this later in
+System Settings → Notifications → mise. Builds without notification support warn
+when a setup repository is connected. Notification failures never block sync.
+Alerts point to `mise bootstrap dotfiles status` for resolution steps.
 
 **Applying.** `mise bootstrap dotfiles pull` writes pending changes as one recoverable
 transaction (a protective checkpoint first, each file journaled, reload

--- a/docs/history.md
+++ b/docs/history.md
@@ -433,9 +433,10 @@ silent; a later pause can notify again after recovery. Set
 never hold up history or sync.
 
 On macOS, allow notifications for mise when prompted; change this later in
-System Settings → Notifications → mise. Builds without notification support warn
-when a setup repository is connected. Notification failures never block sync.
-Alerts point to `mise bootstrap dotfiles status` for resolution steps.
+System Settings → Notifications → mise. Unofficial builds, such as Homebrew,
+warn when connecting a setup repository because notifications are unavailable.
+Notification failures never block sync. Alerts point to
+`mise bootstrap dotfiles status` for resolution steps.
 
 **Applying.** `mise bootstrap dotfiles pull` writes pending changes as one recoverable
 transaction (a protective checkpoint first, each file journaled, reload

--- a/docs/history.md
+++ b/docs/history.md
@@ -432,10 +432,11 @@ silent; a later pause can notify again after recovery. Set
 `settings.history.notify = false` to opt out. Missing or failing notifiers
 never hold up history or sync.
 
-On macOS, allow notifications for mise when prompted; change this later in
-System Settings → Notifications → mise. Unofficial builds, such as Homebrew,
-warn when connecting a setup repository because notifications are unavailable.
-Notification failures never block sync. Alerts point to
+On Linux, notifications require `notify-send`. On macOS, allow notifications
+for mise when prompted; change this later in System Settings → Notifications →
+mise. Unofficial macOS builds, such as Homebrew, warn when connecting a setup
+repository because notifications are unavailable. Notification failures never
+block sync. Alerts point to
 `mise bootstrap dotfiles status` for resolution steps.
 
 **Applying.** `mise bootstrap dotfiles pull` writes pending changes as one recoverable

--- a/docs/history.md
+++ b/docs/history.md
@@ -432,14 +432,10 @@ silent; a later pause can notify again after recovery. Set
 `settings.history.notify = false` to opt out. Missing or failing notifiers
 never hold up history or sync.
 
-Linux and macOS notifications use the mise logo. Official macOS release binaries
-include a Developer ID-signed helper; allow notifications for mise when asked on
-first use, and change that permission later in System Settings > Notifications >
-mise. No compiler, extra notifier, or logo download is needed. Source builds
-without a Developer ID-signed helper warn when a setup repository is connected
-and do not show desktop notifications. Denied or unavailable notifications never
-block sync.
-Alerts name the conflicting file, explain that local saves still work, and
+Linux and macOS notifications use the mise logo. On macOS, allow notifications
+for mise when asked; change that later in System Settings → Notifications → mise.
+Builds without notification support warn when a setup repository is connected.
+Notification failures never block sync. Alerts name the conflicting file and
 point to `mise bootstrap dotfiles status` for resolution steps.
 
 **Applying.** `mise bootstrap dotfiles pull` writes pending changes as one recoverable

--- a/docs/history.md
+++ b/docs/history.md
@@ -432,10 +432,13 @@ silent; a later pause can notify again after recovery. Set
 `settings.history.notify = false` to opt out. Missing or failing notifiers
 never hold up history or sync.
 
-Linux and macOS notifications use the mise logo. On macOS, allow notifications
-for mise when asked on first use; you can change that permission in System
-Settings > Notifications > mise. The helper is included in mise: no compiler,
-extra notifier, or logo download is needed. Denied permissions never block sync.
+Linux and macOS notifications use the mise logo. Official macOS release binaries
+include a Developer ID-signed helper; allow notifications for mise when asked on
+first use, and change that permission later in System Settings > Notifications >
+mise. No compiler, extra notifier, or logo download is needed. Source builds
+without a Developer ID-signed helper warn when a setup repository is connected
+and do not show desktop notifications. Denied or unavailable notifications never
+block sync.
 Alerts name the conflicting file, explain that local saves still work, and
 point to `mise bootstrap dotfiles status` for resolution steps.
 

--- a/scripts/build-tarball.sh
+++ b/scripts/build-tarball.sh
@@ -88,6 +88,10 @@ if [[ $os == "macos" ]]; then
 	# legacy rebase/bind opcodes on every launch. Measurably faster startup for
 	# a binary this large. macOS 11 (EOL since 2023) cannot run these binaries.
 	export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-12.0}
+	# The notification helper is embedded as a complete signed app. Local builds
+	# use an ad-hoc identity; release builds use the same Developer ID certificate
+	# as the outer mise binary so macOS can validate it after extraction.
+	export MISE_NOTIFICATION_SIGN_IDENTITY="Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
 fi
 
 if [[ -n "${MISE_BOLT:-}" ]] && [[ -z "${MISE_PGO:-}" ]]; then
@@ -153,7 +157,7 @@ if [[ $os == "macos" ]]; then
 	# --options runtime and --timestamp are what the notary service requires;
 	# without them a submission comes back Invalid.
 	codesign -f --options runtime --timestamp --prefix dev.jdx. \
-		-s "Developer ID Application: Jeffrey Dickey (4993Y37DX6)" mise/bin/mise
+		-s "$MISE_NOTIFICATION_SIGN_IDENTITY" mise/bin/mise
 fi
 
 if [[ $os == "windows" ]]; then

--- a/settings.toml
+++ b/settings.toml
@@ -1306,12 +1306,10 @@ type = "Duration"
 default = true
 description = "Show a desktop notification when conflicts pause sharing for the setup. Enabled by default; retries stay silent until sharing recovers, and a notifier that is missing or failing never holds up history or sync."
 docs = """
-Linux uses `notify-send`. Official macOS release binaries use a bundled,
-Developer ID-signed mise helper app with the mise icon; allow notifications for
-mise when macOS asks on first use. Permission can be changed later in System
-Settings > Notifications > mise. No extra notifier is required. Source builds
-without a Developer ID-signed helper cannot show desktop notifications and warn
-when a setup repository is connected. Other platforms log the conflict only.
+Linux uses `notify-send`. On macOS, allow notifications for mise when asked;
+change that later in System Settings → Notifications → mise. Builds without
+notification support warn when a setup repository is connected. Other platforms
+log the conflict only.
 `mise bootstrap dotfiles status` and `mise doctor` show the same conflicts without notifications.
 """
 env = "MISE_HISTORY_NOTIFY"

--- a/settings.toml
+++ b/settings.toml
@@ -1306,9 +1306,9 @@ type = "Duration"
 default = true
 description = "Show a desktop notification when conflicts pause sharing for the setup. Enabled by default; retries stay silent until sharing recovers, and a notifier that is missing or failing never holds up history or sync."
 docs = """
-On macOS, allow notifications for mise when prompted. Builds without notification
-support warn when a setup repository is connected. Unsupported platforms log the
-conflict only.
+On macOS, allow notifications for mise when prompted. Unofficial builds, such as
+Homebrew, warn when connecting a setup repository because notifications are
+unavailable. Unsupported platforms log the conflict only.
 `mise bootstrap dotfiles status` and `mise doctor` show the same conflicts without notifications.
 """
 env = "MISE_HISTORY_NOTIFY"

--- a/settings.toml
+++ b/settings.toml
@@ -1306,10 +1306,12 @@ type = "Duration"
 default = true
 description = "Show a desktop notification when conflicts pause sharing for the setup. Enabled by default; retries stay silent until sharing recovers, and a notifier that is missing or failing never holds up history or sync."
 docs = """
-Linux uses `notify-send`. macOS uses a bundled mise helper app with the mise icon;
-allow notifications for mise when macOS asks on first use. Permission can be
-changed later in System Settings > Notifications > mise. No extra notifier is
-required. Other platforms log the conflict only.
+Linux uses `notify-send`. Official macOS release binaries use a bundled,
+Developer ID-signed mise helper app with the mise icon; allow notifications for
+mise when macOS asks on first use. Permission can be changed later in System
+Settings > Notifications > mise. No extra notifier is required. Source builds
+without a Developer ID-signed helper cannot show desktop notifications and warn
+when a setup repository is connected. Other platforms log the conflict only.
 `mise bootstrap dotfiles status` and `mise doctor` show the same conflicts without notifications.
 """
 env = "MISE_HISTORY_NOTIFY"

--- a/settings.toml
+++ b/settings.toml
@@ -1306,10 +1306,9 @@ type = "Duration"
 default = true
 description = "Show a desktop notification when conflicts pause sharing for the setup. Enabled by default; retries stay silent until sharing recovers, and a notifier that is missing or failing never holds up history or sync."
 docs = """
-Linux uses `notify-send`. On macOS, allow notifications for mise when asked;
-change that later in System Settings → Notifications → mise. Builds without
-notification support warn when a setup repository is connected. Other platforms
-log the conflict only.
+On macOS, allow notifications for mise when prompted. Builds without notification
+support warn when a setup repository is connected. Unsupported platforms log the
+conflict only.
 `mise bootstrap dotfiles status` and `mise doctor` show the same conflicts without notifications.
 """
 env = "MISE_HISTORY_NOTIFY"

--- a/settings.toml
+++ b/settings.toml
@@ -1306,9 +1306,10 @@ type = "Duration"
 default = true
 description = "Show a desktop notification when conflicts pause sharing for the setup. Enabled by default; retries stay silent until sharing recovers, and a notifier that is missing or failing never holds up history or sync."
 docs = """
-On macOS, allow notifications for mise when prompted. Unofficial builds, such as
-Homebrew, warn when connecting a setup repository because notifications are
-unavailable. Unsupported platforms log the conflict only.
+On Linux, notifications require `notify-send`. On macOS, allow notifications
+for mise when prompted. Unofficial macOS builds, such as Homebrew, warn when
+connecting a setup repository because notifications are unavailable. Unsupported
+platforms log the conflict only.
 `mise bootstrap dotfiles status` and `mise doctor` show the same conflicts without notifications.
 """
 env = "MISE_HISTORY_NOTIFY"

--- a/src/system/history/notify.rs
+++ b/src/system/history/notify.rs
@@ -1,7 +1,8 @@
 //! Optional desktop notifications for sync conflicts that newly need a
 //! decision (`settings.history.notify`, on by default). Best effort: the
-//! notifier runs and is reaped on a worker thread, a missing desktop or tool is a
-//! debug line, and nothing here ever holds up a capture or a sync.
+//! notifier is prepared before it is dispatched, then runs and is reaped on a
+//! worker thread. A missing desktop or tool is a debug line, and delivery never
+//! holds up a capture or a sync.
 
 use std::process::{Command, Stdio};
 
@@ -36,36 +37,73 @@ fn cache_logo(path: &std::path::Path) -> eyre::Result<()> {
 
 /// Shows a notification with `title` and `body`, if a notifier is available.
 pub(crate) fn send(title: &str, body: &str) {
-    let title = title.to_owned();
-    let body = body.to_owned();
-    if let Err(err) = dispatch(move || {
-        notifier(&title, &body).ok_or_else(|| std::io::Error::other("desktop notifier unavailable"))
-    }) {
-        debug!("history: could not start notification worker: {err}");
+    let Some(command) = notifier(title, body) else {
+        debug!("history: desktop notifier unavailable");
+        return;
+    };
+    if let Err(err) = dispatch(command) {
+        debug!("history: could not dispatch notification: {err}");
     }
 }
 
+#[cfg(target_os = "macos")]
+pub(crate) fn warn_if_release_signing_unavailable() {
+    if crate::config::Settings::get().history.notify && !macos::release_signed() {
+        warn!(
+            "this source-built mise cannot show macOS desktop notifications for setup conflicts because its embedded helper is not Developer ID signed; `mise bootstrap dotfiles status` and `mise doctor` still report conflicts"
+        );
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn warn_if_release_signing_unavailable() {}
+
 fn dispatch(
-    prepare: impl FnOnce() -> std::io::Result<Command> + Send + 'static,
+    mut command: Command,
 ) -> std::io::Result<std::thread::JoinHandle<std::io::Result<std::process::ExitStatus>>> {
-    // Prepare the bundle and reap the child off the watcher thread.
-    std::thread::Builder::new()
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let (started_tx, started_rx) = std::sync::mpsc::sync_channel(0);
+    let worker = std::thread::Builder::new()
         .name("mise-notification".into())
         .spawn(move || {
-            let result = prepare().and_then(|mut command| {
-                command
-                    .stdin(Stdio::null())
-                    .stdout(Stdio::null())
-                    .stderr(Stdio::null())
-                    .status()
-            });
+            // A short-lived `mise bootstrap dotfiles sync` may exit as soon as
+            // dispatch returns. Confirm that the helper process exists first;
+            // it can finish independently if this worker then goes away.
+            let mut child = match command.spawn() {
+                Ok(child) => {
+                    let _ = started_tx.send(Ok(()));
+                    child
+                }
+                Err(err) => {
+                    let notice = std::io::Error::new(err.kind(), err.to_string());
+                    let _ = started_tx.send(Err(notice));
+                    return Err(err);
+                }
+            };
+            let result = child.wait();
             match &result {
                 Ok(status) if status.success() => debug!("history: notifier completed"),
                 Ok(status) => debug!("history: notifier exited with {status}"),
                 Err(err) => debug!("history: could not run notifier: {err}"),
             }
             result
-        })
+        })?;
+    match started_rx.recv() {
+        Ok(Ok(())) => Ok(worker),
+        Ok(Err(err)) => {
+            let _ = worker.join();
+            Err(err)
+        }
+        Err(err) => {
+            let _ = worker.join();
+            Err(std::io::Error::other(format!(
+                "notification worker stopped before starting the helper: {err}"
+            )))
+        }
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -110,20 +148,10 @@ mod tests {
     fn notification_worker_reaps_the_child_and_reports_spawn_errors() {
         let mut command = Command::new("/bin/sh");
         command.args(["-c", "exit 7"]);
-        let status = dispatch(move || Ok(command))
-            .unwrap()
-            .join()
-            .unwrap()
-            .unwrap();
+        let status = dispatch(command).unwrap().join().unwrap().unwrap();
         assert_eq!(status.code(), Some(7));
         let missing = tempfile::tempdir().unwrap().path().join("missing-notifier");
-        assert!(
-            dispatch(move || Ok(Command::new(missing)))
-                .unwrap()
-                .join()
-                .unwrap()
-                .is_err()
-        );
+        assert!(dispatch(Command::new(missing)).is_err());
     }
 
     #[test]

--- a/src/system/history/notify.rs
+++ b/src/system/history/notify.rs
@@ -50,7 +50,7 @@ pub(crate) fn send(title: &str, body: &str) {
 pub(crate) fn warn_if_release_signing_unavailable() {
     if crate::config::Settings::get().history.notify && !macos::release_signed() {
         warn!(
-            "this source-built mise cannot show macOS desktop notifications for setup conflicts because its embedded helper is not Developer ID signed; `mise bootstrap dotfiles status` and `mise doctor` still report conflicts"
+            "macOS desktop notifications are unavailable in unofficial builds such as Homebrew; `mise bootstrap dotfiles status` and `mise doctor` still report setup conflicts"
         );
     }
 }

--- a/src/system/history/notify/macos.plist
+++ b/src/system/history/notify/macos.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>dev.jdx.mise.notifications</string>
+<key>CFBundleName</key><string>mise</string>
+<key>CFBundleDisplayName</key><string>mise</string>
+<key>CFBundleExecutable</key><string>mise-notify</string>
+<key>CFBundleIconFile</key><string>mise.icns</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+<key>CFBundleVersion</key><string>1</string>
+<key>LSUIElement</key><true/>
+<key>LSMinimumSystemVersion</key><string>10.14</string>
+</dict></plist>

--- a/src/system/history/notify/macos.rs
+++ b/src/system/history/notify/macos.rs
@@ -7,26 +7,31 @@ use std::process::Command;
 
 use eyre::{Result, bail};
 
-const HELPER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/mise-notify"));
-const ICON: &[u8] = include_bytes!("../../../../docs/public/android-chrome-512x512.png");
-const INFO: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-<key>CFBundleIdentifier</key><string>dev.jdx.mise.notifications</string>
-<key>CFBundleName</key><string>mise</string>
-<key>CFBundleDisplayName</key><string>mise</string>
-<key>CFBundleExecutable</key><string>mise-notify</string>
-<key>CFBundleIconFile</key><string>mise.icns</string>
-<key>CFBundlePackageType</key><string>APPL</string>
-<key>CFBundleVersion</key><string>1</string>
-<key>LSUIElement</key><true/>
-<key>LSMinimumSystemVersion</key><string>10.14</string>
-</dict></plist>"#;
+const HELPER: &[u8] = include_bytes!(concat!(
+    env!("OUT_DIR"),
+    "/mise-notify.app/Contents/MacOS/mise-notify"
+));
+const INFO: &[u8] = include_bytes!(concat!(
+    env!("OUT_DIR"),
+    "/mise-notify.app/Contents/Info.plist"
+));
+const ICON: &[u8] = include_bytes!(concat!(
+    env!("OUT_DIR"),
+    "/mise-notify.app/Contents/Resources/mise.icns"
+));
+const CODE_RESOURCES: &[u8] = include_bytes!(concat!(
+    env!("OUT_DIR"),
+    "/mise-notify.app/Contents/_CodeSignature/CodeResources"
+));
+
+pub(super) fn release_signed() -> bool {
+    env!("MISE_NOTIFICATION_RELEASE_SIGNED") == "1"
+}
 
 fn app_path(root: &Path) -> PathBuf {
     // A versioned directory permits safe replacement without modifying a
     // running helper. The bundle identifier remains stable across versions.
-    let fingerprint = crate::hash::hash_to_str(&(HELPER, ICON, INFO));
+    let fingerprint = crate::hash::hash_to_str(&(HELPER, INFO, ICON, CODE_RESOURCES));
     root.join(fingerprint).join("mise.app")
 }
 
@@ -38,9 +43,13 @@ fn complete(app: &Path) -> bool {
     executable(app).is_file()
         && app.join("Contents/Info.plist").is_file()
         && app.join("Contents/Resources/mise.icns").is_file()
+        && app.join("Contents/_CodeSignature/CodeResources").is_file()
 }
 
 pub(super) fn notification(title: &str, body: &str) -> Result<Command> {
+    if !release_signed() {
+        bail!("the embedded notification helper is not Developer ID signed");
+    }
     let app = ensure_app(&crate::dirs::DATA.join("notifications"))?;
     Ok(notification_command(&app, title, body))
 }
@@ -58,7 +67,9 @@ fn ensure_app(root: &Path) -> Result<PathBuf> {
     }
     crate::file::create_dir_all(root)?;
     let mut lock = fslock::LockFile::open(&root.join("install.lock"))?;
-    lock.lock()?;
+    if !lock.try_lock()? {
+        bail!("another process is installing the mise notification helper");
+    }
     if complete(&app) {
         return Ok(app);
     }
@@ -67,31 +78,15 @@ fn ensure_app(root: &Path) -> Result<PathBuf> {
     let contents = staged.join("Contents");
     std::fs::create_dir_all(contents.join("MacOS"))?;
     std::fs::create_dir_all(contents.join("Resources"))?;
+    std::fs::create_dir_all(contents.join("_CodeSignature"))?;
     std::fs::write(executable(&staged), HELPER)?;
     std::fs::set_permissions(executable(&staged), std::fs::Permissions::from_mode(0o755))?;
     std::fs::write(contents.join("Info.plist"), INFO)?;
-    // ICNS container with one lossless 512x512 PNG representation (ic09).
-    let mut icon = Vec::with_capacity(ICON.len() + 16);
-    icon.extend_from_slice(b"icns");
-    icon.extend_from_slice(&u32::try_from(ICON.len() + 16)?.to_be_bytes());
-    icon.extend_from_slice(b"ic09");
-    icon.extend_from_slice(&u32::try_from(ICON.len() + 8)?.to_be_bytes());
-    icon.extend_from_slice(ICON);
-    std::fs::write(contents.join("Resources/mise.icns"), icon)?;
-    // Ad-hoc sign this mise-owned bundle, never another installed app.
-    let signed = Command::new("/usr/bin/codesign")
-        .args([
-            "--force",
-            "--sign",
-            "-",
-            "--identifier",
-            "dev.jdx.mise.notifications",
-        ])
-        .arg(&staged)
-        .output()?;
-    if !signed.status.success() {
-        bail!("could not sign the mise notification helper");
-    }
+    std::fs::write(contents.join("Resources/mise.icns"), ICON)?;
+    std::fs::write(
+        contents.join("_CodeSignature/CodeResources"),
+        CODE_RESOURCES,
+    )?;
     std::fs::create_dir_all(app.parent().unwrap())?;
     if app.symlink_metadata().is_ok() {
         // Preserve an incomplete installation for inspection, rather than

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -303,6 +303,7 @@ pub(crate) async fn run(store: &Store, onboarding: &Onboarding) -> Result<Outcom
         status.disconnected = false;
     })?;
     super::origin::write_config(&onboarding.origin, &onboarding.branch, None)?;
+    crate::system::history::notify::warn_if_release_signing_unavailable();
 
     let applied = apply::apply(store, &tracked, &ApplyRequest::automatic()).await?;
     // a conflict (a file that exists here and differs) is not pending: it

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -99,6 +99,7 @@ async fn set_inner(
     // disclosure
     miseprintln!("Setup repository: {} (branch {})", opts.url, opts.branch);
     miseprintln!("Sync mode {}", opts.mode.disclosure());
+    crate::system::history::notify::warn_if_release_signing_unavailable();
     match &repo_state {
         RepoState::Empty => miseprintln!(
             "The repository is empty: the first publication creates `{}` with the mise marker.",


### PR DESCRIPTION
## Summary
- build and Developer ID-sign the complete macOS notification helper app during release packaging
- embed and reconstruct the signed bundle instead of signing it ad hoc at runtime
- wait until the helper process has started so short-lived sync commands cannot terminate before dispatch
- disable notifications in unsigned source builds and warn when users connect a setup origin

## Why
The released binary prepared and ad-hoc signed its helper on a detached worker. A short-lived `mise bootstrap dotfiles sync` could exit before that work completed, and macOS could reject the resulting helper as an unvalidated notification client. Release-time signing gives the helper a stable Developer ID identity, while the spawn handshake removes the process-exit race.

Homebrew and other source builds do not have the release signing identity, so they now get a clear warning during origin setup instead of silently expecting notifications that cannot be delivered.

## Verification
- `cargo test --all-features system::history::notify -- --nocapture`
- Developer ID build of the focused macOS helper test
- `codesign --verify --strict` on the reconstructed helper bundle
- isolated source-build origin setup showing the unsigned-build warning
- scoped `hk run check --safe --format json` for all changed files
- `plutil -lint src/system/history/notify/macos.plist`
- `cargo package --list --allow-dirty` confirms the helper sources and plist are packaged

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS notification delivery, build-time codesigning, and sync/onboarding UX; limited to macOS history notify but affects signed vs unsigned build behavior.
> 
> **Overview**
> **macOS conflict notifications** now rely on a **Developer ID–signed** `mise-notify.app` built at compile time (plist, icon, `codesign` via `MISE_NOTIFICATION_SIGN_IDENTITY`) instead of ad-hoc signing when the helper is extracted at runtime.
> 
> At runtime mise **copies the embedded signed bundle** (including `_CodeSignature/CodeResources`) into the data directory and **skips notifications** when the build was not release-signed (e.g. Homebrew). **`origin set` / onboarding** warn in that case while **`history.notify` docs** note the limitation.
> 
> **Dispatch** prepares the notifier command on the caller thread, then spawns the helper only after a **start handshake** so short **`dotfiles sync`** runs do not exit before the helper process exists. Install locking uses **`try_lock`** instead of blocking lock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d94cb796a8805d872d7b6b0fd59fd38456d13735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - macOS notifications now use a bundled, Developer ID-signed helper app in official release builds.
  - Notification permissions can be managed through macOS System Settings.

- **Bug Fixes**
  - Improved notification startup and error handling to avoid blocking and report unavailable helpers more reliably.
  - Setup flows now warn when source builds cannot provide signed macOS notifications.

- **Documentation**
  - Clarified notification behavior for official releases, source builds, and non-macOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->