### PR TITLE
fix(config): make default inline shell portable

### DIFF
--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -70,7 +70,7 @@ arguments, caching, and dependency configuration.
   Configure with `raw` config or `MISE_RAW` env var
 - **`-s --shell <SHELL>`** — Shell to use to run toml tasks
 
-  Defaults to `sh -c -o errexit -o pipefail` on unix, and `cmd /c` on Windows
+  Defaults to `sh -o errexit -c` on unix, and `cmd /c` on Windows
   Can also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`
   Or it can be overridden with the `shell` property on a task.
 - **`-S --silent`** — Don't show any output except for errors

--- a/docs/cli/tasks/run.md
+++ b/docs/cli/tasks/run.md
@@ -70,7 +70,7 @@ arguments, caching, and dependency configuration.
   Configure with `raw` config or `MISE_RAW` env var
 - **`-s --shell <SHELL>`** — Shell to use to run toml tasks
 
-  Defaults to `sh -c -o errexit -o pipefail` on unix, and `cmd /c` on Windows
+  Defaults to `sh -o errexit -c` on unix, and `cmd /c` on Windows
   Can also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`
   Or it can be overridden with the `shell` property on a task.
 - **`-S --silent`** — Don't show any output except for errors

--- a/e2e/cli/test_deps_command_freshness_slow
+++ b/e2e/cli/test_deps_command_freshness_slow
@@ -29,7 +29,7 @@ assert_contains "mise deps --only command 2>&1" "up to date"
 mkdir -p "$HOME/.config/mise"
 cat >"$HOME/.config/mise/config.toml" <<'EOF'
 [settings]
-unix_default_inline_shell_args = "sh -c -o errexit"
+unix_default_inline_shell_args = "sh -o errexit -c"
 EOF
 
 cat >mise.toml <<'EOF'

--- a/e2e/tasks/test_inline_shell_portable
+++ b/e2e/tasks/test_inline_shell_portable
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Model a shell whose -c operand must immediately follow the flag (FreeBSD).
+mkdir -p bin
+cat >bin/sh <<'EOF'
+#!/bin/sh
+if [ "$1" != -o ] || [ "$2" != errexit ] || [ "$3" != -c ] || [ "$#" != 4 ]; then
+  echo 'incorrect inline shell arguments' >&2
+  exit 99
+fi
+exec /bin/sh "$@"
+EOF
+chmod +x bin/sh
+export PATH="$PWD/bin:$PATH"
+
+cat >mise.toml <<'EOF'
+[tasks.hello]
+run = "echo portable-inline-shell"
+
+[tasks.fail]
+run = "false; echo should-not-run"
+EOF
+
+assert_contains "mise run hello" "portable-inline-shell"
+assert_fail "mise run fail"
+assert_not_contains "mise run fail 2>&1 || true" "incorrect inline shell arguments"
+assert_not_contains "mise run --quiet fail 2>&1 || true" "should-not-run"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -6012,7 +6012,7 @@ Configure with `raw` config or `MISE_RAW` env var
 \fB\-s, \-\-shell\fR \fI<SHELL>\fR
 Shell to use to run toml tasks
 
-Defaults to `sh \-c \-o errexit \-o pipefail` on unix, and `cmd /c` on Windows
+Defaults to `sh \-o errexit \-c` on unix, and `cmd /c` on Windows
 Can also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`
 Or it can be overridden with the `shell` property on a task.
 .TP
@@ -7432,7 +7432,7 @@ Configure with `raw` config or `MISE_RAW` env var
 \fB\-s, \-\-shell\fR \fI<SHELL>\fR
 Shell to use to run toml tasks
 
-Defaults to `sh \-c \-o errexit \-o pipefail` on unix, and `cmd /c` on Windows
+Defaults to `sh \-o errexit \-c` on unix, and `cmd /c` on Windows
 Can also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`
 Or it can be overridden with the `shell` property on a task.
 .TP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -4205,7 +4205,7 @@ Configure with `raw` config or `MISE_RAW` env var
         long_help #"""
 Shell to use to run toml tasks
 
