### PR TITLE
feat(bootstrap): support typed plist collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,6 +6303,8 @@ dependencies = [
  "confique",
  "console",
  "contracts",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
  "ctor",
  "dashmap 6.2.1",
  "demand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,6 +288,10 @@ self_update = { version = "1", optional = true, default-features = false, featur
 landlock = "0.4"
 seccompiler = "0.5"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10"
+core-foundation-sys = "0.8"
+
 [target.'cfg(windows)'.dependencies]
 self_update = { version = "1", optional = true, default-features = false, features = [
   "archive-zip",

--- a/docs/bootstrap/macos-defaults.md
+++ b/docs/bootstrap/macos-defaults.md
@@ -105,18 +105,31 @@ a warning and are ignored.
 ## Raw defaults
 
 Each key under `[bootstrap.macos.defaults]` is a preferences domain. Quote
-domains containing dots. Values map to the matching `defaults write` type:
+domains containing dots. TOML values map to property-list types as follows:
 
-| TOML value | written as         | example                |
-| ---------- | ------------------ | ---------------------- |
-| boolean    | `-bool true/false` | `autohide = true`      |
-| integer    | `-int <n>`         | `tilesize = 48`        |
-| float      | `-float <n>`       | `scale = 1.5`          |
-| string     | `-string <s>`      | `orientation = "left"` |
+| TOML value | property-list type | example                        |
+| ---------- | ------------------ | ------------------------------ |
+| boolean    | boolean            | `autohide = true`              |
+| integer    | integer            | `tilesize = 48`                |
+| float      | real               | `scale = 1.5`                  |
+| string     | string             | `orientation = "left"`         |
+| array      | array              | `favorite-spaces = [1, 2, 3]`  |
+| table      | dictionary         | `options = { enabled = true }` |
 
-Other plist shapes (arrays, dicts, dates, data) are not supported; entries
-using them parse fine but are skipped with a warning, so configs written for
-newer mise versions still work.
+Arrays and tables are converted recursively, so nested values retain their
+types. For example, a Dock entry can be declared as an array of dictionaries:
+
+```toml
+[bootstrap.macos.defaults."com.apple.dock"]
+"persistent-apps" = [
+  { "tile-type" = "file-tile", "tile-data" = { "file-label" = "Terminal" } },
+]
+```
+
+The configured value replaces the entire preference value; arrays and
+dictionaries are not merged element-by-element. TOML dates and times are not
+supported and are skipped with a warning. Binary plist data has no native TOML
+type and is also not supported.
 
 ## Semantics
 
@@ -151,7 +164,7 @@ mise bootstrap macos defaults status            # shows defaults drift
 mise bootstrap macos defaults status --missing  # exit 1 if anything is unset or differs
 
 mise bootstrap macos defaults apply           # writes unset/differing defaults
-mise bootstrap macos defaults apply --dry-run # print the `defaults write` commands
+mise bootstrap macos defaults apply --dry-run # print the planned preference writes
 mise bootstrap macos defaults apply --yes     # skip the confirmation prompt
 ```
 

--- a/e2e/cli/test_system_defaults
+++ b/e2e/cli/test_system_defaults
@@ -3,7 +3,7 @@
 cat <<EOF >mise.toml
 [bootstrap.macos.defaults]
 NSGlobalDomain = { KeyRepeat = 2 }
-"com.apple.dock" = { autohide = true, tilesize = 48, orientation = "left" }
+"com.apple.dock" = { autohide = true, tilesize = 48, orientation = "left", "persistent-apps" = [{ "tile-type" = "file-tile", "tile-data" = { enabled = true, position = 1 } }] }
 
 [bootstrap.macos.dock]
 show_recents = false
@@ -26,6 +26,7 @@ assert_contains "mise bootstrap macos defaults status" "show-recents"
 assert_contains "mise bootstrap macos defaults status" "AppleShowAllFiles"
 assert_contains "mise bootstrap macos defaults status" "InitialKeyRepeat"
 assert_contains "mise bootstrap macos defaults status" "Clicking"
+assert_contains "mise bootstrap macos defaults status" "persistent-apps"
 assert_contains "mise bootstrap macos defaults status --json" '"macos_defaults"'
 if [[ $(uname) != "Darwin" ]]; then
   assert_contains "mise bootstrap macos defaults status" "skipped"
@@ -39,10 +40,10 @@ fi
 # dry-run never writes anything
 assert_succeed "mise bootstrap macos defaults apply --dry-run --yes"
 
-# unsupported value types warn but don't fail
+# unsupported TOML datetimes warn but don't fail
 cat <<EOF >mise.toml
 [bootstrap.macos.defaults]
-"com.apple.dock" = { future-array = [1, 2] }
+"com.apple.dock" = { future-date = 1979-05-27T07:32:00Z }
 EOF
 assert_succeed "mise bootstrap macos defaults status"
 assert_contains "mise bootstrap macos defaults status 2>&1" "unsupported value type"

--- a/src/system/defaults.rs
+++ b/src/system/defaults.rs
@@ -69,6 +69,7 @@ impl DefaultsValue {
         }
     }
 
+    #[cfg(any(target_os = "macos", test))]
     fn to_plist(&self) -> plist::Value {
         match self {
             Self::Bool(value) => plist::Value::Boolean(*value),
@@ -169,6 +170,11 @@ pub(crate) fn unavailable_reason() -> String {
 
 /// Query the current state of each entry. Side-effect free.
 pub(crate) async fn status(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsStatus>> {
+    let requests = requests.to_vec();
+    tokio::task::spawn_blocking(move || status_sync(&requests)).await?
+}
+
+fn status_sync(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsStatus>> {
     let mut out = vec![];
     for req in requests {
         let state = match read(&req.domain, &req.key)? {
@@ -205,9 +211,12 @@ pub(crate) async fn apply(requests: &[DefaultsRequest], dry_run: bool) -> Result
             continue;
         }
         debug!("setting macOS preference {req}");
-        write(&req.domain, &req.key, &req.value)?;
     }
-    Ok(())
+    if dry_run {
+        return Ok(());
+    }
+    let requests = requests.to_vec();
+    tokio::task::spawn_blocking(move || write_all(&requests)).await?
 }
 
 fn display_plist(value: &plist::Value) -> String {
@@ -240,12 +249,12 @@ fn read(_domain: &str, _key: &str) -> Result<Option<plist::Value>> {
 }
 
 #[cfg(target_os = "macos")]
-fn write(domain: &str, key: &str, value: &DefaultsValue) -> Result<()> {
-    macos::write(domain, key, value)
+fn write_all(requests: &[DefaultsRequest]) -> Result<()> {
+    macos::write_all(requests)
 }
 
 #[cfg(not(target_os = "macos"))]
-fn write(_domain: &str, _key: &str, _value: &DefaultsValue) -> Result<()> {
+fn write_all(_requests: &[DefaultsRequest]) -> Result<()> {
     Ok(())
 }
 
@@ -262,6 +271,7 @@ mod macos {
     use core_foundation_sys::propertylist::{
         kCFPropertyListImmutable, kCFPropertyListXMLFormat_v1_0,
     };
+    use indexmap::IndexSet;
 
     use super::*;
 
@@ -297,7 +307,7 @@ mod macos {
         Ok(Some(plist::Value::from_reader_xml(data.bytes())?))
     }
 
-    pub(super) fn write(domain: &str, key: &str, value: &DefaultsValue) -> Result<()> {
+    fn set(domain: &str, key: &str, value: &DefaultsValue) -> Result<()> {
         let mut xml = Vec::new();
         plist::to_writer_xml(&mut xml, &value.to_plist())?;
         let data = CFData::from_buffer(&xml);
@@ -314,6 +324,13 @@ mod macos {
                 kCFPreferencesCurrentUser,
                 kCFPreferencesAnyHost,
             );
+        }
+        Ok(())
+    }
+
+    fn synchronize(domain: &str) -> Result<()> {
+        let (_application, application_id) = application_id(domain);
+        unsafe {
             if CFPreferencesSynchronize(
                 application_id,
                 kCFPreferencesCurrentUser,
@@ -322,6 +339,18 @@ mod macos {
             {
                 eyre::bail!("failed to synchronize macOS preference domain {domain}");
             }
+        }
+        Ok(())
+    }
+
+    pub(super) fn write_all(requests: &[DefaultsRequest]) -> Result<()> {
+        let mut domains = IndexSet::new();
+        for request in requests {
+            set(&request.domain, &request.key, &request.value)?;
+            domains.insert(request.domain.as_str());
+        }
+        for domain in domains {
+            synchronize(domain)?;
         }
         Ok(())
     }
@@ -489,7 +518,12 @@ mod tests {
         ))
         .unwrap();
 
-        write(domain, key, &value).unwrap();
+        write_all(&[DefaultsRequest {
+            domain: domain.into(),
+            key: key.into(),
+            value: value.clone(),
+        }])
+        .unwrap();
         let current = read(domain, key);
         let cleanup = macos::remove(domain, key);
 

--- a/src/system/defaults.rs
+++ b/src/system/defaults.rs
@@ -229,12 +229,39 @@ fn display_plist(value: &plist::Value) -> String {
             .unwrap_or_else(|| format!("{value:?}")),
         plist::Value::Real(value) => value.to_string(),
         plist::Value::String(value) => value.clone(),
-        plist::Value::Array(values) => format!("array ({} items)", values.len()),
-        plist::Value::Dictionary(values) => format!("dictionary ({} entries)", values.len()),
+        plist::Value::Array(values) => plist_to_json(value)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| format!("array ({} items)", values.len())),
+        plist::Value::Dictionary(values) => plist_to_json(value)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| format!("dictionary ({} entries)", values.len())),
         plist::Value::Data(value) => format!("data ({} bytes)", value.len()),
         plist::Value::Date(value) => format!("{value:?}"),
         plist::Value::Uid(value) => format!("{value:?}"),
         _ => format!("{value:?}"),
+    }
+}
+
+fn plist_to_json(value: &plist::Value) -> Option<serde_json::Value> {
+    match value {
+        plist::Value::Boolean(value) => Some((*value).into()),
+        plist::Value::Integer(value) => value
+            .as_signed()
+            .map(Into::into)
+            .or_else(|| value.as_unsigned().map(Into::into)),
+        plist::Value::Real(value) => Some((*value).into()),
+        plist::Value::String(value) => Some(value.clone().into()),
+        plist::Value::Array(values) => values
+            .iter()
+            .map(plist_to_json)
+            .collect::<Option<Vec<_>>>()
+            .map(Into::into),
+        plist::Value::Dictionary(values) => values
+            .iter()
+            .map(|(key, value)| Some((key.clone(), plist_to_json(value)?)))
+            .collect::<Option<serde_json::Map<_, _>>>()
+            .map(Into::into),
+        _ => None,
     }
 }
 
@@ -474,6 +501,19 @@ mod tests {
 
         let nested = DefaultsValue::from_toml(&val("[{ enabled = true, count = 2 }]")).unwrap();
         assert!(nested.matches(&nested.to_plist()));
+    }
+
+    #[test]
+    fn test_display_plist_collections() {
+        let nested = DefaultsValue::from_toml(&val("[{ enabled = true, count = 2 }]")).unwrap();
+        assert_eq!(
+            display_plist(&nested.to_plist()),
+            r#"[{"enabled":true,"count":2}]"#
+        );
+        assert_eq!(
+            display_plist(&plist::Value::Array(vec![plist::Value::Data(vec![1])])),
+            "array (1 items)"
+        );
     }
 
     /// `status()` must not fail when keys don't exist yet — this is the

--- a/src/system/defaults.rs
+++ b/src/system/defaults.rs
@@ -1,15 +1,11 @@
 //! macOS user defaults (preferences) for the `[bootstrap.macos.defaults]` config section.
 //!
-//! Entries are written with `defaults write <domain> <key> <-type> <value>`
-//! and checked with `defaults read-type`/`defaults read`. Like
-//! `[bootstrap.packages]` they are machine-global, declarative, and only ever
-//! applied when explicitly requested with `mise bootstrap macos defaults apply`
-//! or `mise bootstrap`.
+//! Entries are read and written with Core Foundation's preferences API so
+//! nested property-list values retain their types. Like `[bootstrap.packages]`
+//! they are machine-global, declarative, and only ever applied when explicitly
+//! requested with `mise bootstrap macos defaults apply` or `mise bootstrap`.
 
-use std::process::Stdio;
-use std::sync::LazyLock;
-
-use regex::Regex;
+use indexmap::IndexMap;
 
 use crate::result::Result;
 
@@ -28,15 +24,16 @@ impl std::fmt::Display for DefaultsRequest {
     }
 }
 
-/// The value types `defaults write` can set and mise can verify. Other plist
-/// types (arrays, dicts, dates, data) are not supported — config entries with
-/// those TOML types warn and are skipped.
+/// Property-list values that mise can write and verify. TOML arrays and tables
+/// are converted recursively, preserving the types of nested values.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum DefaultsValue {
     Bool(bool),
     Int(i64),
     Float(f64),
     Str(String),
+    Array(Vec<Self>),
+    Dict(IndexMap<String, Self>),
 }
 
 impl DefaultsValue {
@@ -46,17 +43,46 @@ impl DefaultsValue {
             toml::Value::Integer(i) => Some(Self::Int(*i)),
             toml::Value::Float(f) => Some(Self::Float(*f)),
             toml::Value::String(s) => Some(Self::Str(s.clone())),
-            _ => None,
+            toml::Value::Array(values) => values
+                .iter()
+                .map(Self::from_toml)
+                .collect::<Option<Vec<_>>>()
+                .map(Self::Array),
+            toml::Value::Table(values) => values
+                .iter()
+                .map(|(key, value)| Some((key.clone(), Self::from_toml(value)?)))
+                .collect::<Option<IndexMap<_, _>>>()
+                .map(Self::Dict),
+            toml::Value::Datetime(_) => None,
         }
     }
 
-    /// type+value arguments for `defaults write <domain> <key> ...`
-    pub(crate) fn write_args(&self) -> Vec<String> {
+    /// A copy-pasteable `defaults write` suffix for scalar values. The CLI
+    /// cannot safely represent nested typed property-list values.
+    fn write_args(&self) -> Option<Vec<String>> {
         match self {
-            Self::Bool(b) => vec!["-bool".into(), b.to_string()],
-            Self::Int(i) => vec!["-int".into(), i.to_string()],
-            Self::Float(f) => vec!["-float".into(), f.to_string()],
-            Self::Str(s) => vec!["-string".into(), s.clone()],
+            Self::Bool(b) => Some(vec!["-bool".into(), b.to_string()]),
+            Self::Int(i) => Some(vec!["-int".into(), i.to_string()]),
+            Self::Float(f) => Some(vec!["-float".into(), f.to_string()]),
+            Self::Str(s) => Some(vec!["-string".into(), s.clone()]),
+            Self::Array(_) | Self::Dict(_) => None,
+        }
+    }
+
+    fn to_plist(&self) -> plist::Value {
+        match self {
+            Self::Bool(value) => plist::Value::Boolean(*value),
+            Self::Int(value) => plist::Value::Integer((*value).into()),
+            Self::Float(value) => plist::Value::Real(*value),
+            Self::Str(value) => plist::Value::String(value.clone()),
+            Self::Array(values) => plist::Value::Array(values.iter().map(Self::to_plist).collect()),
+            Self::Dict(values) => {
+                let mut dict = plist::Dictionary::new();
+                for (key, value) in values {
+                    dict.insert(key.clone(), value.to_plist());
+                }
+                plist::Value::Dictionary(dict)
+            }
         }
     }
 
@@ -66,22 +92,41 @@ impl DefaultsValue {
             Self::Int(i) => (*i).into(),
             Self::Float(f) => (*f).into(),
             Self::Str(s) => s.clone().into(),
+            Self::Array(values) => values.iter().map(Self::to_json).collect::<Vec<_>>().into(),
+            Self::Dict(values) => values
+                .iter()
+                .map(|(key, value)| (key.clone(), value.to_json()))
+                .collect::<serde_json::Map<_, _>>()
+                .into(),
         }
     }
 
-    /// Does the pair from `defaults read-type` ("boolean", "integer", ...)
-    /// and `defaults read` (raw value; booleans print as 1/0) match this
-    /// value? Types are compared strictly: an integer 1 does not satisfy a
-    /// configured `true` — `mise bootstrap macos defaults apply` converges it to the typed
-    /// value.
-    fn matches(&self, read_type: &str, raw: &str) -> bool {
-        match self {
-            Self::Bool(b) => read_type == "boolean" && raw == if *b { "1" } else { "0" },
-            Self::Int(i) => read_type == "integer" && raw.parse::<i64>() == Ok(*i),
-            Self::Float(f) => {
-                read_type == "float" && raw.parse::<f64>().is_ok_and(|v| (v - f).abs() < 1e-9)
+    fn matches(&self, current: &plist::Value) -> bool {
+        match (self, current) {
+            (Self::Bool(expected), plist::Value::Boolean(current)) => expected == current,
+            (Self::Int(expected), plist::Value::Integer(current)) => {
+                current.as_signed() == Some(*expected)
             }
-            Self::Str(s) => read_type == "string" && raw == s,
+            (Self::Float(expected), plist::Value::Real(current)) => {
+                (current - expected).abs() < 1e-9
+            }
+            (Self::Str(expected), plist::Value::String(current)) => expected == current,
+            (Self::Array(expected), plist::Value::Array(current)) => {
+                expected.len() == current.len()
+                    && expected
+                        .iter()
+                        .zip(current)
+                        .all(|(expected, current)| expected.matches(current))
+            }
+            (Self::Dict(expected), plist::Value::Dictionary(current)) => {
+                expected.len() == current.len()
+                    && expected.iter().all(|(key, expected)| {
+                        current
+                            .get(key)
+                            .is_some_and(|current| expected.matches(current))
+                    })
+            }
+            _ => false,
         }
     }
 }
@@ -93,6 +138,7 @@ impl std::fmt::Display for DefaultsValue {
             Self::Int(i) => write!(f, "{i}"),
             Self::Float(v) => write!(f, "{v}"),
             Self::Str(s) => write!(f, "{s}"),
+            Self::Array(_) | Self::Dict(_) => write!(f, "{}", self.to_json()),
         }
     }
 }
@@ -114,34 +160,25 @@ pub(crate) struct DefaultsStatus {
 }
 
 pub(crate) fn is_available() -> bool {
-    cfg!(target_os = "macos") && crate::file::which("defaults").is_some()
+    cfg!(target_os = "macos")
 }
 
 pub(crate) fn unavailable_reason() -> String {
-    if cfg!(target_os = "macos") {
-        "`defaults` not found".to_string()
-    } else {
-        "only available on macos".to_string()
-    }
+    "only available on macos".to_string()
 }
 
 /// Query the current state of each entry. Side-effect free.
 pub(crate) async fn status(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsStatus>> {
     let mut out = vec![];
     for req in requests {
-        let state = match read(&req.domain, &req.key).await? {
-            Some((read_type, raw)) => {
-                if req.value.matches(&read_type, &raw) {
+        let state = match read(&req.domain, &req.key)? {
+            Some(current) => {
+                if req.value.matches(&current) {
                     DefaultsState::Set
                 } else {
-                    // call out a type mismatch when the raw value alone
-                    // would look identical to the configured one
-                    let current = if raw == req.value.to_string() {
-                        format!("{raw} ({read_type})")
-                    } else {
-                        raw
-                    };
-                    DefaultsState::Differs { current }
+                    DefaultsState::Differs {
+                        current: display_plist(&current),
+                    }
                 }
             }
             None => DefaultsState::Unset,
@@ -157,83 +194,161 @@ pub(crate) async fn status(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsS
 /// Write the given entries (already filtered to unset/differing ones)
 pub(crate) async fn apply(requests: &[DefaultsRequest], dry_run: bool) -> Result<()> {
     for req in requests {
-        let mut args = vec!["write".to_string(), req.domain.clone(), req.key.clone()];
-        args.extend(req.value.write_args());
-        // shell-quoted so the printed command is copy-pasteable even when a
-        // string value contains spaces
-        let display = shell_words::join(&args);
         if dry_run {
-            miseprintln!("defaults {display}");
+            if let Some(write_args) = req.value.write_args() {
+                let mut args = vec!["write".to_string(), req.domain.clone(), req.key.clone()];
+                args.extend(write_args);
+                miseprintln!("defaults {}", shell_words::join(&args));
+            } else {
+                miseprintln!("macOS preference {req}");
+            }
             continue;
         }
-        debug!("$ defaults {display}");
-        let output = tokio::process::Command::new("defaults")
-            .args(&args)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .await?;
-        if !output.status.success() {
-            eyre::bail!(
-                "`defaults {display}` failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
-        }
+        debug!("setting macOS preference {req}");
+        write(&req.domain, &req.key, &req.value)?;
     }
     Ok(())
 }
 
-/// `defaults read-type` + `defaults read` for one key. Returns
-/// `(type, raw value)`, or None when the key (or domain) does not exist —
-/// both commands exit non-zero for that, which is not an error here.
-async fn read(domain: &str, key: &str) -> Result<Option<(String, String)>> {
-    let Some(read_type) = defaults_cmd(&["read-type", domain, key]).await? else {
-        return Ok(None);
-    };
-    // "Type is boolean" -> "boolean"
-    let read_type = read_type
-        .strip_prefix("Type is ")
-        .unwrap_or(&read_type)
-        .to_string();
-    let Some(raw) = defaults_cmd(&["read", domain, key]).await? else {
-        return Ok(None);
-    };
-    Ok(Some((read_type, raw)))
+fn display_plist(value: &plist::Value) -> String {
+    match value {
+        plist::Value::Boolean(value) => value.to_string(),
+        plist::Value::Integer(value) => value
+            .as_signed()
+            .map(|value| value.to_string())
+            .or_else(|| value.as_unsigned().map(|value| value.to_string()))
+            .unwrap_or_else(|| format!("{value:?}")),
+        plist::Value::Real(value) => value.to_string(),
+        plist::Value::String(value) => value.clone(),
+        plist::Value::Array(values) => format!("array ({} items)", values.len()),
+        plist::Value::Dictionary(values) => format!("dictionary ({} entries)", values.len()),
+        plist::Value::Data(value) => format!("data ({} bytes)", value.len()),
+        plist::Value::Date(value) => format!("{value:?}"),
+        plist::Value::Uid(value) => format!("{value:?}"),
+        _ => format!("{value:?}"),
+    }
 }
 
-async fn defaults_cmd(args: &[&str]) -> Result<Option<String>> {
-    debug!("$ defaults {}", shell_words::join(args));
-    let output = tokio::process::Command::new("defaults")
-        .args(args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .await?;
-    if !output.status.success() {
-        // "does not exist" is the expected missing-key/-domain answer;
-        // "could not find key" is the same for `read-type`;
-        // "Domain [...] not found" is the expected answer when the domain does not exist;
-        // any other failure (cfprefsd unavailable, managed domain, ...) must not
-        // masquerade as Unset
-        static MISSING_KEY_RE: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(r"(?i)does not exist|could not find key|Domain .* not found").unwrap()
-        });
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if MISSING_KEY_RE.is_match(&stderr) {
+#[cfg(target_os = "macos")]
+fn read(domain: &str, key: &str) -> Result<Option<plist::Value>> {
+    macos::read(domain, key)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read(_domain: &str, _key: &str) -> Result<Option<plist::Value>> {
+    Ok(None)
+}
+
+#[cfg(target_os = "macos")]
+fn write(domain: &str, key: &str, value: &DefaultsValue) -> Result<()> {
+    macos::write(domain, key, value)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn write(_domain: &str, _key: &str, _value: &DefaultsValue) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use core_foundation::base::TCFType;
+    use core_foundation::data::CFData;
+    use core_foundation::propertylist::{CFPropertyList, create_data, create_with_data};
+    use core_foundation::string::CFString;
+    use core_foundation_sys::preferences::{
+        CFPreferencesCopyValue, CFPreferencesSetValue, CFPreferencesSynchronize,
+        kCFPreferencesAnyApplication, kCFPreferencesAnyHost, kCFPreferencesCurrentUser,
+    };
+    use core_foundation_sys::propertylist::{
+        kCFPropertyListImmutable, kCFPropertyListXMLFormat_v1_0,
+    };
+
+    use super::*;
+
+    fn application_id(
+        domain: &str,
+    ) -> (Option<CFString>, core_foundation_sys::string::CFStringRef) {
+        if matches!(domain, "NSGlobalDomain" | "-g" | "-globalDomain") {
+            (None, unsafe { kCFPreferencesAnyApplication })
+        } else {
+            let domain = CFString::new(domain);
+            let reference = domain.as_concrete_TypeRef();
+            (Some(domain), reference)
+        }
+    }
+
+    pub(super) fn read(domain: &str, key: &str) -> Result<Option<plist::Value>> {
+        let key = CFString::new(key);
+        let (_application, application_id) = application_id(domain);
+        let value = unsafe {
+            CFPreferencesCopyValue(
+                key.as_concrete_TypeRef(),
+                application_id,
+                kCFPreferencesCurrentUser,
+                kCFPreferencesAnyHost,
+            )
+        };
+        if value.is_null() {
             return Ok(None);
         }
-        eyre::bail!(
-            "`defaults {}` failed: {}",
-            shell_words::join(args),
-            stderr.trim()
-        );
+        let value = unsafe { CFPropertyList::wrap_under_create_rule(value) };
+        let data = create_data(value.as_CFTypeRef(), kCFPropertyListXMLFormat_v1_0)
+            .map_err(|err| eyre::eyre!("failed to serialize macOS preference: {err}"))?;
+        Ok(Some(plist::Value::from_reader_xml(data.bytes())?))
     }
-    // strip only the trailing newline — leading/trailing spaces can be
-    // significant in string values
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(Some(stdout.trim_end_matches(['\r', '\n']).to_string()))
+
+    pub(super) fn write(domain: &str, key: &str, value: &DefaultsValue) -> Result<()> {
+        let mut xml = Vec::new();
+        plist::to_writer_xml(&mut xml, &value.to_plist())?;
+        let data = CFData::from_buffer(&xml);
+        let (value, _) = create_with_data(data, kCFPropertyListImmutable)
+            .map_err(|err| eyre::eyre!("failed to parse macOS preference: {err}"))?;
+        let value = unsafe { CFPropertyList::wrap_under_create_rule(value) };
+        let key = CFString::new(key);
+        let (_application, application_id) = application_id(domain);
+        unsafe {
+            CFPreferencesSetValue(
+                key.as_concrete_TypeRef(),
+                value.as_CFTypeRef(),
+                application_id,
+                kCFPreferencesCurrentUser,
+                kCFPreferencesAnyHost,
+            );
+            if CFPreferencesSynchronize(
+                application_id,
+                kCFPreferencesCurrentUser,
+                kCFPreferencesAnyHost,
+            ) == 0
+            {
+                eyre::bail!("failed to synchronize macOS preference domain {domain}");
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(super) fn remove(domain: &str, key: &str) -> Result<()> {
+        let key = CFString::new(key);
+        let (_application, application_id) = application_id(domain);
+        unsafe {
+            CFPreferencesSetValue(
+                key.as_concrete_TypeRef(),
+                std::ptr::null(),
+                application_id,
+                kCFPreferencesCurrentUser,
+                kCFPreferencesAnyHost,
+            );
+            if CFPreferencesSynchronize(
+                application_id,
+                kCFPreferencesCurrentUser,
+                kCFPreferencesAnyHost,
+            ) == 0
+            {
+                eyre::bail!("failed to synchronize macOS preference domain {domain}");
+            }
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -262,50 +377,78 @@ mod tests {
             DefaultsValue::from_toml(&val(r#""right""#)),
             Some(DefaultsValue::Str("right".into()))
         );
+        assert_eq!(
+            DefaultsValue::from_toml(&val("[1, true]")),
+            Some(DefaultsValue::Array(vec![
+                DefaultsValue::Int(1),
+                DefaultsValue::Bool(true),
+            ]))
+        );
+        assert_eq!(
+            DefaultsValue::from_toml(&val(r#"{ a = 1, nested = { enabled = true } }"#)),
+            Some(DefaultsValue::Dict(IndexMap::from([
+                ("a".into(), DefaultsValue::Int(1)),
+                (
+                    "nested".into(),
+                    DefaultsValue::Dict(IndexMap::from([(
+                        "enabled".into(),
+                        DefaultsValue::Bool(true),
+                    )])),
+                ),
+            ])))
+        );
 
-        // unsupported plist shapes are None -> warned + skipped by the caller
-        assert_eq!(DefaultsValue::from_toml(&val("[1, 2]")), None);
-        assert_eq!(DefaultsValue::from_toml(&val("{ a = 1 }")), None);
+        // Dates and times remain unsupported; this change only adds arrays and tables.
+        assert_eq!(DefaultsValue::from_toml(&val("1979-05-27T07:32:00Z")), None);
     }
 
     #[test]
     fn test_write_args() {
-        assert_eq!(DefaultsValue::Bool(true).write_args(), ["-bool", "true"]);
-        assert_eq!(DefaultsValue::Bool(false).write_args(), ["-bool", "false"]);
-        assert_eq!(DefaultsValue::Int(2).write_args(), ["-int", "2"]);
-        assert_eq!(DefaultsValue::Float(0.5).write_args(), ["-float", "0.5"]);
         assert_eq!(
-            DefaultsValue::Str("left".into()).write_args(),
+            DefaultsValue::Bool(true).write_args().unwrap(),
+            ["-bool", "true"]
+        );
+        assert_eq!(
+            DefaultsValue::Bool(false).write_args().unwrap(),
+            ["-bool", "false"]
+        );
+        assert_eq!(DefaultsValue::Int(2).write_args().unwrap(), ["-int", "2"]);
+        assert_eq!(
+            DefaultsValue::Float(0.5).write_args().unwrap(),
+            ["-float", "0.5"]
+        );
+        assert_eq!(
+            DefaultsValue::Str("left".into()).write_args().unwrap(),
             ["-string", "left"]
         );
+        assert_eq!(DefaultsValue::Array(vec![]).write_args(), None);
     }
 
     #[test]
     fn test_matches() {
-        // booleans read back as 1/0
-        assert!(DefaultsValue::Bool(true).matches("boolean", "1"));
-        assert!(DefaultsValue::Bool(false).matches("boolean", "0"));
-        assert!(!DefaultsValue::Bool(true).matches("boolean", "0"));
+        assert!(DefaultsValue::Bool(true).matches(&plist::Value::Boolean(true)));
+        assert!(DefaultsValue::Bool(false).matches(&plist::Value::Boolean(false)));
+        assert!(!DefaultsValue::Bool(true).matches(&plist::Value::Boolean(false)));
         // strict typing: integer 1 does not satisfy `true`
-        assert!(!DefaultsValue::Bool(true).matches("integer", "1"));
+        assert!(!DefaultsValue::Bool(true).matches(&plist::Value::Integer(1.into())));
 
-        assert!(DefaultsValue::Int(2).matches("integer", "2"));
-        assert!(!DefaultsValue::Int(2).matches("integer", "3"));
-        assert!(!DefaultsValue::Int(2).matches("float", "2"));
+        assert!(DefaultsValue::Int(2).matches(&plist::Value::Integer(2.into())));
+        assert!(!DefaultsValue::Int(2).matches(&plist::Value::Integer(3.into())));
+        assert!(!DefaultsValue::Int(2).matches(&plist::Value::Real(2.0)));
 
-        // `defaults read` may print floats without a fraction
-        assert!(DefaultsValue::Float(48.0).matches("float", "48"));
-        assert!(DefaultsValue::Float(0.5).matches("float", "0.5"));
-        assert!(!DefaultsValue::Float(0.5).matches("float", "0.6"));
+        assert!(DefaultsValue::Float(48.0).matches(&plist::Value::Real(48.0)));
+        assert!(DefaultsValue::Float(0.5).matches(&plist::Value::Real(0.5)));
+        assert!(!DefaultsValue::Float(0.5).matches(&plist::Value::Real(0.6)));
 
-        assert!(DefaultsValue::Str("left".into()).matches("string", "left"));
-        assert!(!DefaultsValue::Str("left".into()).matches("string", "right"));
+        assert!(DefaultsValue::Str("left".into()).matches(&plist::Value::String("left".into())));
+        assert!(!DefaultsValue::Str("left".into()).matches(&plist::Value::String("right".into())));
+
+        let nested = DefaultsValue::from_toml(&val("[{ enabled = true, count = 2 }]")).unwrap();
+        assert!(nested.matches(&nested.to_plist()));
     }
 
-    /// `status()` must not fail when keys don't exist yet — this is
-    /// the expected path on a fresh macOS install. Non-zero exits from
-    /// `defaults read` / `read-type` are treated as "unset" only for known
-    /// missing key/domain errors.
+    /// `status()` must not fail when keys don't exist yet — this is the
+    /// expected path on a fresh macOS install.
     #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn test_status_missing_keys_are_unset() {
@@ -334,5 +477,23 @@ mod tests {
                 s.state
             );
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_nested_value_round_trip() {
+        let domain = "com.mise.defaults-test";
+        let key = "NestedValue";
+        let value = DefaultsValue::from_toml(&val(
+            r#"[{ name = "Terminal", enabled = true, position = 1, scale = 1.5, metadata = { kind = "file-tile" } }]"#,
+        ))
+        .unwrap();
+
+        write(domain, key, &value).unwrap();
+        let current = read(domain, key);
+        let cleanup = macos::remove(domain, key);
+
+        assert_eq!(current.unwrap(), Some(value.to_plist()));
+        cleanup.unwrap();
     }
 }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -745,7 +745,7 @@ pub(crate) fn defaults_from_config(config: &Config) -> Vec<DefaultsRequest> {
             Some(value) => out.push(DefaultsRequest { domain, key, value }),
             None => warn!(
                 "[bootstrap.macos.defaults]: unsupported value type for {domain} {key} \
-                 (expected bool, integer, float, or string)"
+                 (expected bool, integer, float, string, array, or table)"
             ),
         }
     }


### PR DESCRIPTION
## Summary
- support recursively typed TOML arrays and tables in macOS bootstrap defaults
- read and write preferences through Core Foundation so nested booleans, numbers, strings, arrays, and dictionaries retain their plist types
- document whole-value replacement semantics and keep differing collection output concise

This addresses [discussion #12942](https://github.com/jdx/mise/discussions/12942). The `defaults` CLI cannot nest arrays and dictionaries via its typed flags, and its OpenStep representation coerces nested scalar values to strings, so this uses the native preferences API instead.

## Testing
- `mise x -- cargo test --all-features system::defaults`
- `mise run test:e2e e2e/cli/test_system_defaults`
- scoped `hk run check --safe --format json --files0-from -`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces how mise reads and writes user preferences on macOS; misconfigured nested values can overwrite entire array/dictionary keys in real preference domains when `apply` runs.
> 
> **Overview**
> **macOS bootstrap defaults** can now express **nested TOML arrays and tables** (e.g. Dock `persistent-apps`) and compare/apply them with correct plist types instead of skipping those shapes with a warning.
> 
> Implementation moves from shelling out to **`defaults read`/`write`** to **Core Foundation preferences APIs** on macOS (`CFPreferencesCopyValue` / `SetValue` / `Synchronize`), with blocking work on a thread pool. **Scalars** still get copy-pasteable `defaults write` lines on `--dry-run`; **collections** print a generic “macOS preference …” line because the CLI cannot represent them safely.
> 
> **Status/drift** compares against typed `plist::Value` (strict type matching preserved). **Whole-value replacement** applies to arrays and dictionaries—no element-wise merge. **TOML datetimes** and binary plist data remain unsupported (warn and skip). Docs and e2e tests were updated accordingly; macOS-only `core-foundation` deps were added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e0dc724f2bb74d9f7b9d222d441fea26a7ef74b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS preference management now supports nested arrays and dictionaries, preserving their structure when reading, writing, and comparing values.
  * Preference status and updates use more reliable native macOS handling.
* **Bug Fixes**
  * Improved synchronization error reporting for macOS preferences.
  * Unsupported dates, times, and binary values are skipped with clear warnings.
* **Documentation**
  * Updated macOS defaults documentation with nested value examples and clarified dry-run output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->