-Defaults to `sh -c -o errexit -o pipefail` on unix, and `cmd /c` on Windows
+Defaults to `sh -o errexit -c` on unix, and `cmd /c` on Windows
 Can also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`
 Or it can be overridden with the `shell` property on a task.
 """#
@@ -5067,7 +5067,7 @@ Configure with `raw` config or `MISE_RAW` env var
             long_help #"""
 Shell to use to run toml tasks
 
-Defaults to `sh -c -o errexit -o pipefail` on unix, and `cmd /c` on Windows
+Defaults to `sh -o errexit -c` on unix, and `cmd /c` on Windows
 Can also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`
 Or it can be overridden with the `shell` property on a task.
 """#

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2254,7 +2254,7 @@
           "type": "string"
         },
         "unix_default_inline_shell_args": {
-          "default": "sh -c -o errexit",
+          "default": "sh -o errexit -c",
           "description": "Default shell arguments for Unix to be used for inline commands. For example, `sh -c` for sh.",
           "type": "string"
         },

--- a/settings.toml
+++ b/settings.toml
@@ -3702,7 +3702,7 @@ global_only = true
 type = "String"
 
 [unix_default_inline_shell_args]
-default = "sh -c -o errexit"
+default = "sh -o errexit -c"
 description = "Default shell arguments for Unix to be used for inline commands. For example, `sh -c` for sh."
 env = "MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS"
 global_only = true

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -178,7 +178,7 @@ pub(crate) struct Run {
 
     /// Shell to use to run toml tasks
     ///
-    /// Defaults to `sh -c -o errexit -o pipefail` on unix, and `cmd /c` on Windows
+    /// Defaults to `sh -o errexit -c` on unix, and `cmd /c` on Windows
     /// Can also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`
     /// Or it can be overridden with the `shell` property on a task.
     #[usage(long, short, verbatim_doc_comment)]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -874,7 +874,7 @@ fn resolve_age_paths(settings: &mut toml::Table, path: &Path) -> Result<()> {
 
 impl Settings {
     const UNIX_DEFAULT_FILE_SHELL_ARGS: &'static str = "sh";
-    const UNIX_DEFAULT_INLINE_SHELL_ARGS: &'static str = "sh -c -o errexit";
+    const UNIX_DEFAULT_INLINE_SHELL_ARGS: &'static str = "sh -o errexit -c";
     const WINDOWS_DEFAULT_FILE_SHELL_ARGS: &'static str = "cmd /c";
     const WINDOWS_DEFAULT_INLINE_SHELL_ARGS: &'static str = "cmd /c";
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -997,8 +997,8 @@ mod tests {
         assert_eq!(split_shell_command("bash -c").unwrap(), sv(&["bash", "-c"]));
         assert_eq!(split_shell_command("sh -c").unwrap(), sv(&["sh", "-c"]));
         assert_eq!(
-            split_shell_command("sh -c -o errexit").unwrap(),
-            sv(&["sh", "-c", "-o", "errexit"])
+            split_shell_command("sh -o errexit -c").unwrap(),
+            sv(&["sh", "-o", "errexit", "-c"])
         );
     }
 

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -438,7 +438,7 @@ logins:
 
     #[test]
     fn test_credential_command_shell_preserves_sh_host_arg() {
-        let shell = shell_words::split("sh -c -o errexit").unwrap();
+        let shell = shell_words::split("sh -o errexit -c").unwrap();
         let (program, args) =
             credential_command_shell_from(&shell, "echo token-for-$1", "ghe.example.com").unwrap();
 
@@ -446,9 +446,9 @@ logins:
         assert_eq!(
             args,
             vec![
-                "-c",
                 "-o",
                 "errexit",
+                "-c",
                 "echo token-for-$1",
                 "mise-credential-helper",
                 "ghe.example.com"


### PR DESCRIPTION
FreeBSD sh consumes the argument immediately after `-c`, so the old default tried to execute `-o` instead of the user's command. Put the flags first (`sh -o errexit -c`) in both the default and fallback, and correct the generated help's stale `pipefail` claim.

Verified with the all-features build/check, `mise run lint-fix`, documentation/schema generation, and an E2E strict-shell fixture covering execution and errexit.

Fixes https://github.com/jdx/mise/discussions/12935

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters the default Unix command line for inline tasks and deps runs, which could surprise users who relied on the old ordering, though explicit `unix_default_inline_shell_args` overrides are unchanged.
> 
> **Overview**
> Changes the Unix default inline shell for TOML tasks from **`sh -c -o errexit`** to **`sh -o errexit -c`** so shells where **`-c`’s command must come immediately after the flag** (e.g. FreeBSD) run the user script instead of treating **`-o`** as the command.
> 
> The new default is wired through **`Settings::UNIX_DEFAULT_INLINE_SHELL_ARGS`**, **`unix_default_inline_shell_args`** in config/schema, and generated CLI help/docs (also dropping the outdated **`pipefail`** mention in the documented default). Unit tests for shell splitting and credential-helper wrapping match the new argument order.
> 
> An E2E fixture simulates a strict **`sh`** wrapper and checks **`mise run`** success and **`errexit`** behavior; an existing deps freshness test uses the updated setting value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a3b09eec33080e94bbcb19c7db2b8cbf002245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Updated the default Unix inline shell invocation for `mise run` and `mise tasks run` to use `sh -o errexit -c`.
  - Removed the default `pipefail` option from this invocation.
  - Windows continues to use `cmd /c`.

- **Documentation**
  - Updated command help, manuals, schemas, and configuration references to reflect the new Unix shell arguments.

- **Tests**
  - Added coverage confirming portable inline-shell execution, including success and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->