### PR TITLE
perf: bypass the shell for simple inline commands

### DIFF
--- a/docs/tasks/running-tasks.md
+++ b/docs/tasks/running-tasks.md
@@ -48,9 +48,21 @@ For a precise, validated task interface, define arguments and flags with the
 are forwarded according to how the task is executed:
 
 - If `run` is an array, the arguments are passed only to its last entry.
-- For a regular inline shell command, the arguments are appended to the command text.
+- For a regular inline command, arguments are appended as literal arguments (shell-quoted when a shell is used).
 - A [shebang task](/tasks/toml-tasks#shell-shebang) is executed as a script file, so its interpreter
   exposes the arguments normally—for example, as `$1` and `$@` in Bash.
+
+On Unix, mise can execute simple inline commands such as `node build.js` directly,
+without starting the default `sh`. Shell syntax, quoting, expansion, builtins,
+ambiguous executable lookup, and environments containing `ENV` or `BASH_ENV`
+keep using the shell. Sandboxed and audited tasks also retain their shell.
+Windows execution is unchanged.
+
+An explicit task `shell`, `mise run --shell`, or `unix_default_inline_shell_args`
+setting always forces shell execution, even when it names the default shell.
+A wrapper named `sh` on `PATH` may be bypassed; configure it explicitly if it
+must run. The same optimization applies to mise-owned inline hooks, templates,
+dependency commands, installation commands, credentials, and task cache inputs.
 
 Because everything after the task name belongs to the task, mise's own flags have to come
 _before_ it—`mise run --silent build` rather than `mise run build --silent`, which passes

--- a/docs/tasks/running-tasks.md
+++ b/docs/tasks/running-tasks.md
@@ -58,10 +58,14 @@ ambiguous executable lookup, and environments containing `ENV` or `BASH_ENV`
 keep using the shell. Sandboxed and audited tasks also retain their shell.
 Windows execution is unchanged.
 
+:::warning Custom shell wrappers
 An explicit task `shell`, `mise run --shell`, or `unix_default_inline_shell_args`
 setting always forces shell execution, even when it names the default shell.
 A wrapper named `sh` on `PATH` may be bypassed; configure it explicitly if it
-must run. The same optimization applies to mise-owned inline hooks, templates,
+must run.
+:::
+
+The same optimization applies to mise-owned inline hooks, templates,
 dependency commands, installation commands, credentials, and task cache inputs.
 
 Because everything after the task name belongs to the task, mise's own flags have to come

--- a/e2e/config/test_inline_direct_consumers
+++ b/e2e/config/test_inline_direct_consumers
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+mkdir -p bin
+cat >bin/sh <<'EOF'
+#!/bin/sh
+export INLINE_SHELL_USED=shell
+exec /bin/sh "$@"
+EOF
+cat >bin/probe <<'EOF'
+#!/bin/sh
+printf '%s:%s\n' "${INLINE_SHELL_USED:-direct}" "$1"
+EOF
+chmod +x bin/sh bin/probe
+export PATH="$PWD/bin:$PATH"
+touch watched.txt input.txt
+cat >mise.toml <<'EOF'
+[settings]
+experimental = true
+[env]
+FROM_TEMPLATE = "{{ exec(command='probe template') }}"
+[hooks.enter]
+run = "probe hook"
+[[watch_files]]
+patterns = ["watched.txt"]
+run = "probe watch"
+[deps.local]
+run = "probe deps"
+sources = ["input.txt"]
+outputs = []
+[tasks.cached]
+run = "probe task"
+sources = ["input.txt"]
+outputs = []
+cache = { enabled = true, command_inputs = ["probe cache"] }
+EOF
+assert_contains "mise env" "direct:template"
+assert_contains "MISE_TERA_V1=1 mise env" "direct:template"
+assert_contains "mise hook-env 2>&1" "direct:hook"
+eval "$(mise hook-env)"
+sleep 1
+touch watched.txt
+assert_contains "mise hook-env 2>&1" "direct:watch"
+assert_contains "mise deps --only local 2>&1" "direct:deps"
+assert_contains "mise run -q cached" "direct:task"
+cat >>mise.toml <<'EOF'
+[tools]
+dummy = { version = "1.0.0", postinstall = "probe tool-postinstall" }
+[hooks.preinstall]
+run = "probe preinstall"
+[hooks.postinstall]
+run = "probe postinstall"
+[bootstrap.hooks.final]
+run = "probe bootstrap"
+EOF
+mise install >install.out 2>&1
+assert_contains "cat install.out" "direct:preinstall"
+assert_contains "cat install.out" "direct:postinstall"
+assert_contains "cat install.out" "direct:tool-postinstall"
+assert_contains "mise bootstrap --yes 2>&1" "direct:bootstrap"
+# A failing PATH sh proves command-input capture itself also skips that shell.
+cat >bin/sh <<'EOF'
+#!/bin/sh
+echo unexpected-inline-shell >&2
+exit 99
+EOF
+assert_contains "mise run -q --force cached" "direct:task"
+
+# Credential helper positional parameters are shell-only, not extra argv.
+unset GITHUB_TOKEN GH_TOKEN MISE_GITHUB_TOKEN GITHUB_ENTERPRISE_TOKEN GH_ENTERPRISE_TOKEN GITHUB_API_TOKEN MISE_GITHUB_ENTERPRISE_TOKEN
+cat >bin/credential-probe <<'EOF'
+#!/bin/sh
+printf '%s-%s-%s-%s\n' "${INLINE_SHELL_USED:-direct}" "$#" "$MISE_CREDENTIAL_HOST" "$MISE_CREDENTIAL_PROVIDER"
+EOF
+chmod +x bin/credential-probe
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[settings.github]
+credential_command = "credential-probe"
+EOF
+assert "mise token github inline.example --raw" "direct-0-inline.example-github"
+cat >bin/sh <<'EOF'
+#!/bin/sh
+exec /bin/sh "$@"
+EOF
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[settings.github]
+credential_command = 'printf token-for-%s "$1"'
+EOF
+assert "mise token github inline.example --raw" "token-for-inline.example"

--- a/e2e/tasks/test_inline_direct
+++ b/e2e/tasks/test_inline_direct
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+mkdir -p bin child
+cat >bin/sh <<'EOF'
+#!/bin/sh
+export INLINE_SHELL_USED=shell
+exec /bin/sh "$@"
+EOF
+cat >bin/probe <<'EOF'
+#!/bin/sh
+printf '%s\n' "${INLINE_SHELL_USED:-direct}" "$PWD" "${CHECK_ENV:-unset}" "$@"
+EOF
+cat >bin/fail-probe <<'EOF'
+#!/bin/sh
+echo failed-probe >&2
+exit 23
+EOF
+cat >bin/plain-probe <<'EOF'
+echo interpreted-by-shell
+EOF
+chmod +x bin/sh bin/probe bin/fail-probe bin/plain-probe
+export PATH="$PWD/bin:$PATH"
+
+cat >mise.toml <<'EOF'
+[tasks.direct]
+run = "probe first --key=value"
+dir = "child"
+env = { CHECK_ENV = "child-env" }
+[tasks.native]
+run = "env"
+[tasks.explicit]
+run = "probe"
+shell = "sh -o errexit -c"
+[tasks.expansion]
+run = "probe $CHECK_ENV"
+env = { CHECK_ENV = "expanded" }
+[tasks.init]
+run = "probe"
+env = { ENV = "" }
+[tasks.bash-init]
+run = "probe"
+env = { BASH_ENV = "" }
+[tasks.plain]
+run = "plain-probe"
+[tasks.fail]
+run = "fail-probe"
+[tasks.missing]
+run = "missing-inline-command-12935"
+EOF
+
+# Deliberately pass dollar syntax literally, without shell expansion.
+# shellcheck disable=SC2016
+literal_arg='$literal'
+assert "mise run -q direct -- 'literal space' '$literal_arg' '*.rs'" "$(printf 'direct\n%s/child\nchild-env\nfirst\n--key=value\nliteral space\n%s\n*.rs' "$PWD" "$literal_arg")"
+# Native env really bypasses the PATH-provided sh (not just a shell exec-ing it).
+assert_not_contains "mise run -q native" "INLINE_SHELL_USED="
+assert_contains "mise run -q explicit" "shell"
+assert_contains "mise run -q --shell 'sh -o errexit -c' direct" "shell"
+assert_contains "mise run -q expansion" "expanded"
+assert_contains "mise run -q expansion" "shell"
+assert_contains "mise run -q init" "shell"
+assert_contains "mise run -q bash-init" "shell"
+assert "mise run -q plain" "interpreted-by-shell"
+assert_fail_contains "mise run -q fail" "failed-probe"
+assert 'mise run -q fail >/dev/null 2>&1; echo $?' "23"
+assert_fail "mise run -q missing"
+assert_contains "MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS='sh -o errexit -c' mise run -q direct" "shell"
+# Relative and empty PATH components retain shell lookup semantics.
+assert_contains "PATH='$PATH:.' mise run -q direct" "shell"
+assert_contains "PATH='$PATH:' mise run -q direct" "shell"
+
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[settings]
+unix_default_inline_shell_args = "sh -o errexit -c"
+EOF
+assert_contains "mise run -q direct" "shell"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3578,7 +3578,13 @@ pub(crate) trait Backend: Debug + Send + Sync {
                 .env("MISE_PROJECT_ROOT", project_root);
         }
 
-        runner.execute()?;
+        runner
+            .optimize_inline(
+                &rendered_script,
+                &[],
+                Settings::get().implicit_inline_shell(),
+            )
+            .execute()?;
         Ok(())
     }
 

--- a/src/backend/spm.rs
+++ b/src/backend/spm.rs
@@ -385,6 +385,11 @@ impl SPMBackend {
                     .list_paths(&ctx.config)
                     .await,
             )?
+            .optimize_inline(
+                install_command,
+                &[],
+                Settings::get().implicit_inline_shell(),
+            )
             .execute()?;
 
         verify_install_command_output(install_command, &tv.install_path().join("bin"))
@@ -1304,6 +1309,53 @@ mod tests {
         ));
         let request = ToolRequest::new(ba, version, ToolSource::Argument).unwrap();
         ToolVersion::new(request, version.to_string())
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_inline_install_command_uses_install_environment() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("helpers");
+        std::fs::create_dir(&bin).unwrap();
+        std::fs::write(bin.join("sh"), "#!/bin/sh\nexit 99\n").unwrap();
+        std::fs::set_permissions(bin.join("sh"), std::fs::Permissions::from_mode(0o755)).unwrap();
+        symlink("/bin/cp", bin.join("copy-probe")).unwrap();
+        let mut tv = tool_version("1.2.3");
+        let ba = Arc::new(tv.ba().clone());
+        let mut options = ToolVersionOptions::default();
+        options
+            .core
+            .install_env
+            .insert("PATH".into(), bin.to_string_lossy().as_ref().into());
+        tv.request =
+            ToolRequest::new_with_options(ba.clone(), "1.2.3", options, ToolSource::Argument)
+                .unwrap();
+        tv.install_path = Some(dir.path().join("prefix"));
+        std::fs::create_dir_all(tv.install_path().join("bin")).unwrap();
+        let config = Config::get().await.unwrap();
+        let ctx = InstallContext {
+            config,
+            ts: Arc::new(Default::default()),
+            pr: crate::ui::multi_progress_report::MultiProgressReport::get()
+                .add("inline install")
+                .into(),
+            force: false,
+            dry_run: false,
+            locked: false,
+            before_date: None,
+            dependency_context: Default::default(),
+        };
+        SPMBackend { ba }
+            .run_install_command(
+                &ctx,
+                &tv,
+                dir.path(),
+                "copy-probe /bin/cp prefix/bin/copied",
+            )
+            .await
+            .unwrap();
+        assert!(tv.install_path().join("bin/copied").is_file());
     }
 
     #[test]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -125,6 +125,7 @@ pub(crate) struct CmdLineRunner<'a> {
     observe_stderr: Option<OutputObserver<'a>>,
     timeout: Option<Duration>,
     sandbox: Option<crate::sandbox::SandboxConfig>,
+    inherit_env: bool,
 }
 
 const GUARD_RUNNING: u8 = 0;
@@ -575,6 +576,7 @@ impl<'a> CmdLineRunner<'a> {
             observe_stderr: None,
             timeout: None,
             sandbox: None,
+            inherit_env: true,
         }
     }
 
@@ -683,6 +685,34 @@ impl<'a> CmdLineRunner<'a> {
 
     pub(crate) fn env_clear(mut self) -> Self {
         self.cmd.env_clear();
+        self.inherit_env = false;
+        self
+    }
+
+    /// Must run after environment/cwd configuration and before custom stdio or
+    /// pre-exec setup. Sandboxed commands retain their shell and policy target.
+    pub(crate) fn optimize_inline(
+        mut self,
+        body: &str,
+        forwarded: &[String],
+        enabled: bool,
+    ) -> Self {
+        if self.sandbox.is_none()
+            && let Some(command) = crate::inline_command::direct_command(
+                self.cmd.as_std(),
+                self.inherit_env,
+                body,
+                forwarded,
+                enabled,
+            )
+        {
+            self.cmd = command.into();
+            self.cmd
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            self.inherit_env = false;
+        }
         self
     }
 
@@ -2292,6 +2322,38 @@ mod tests {
         assert_eq!(stderr.lock().unwrap().as_slice(), ["err"]);
         assert_eq!(observed_stdout.lock().unwrap().as_slice(), ["out"]);
         assert_eq!(observed_stderr.lock().unwrap().as_slice(), ["err"]);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_direct_inline_supervision() {
+        let runner = || {
+            super::CmdLineRunner::new("missing-shell")
+                .env_clear()
+                .env("PATH", "/usr/bin:/bin")
+                .args(["-c", "sleep 10"])
+                .optimize_inline("sleep 10", &[], true)
+        };
+        let err = runner()
+            .with_timeout(std::time::Duration::from_millis(20))
+            .execute_async()
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("timed out"), "{err:?}");
+        let err = runner()
+            .execute_async_with_cancel_check(|| true)
+            .await
+            .unwrap_err();
+        assert!(crate::errors::Error::is_task_interrupted_before_start(&err));
+        let output = super::CmdLineRunner::new("missing-shell")
+            .env_clear()
+            .env("PATH", "/usr/bin:/bin")
+            .optimize_inline("cat", &[], true)
+            .stdin_string("literal input")
+            .read_bounded(1024)
+            .await
+            .unwrap();
+        assert_eq!(output, "literal input");
     }
 
     #[cfg(unix)]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -310,6 +310,7 @@ static BASE_SETTINGS: RwLock<Option<Arc<Settings>>> = RwLock::new(None);
 /// 0 = false, 1 = true, 2 = never loaded (fall back to the env var).
 static LAST_SAFE: AtomicU8 = AtomicU8::new(2);
 static CLI_SETTINGS: Mutex<Option<SettingsPartial>> = Mutex::new(None);
+static EXPLICIT_INLINE_SHELL: RwLock<Option<bool>> = RwLock::new(None);
 static PENDING_DEPRECATED_SETTINGS: Lazy<Mutex<BTreeSet<&'static str>>> =
     Lazy::new(Default::default);
 /// Settings files that failed to parse, held until warnings can be printed.
@@ -1330,6 +1331,7 @@ impl Settings {
     }
 
     pub(crate) fn reset(cli_settings: Option<SettingsPartial>) {
+        *EXPLICIT_INLINE_SHELL.write().unwrap() = None;
         *CLI_SETTINGS.lock().unwrap() = cli_settings;
         *BASE_SETTINGS.write().unwrap() = None;
         // Clear caches that depend on settings and environment
@@ -1339,6 +1341,7 @@ impl Settings {
 
     /// Invalidate settings loaded from config files without discarding CLI overrides.
     pub(crate) fn reload() {
+        *EXPLICIT_INLINE_SHELL.write().unwrap() = None;
         *BASE_SETTINGS.write().unwrap() = None;
         crate::config::config_file::config_root::reset();
         crate::toolset::install_state::reset_tools();
@@ -1353,6 +1356,7 @@ impl Settings {
     /// BASE_SETTINGS so the next `Settings::get()` rebuilds with the override
     /// applied.
     pub(crate) fn override_with(updater: impl FnOnce(&mut SettingsPartial)) {
+        *EXPLICIT_INLINE_SHELL.write().unwrap() = None;
         let mut lock = CLI_SETTINGS.lock().unwrap();
         let partial = lock.get_or_insert_with(SettingsPartial::empty);
         updater(partial);
@@ -1600,6 +1604,26 @@ impl Settings {
         let mut shell = split_default_shell_or_fallback(sa, fallback)?;
         self.maybe_no_profile(&mut shell);
         Ok(shell)
+    }
+
+    /// Explicitly selecting even the default value expresses intent to run a
+    /// shell. Cache provenance separately from the resolved string value.
+    pub(crate) fn implicit_inline_shell(&self) -> bool {
+        if cfg!(windows) {
+            return false;
+        }
+        if let Some(explicit) = *EXPLICIT_INLINE_SHELL.read().unwrap() {
+            return !explicit;
+        }
+        let explicit = std::env::var_os("MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS").is_some()
+            || Self::cli_settings_layer()
+                .unix_default_inline_shell_args
+                .is_some()
+            || Self::settings_layers_from(None, SettingsTrustPolicy::AsDiscovered)
+                .iter()
+                .any(|layer| layer.unix_default_inline_shell_args.is_some());
+        *EXPLICIT_INLINE_SHELL.write().unwrap() = Some(explicit);
+        !explicit
     }
 
     pub(crate) fn default_file_shell(&self) -> Result<Vec<String>> {

--- a/src/deps/engine.rs
+++ b/src/deps/engine.rs
@@ -1247,6 +1247,12 @@ impl DepsEngine {
             runner = runner.env(k, v);
         }
 
+        if cmd.inline
+            && let Some(body) = cmd.args.last()
+        {
+            runner = runner.optimize_inline(body, &[], Settings::get().implicit_inline_shell());
+        }
+
         // Use raw output for better UX during dependency installation
         if Settings::get().raw {
             runner = runner.raw(true);

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -110,6 +110,8 @@ impl FreshnessResult {
 /// A command to execute for dependency management
 #[derive(Debug, Clone)]
 pub(crate) struct DepsCommand {
+    /// True only for commands originating as inline shell text.
+    pub inline: bool,
     /// The program to execute
     pub program: String,
     /// Arguments to pass to the program
@@ -145,6 +147,7 @@ impl DepsCommand {
         args.push(run.to_string());
 
         Ok(Self {
+            inline: true,
             program: program.to_string(),
             args,
             env: config.env.clone(),
@@ -467,6 +470,7 @@ mod tests {
 
     fn command() -> DepsCommand {
         DepsCommand {
+            inline: true,
             program: "sh".to_string(),
             args: vec!["-c".to_string(), "echo first".to_string()],
             env: BTreeMap::from([("MODE".to_string(), "debug".to_string())]),

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -174,6 +174,7 @@ impl DepsCommand {
         }
 
         let mut hasher = blake3::Hasher::new();
+        update(&mut hasher, &[u8::from(self.inline)]);
         update(&mut hasher, self.program.as_bytes());
         update(&mut hasher, &(self.args.len() as u64).to_le_bytes());
         for arg in &self.args {
@@ -482,6 +483,9 @@ mod tests {
     #[test]
     fn deps_command_freshness_hash_tracks_execution_inputs() {
         let original = command();
+        let mut changed = original.clone();
+        changed.inline = !original.inline;
+        assert_ne!(original.freshness_hash(), changed.freshness_hash());
         assert_eq!(original.freshness_hash(), command().freshness_hash());
 
         let mut changed = command();

--- a/src/deps/providers/mod.rs
+++ b/src/deps/providers/mod.rs
@@ -147,6 +147,7 @@ impl ProviderBase {
 
     fn command(&self, program: &str, args: &[&str], description: String) -> DepsCommand {
         DepsCommand {
+            inline: false,
             program: program.to_string(),
             args: args.iter().map(|arg| arg.to_string()).collect(),
             env: self.config.env.clone(),

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -663,6 +663,7 @@ async fn execute(
     let Some(run) = hook.action.run_for_current_platform() else {
         return Ok(());
     };
+    let direct_enabled = shell.is_none() && Settings::get().implicit_inline_shell();
     let mut shell = shell
         .as_ref()
         .map(|shell| crate::path::split_shell_command(shell))
@@ -777,13 +778,14 @@ async fn execute(
         }
     }
 
-    let command = cmd(&shell[0], args).stdout_to_stderr().full_env(env);
-    let command = if matches!(hook.hook, Hooks::Preinstall | Hooks::Postinstall) {
-        command.dir(project_root)
-    } else {
-        command
-    };
-    command.run()?;
+    let cwd = matches!(hook.hook, Hooks::Preinstall | Hooks::Postinstall).then_some(project_root);
+    let mut command = cmd(&shell[0], args).full_env(&env);
+    if let Some(cwd) = cwd {
+        command = command.dir(cwd);
+    }
+    crate::inline_command::optimize_expression(command, run, &env, cwd, direct_enabled)
+        .stdout_to_stderr()
+        .run()?;
     Ok(())
 }
 

--- a/src/inline_command.rs
+++ b/src/inline_command.rs
@@ -117,9 +117,27 @@ mod unix {
                     return None;
                 }
                 nix::unistd::access(interpreter, nix::unistd::AccessFlags::X_OK).ok()?;
+                // Nested script interpreters have platform-specific recursion
+                // rules. In particular, executable text may produce ENOEXEC,
+                // which the shell would handle by interpreting the outer script.
+                let mut header = [0; 256];
+                let n = std::fs::File::open(interpreter)
+                    .ok()?
+                    .read(&mut header)
+                    .ok()?;
+                if !native_header(&header[..n]) {
+                    return None;
+                }
                 return Some(candidate);
             }
-            let launchable = [
+            return native_header(head).then_some(candidate);
+        }
+        None
+    }
+
+    fn native_header(head: &[u8]) -> bool {
+        head.len() >= 32
+            && [
                 &b"\x7fELF"[..],
                 &[0xfe, 0xed, 0xfa, 0xce],
                 &[0xfe, 0xed, 0xfa, 0xcf],
@@ -129,10 +147,7 @@ mod unix {
                 &[0xbe, 0xba, 0xfe, 0xca],
             ]
             .iter()
-            .any(|magic| head.starts_with(magic));
-            return (head.len() >= 32 && launchable).then_some(candidate);
-        }
-        None
+            .any(|magic| head.starts_with(magic))
     }
 
     pub(super) fn direct_command(
@@ -339,6 +354,26 @@ mod unix {
             shell.env("ENV", "");
             assert!(direct_command(&shell, false, "tool", &[], true).is_none());
             shell.env_remove("ENV");
+            let interpreter = dir.path().join("interpreter");
+            std::fs::write(&interpreter, "echo not-native\n").unwrap();
+            std::fs::set_permissions(&interpreter, std::fs::Permissions::from_mode(0o755)).unwrap();
+            std::fs::write(
+                &tool,
+                format!("#!{}\nprintf fallback\n", interpreter.display()),
+            )
+            .unwrap();
+            assert!(direct_command(&shell, false, "tool", &[], true).is_none());
+            let output = Command::new("/bin/sh")
+                .env_clear()
+                .env("PATH", dir.path())
+                .args(["-c", "tool"])
+                .output()
+                .unwrap();
+            assert!(output.status.success());
+            assert_eq!(output.stdout, b"fallback");
+            // Defer even valid nested shebangs, including potential cycles.
+            std::fs::write(&interpreter, "#!/bin/sh\n").unwrap();
+            assert!(direct_command(&shell, false, "tool", &[], true).is_none());
             std::fs::write(&tool, "echo no-shebang\n").unwrap();
             assert!(direct_command(&shell, false, "tool", &[], true).is_none());
             for body in [

--- a/src/inline_command.rs
+++ b/src/inline_command.rs
@@ -1,0 +1,353 @@
+//! Conservative shell elision, inspired by aube-scripts' direct-exec planner.
+//! Unknown syntax or execution context always retains the configured shell.
+
+use std::process::Command;
+
+/// Keep duct's capture/redirection and child supervision around the new program.
+pub(crate) fn optimize_expression(
+    fallback: duct::Expression,
+    body: &str,
+    env: &crate::env_diff::EnvMap,
+    cwd: Option<&std::path::Path>,
+    enabled: bool,
+) -> duct::Expression {
+    let mut context = Command::new("sh");
+    context.env_clear().envs(env);
+    if let Some(cwd) = cwd {
+        context.current_dir(cwd);
+    }
+    let Some(command) = direct_command(&context, false, body, &[], enabled) else {
+        return fallback;
+    };
+    let expression = duct::cmd(command.get_program(), command.get_args())
+        .full_env(command.get_envs().filter_map(|(k, v)| v.map(|v| (k, v))))
+        .dir(command.get_current_dir().expect("direct command has cwd"));
+    #[cfg(unix)]
+    let expression = {
+        use std::os::unix::process::CommandExt;
+        let arg0 = body.split_ascii_whitespace().next().unwrap().to_owned();
+        expression.before_spawn(move |command| {
+            command.arg0(&arg0);
+            Ok(())
+        })
+    };
+    expression
+}
+
+/// Build a replacement before configuring stdio or pre-exec hooks. The caller
+/// retains its existing process supervision and output handling.
+pub(crate) fn direct_command(
+    shell: &Command,
+    inherit_env: bool,
+    body: &str,
+    forwarded: &[String],
+    enabled: bool,
+) -> Option<Command> {
+    #[cfg(unix)]
+    {
+        unix::direct_command(shell, inherit_env, body, forwarded, enabled)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (shell, inherit_env, body, forwarded, enabled);
+        None
+    }
+}
+
+#[cfg(unix)]
+mod unix {
+    use std::collections::BTreeMap;
+    use std::ffi::OsString;
+    use std::io::Read;
+    use std::os::unix::process::CommandExt;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    // Include builtins with external counterparts: /usr/bin/echo, printf, test,
+    // etc. need not behave like the shell's implementation.
+    const SHELL_WORDS: &str = ". : [ [[ ]] alias bg bind break builtin caller case cd command compgen complete continue coproc declare dirs disown do done echo elif else enable esac eval exec exit export false fc fg fi for function getopts hash history if in jobs kill let local logout mapfile popd printf pushd pwd read readarray readonly return select set shift shopt source suspend test then time times trap true type typeset ulimit umask unalias unset until wait while { }";
+
+    fn words(body: &str) -> Option<Vec<&str>> {
+        if !body
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b" ._-+/@:,=".contains(&b))
+        {
+            return None;
+        }
+        let words: Vec<_> = body.split_ascii_whitespace().collect();
+        let program = *words.first()?;
+        if program.starts_with('-')
+            || program.contains(['/', '='])
+            || SHELL_WORDS
+                .split_ascii_whitespace()
+                .any(|word| word == program)
+        {
+            return None;
+        }
+        Some(words)
+    }
+
+    fn resolve(program: &str, path: &std::ffi::OsStr) -> Option<PathBuf> {
+        let dirs: Vec<_> = std::env::split_paths(path).collect();
+        if dirs.iter().any(|dir| !dir.is_absolute()) {
+            return None;
+        }
+        for dir in dirs {
+            let candidate = dir.join(program);
+            match std::fs::metadata(&candidate) {
+                Ok(meta) if meta.is_file() => {}
+                Ok(_) => return None,
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(_) => return None,
+            }
+            nix::unistd::access(&candidate, nix::unistd::AccessFlags::X_OK).ok()?;
+            // A shell interprets executable text without a shebang after ENOEXEC.
+            // Defer rather than changing that behavior or searching later entries.
+            let mut head = [0; 256];
+            let n = std::fs::File::open(&candidate).ok()?.read(&mut head).ok()?;
+            let head = &head[..n];
+            if let Some(shebang) = head.strip_prefix(b"#!") {
+                use std::os::unix::ffi::OsStrExt;
+                let end = shebang.iter().position(|b| *b == b'\n')?;
+                let interpreter = shebang[..end]
+                    .split(|b| *b == b' ' || *b == b'\t')
+                    .find(|word| !word.is_empty())?;
+                let interpreter = Path::new(std::ffi::OsStr::from_bytes(interpreter));
+                if !interpreter.is_absolute() || !interpreter.is_file() {
+                    return None;
+                }
+                nix::unistd::access(interpreter, nix::unistd::AccessFlags::X_OK).ok()?;
+                return Some(candidate);
+            }
+            let launchable = [
+                &b"\x7fELF"[..],
+                &[0xfe, 0xed, 0xfa, 0xce],
+                &[0xfe, 0xed, 0xfa, 0xcf],
+                &[0xce, 0xfa, 0xed, 0xfe],
+                &[0xcf, 0xfa, 0xed, 0xfe],
+                &[0xca, 0xfe, 0xba, 0xbe],
+                &[0xbe, 0xba, 0xfe, 0xca],
+            ]
+            .iter()
+            .any(|magic| head.starts_with(magic));
+            return (head.len() >= 32 && launchable).then_some(candidate);
+        }
+        None
+    }
+
+    pub(super) fn direct_command(
+        shell: &Command,
+        inherit_env: bool,
+        body: &str,
+        forwarded: &[String],
+        enabled: bool,
+    ) -> Option<Command> {
+        if !enabled {
+            return None;
+        }
+        let words = words(body)?;
+        let mut env: BTreeMap<OsString, OsString> = if inherit_env {
+            std::env::vars_os().collect()
+        } else {
+            BTreeMap::new()
+        };
+        for (key, value) in shell.get_envs() {
+            match value {
+                Some(value) => {
+                    env.insert(key.to_owned(), value.to_owned());
+                }
+                None => {
+                    env.remove(key);
+                }
+            }
+        }
+        if ["ENV", "BASH_ENV", "SHELLOPTS", "BASHOPTS"]
+            .iter()
+            .any(|key| env.contains_key(std::ffi::OsStr::new(key)))
+            || env
+                .keys()
+                .any(|key| key.to_string_lossy().starts_with("BASH_FUNC_"))
+        {
+            return None;
+        }
+        let program = resolve(words[0], env.get(std::ffi::OsStr::new("PATH"))?)?;
+        let cwd = match shell.get_current_dir() {
+            Some(dir) if dir.is_absolute() => dir.to_owned(),
+            Some(dir) => std::env::current_dir().ok()?.join(dir),
+            None => std::env::current_dir().ok()?,
+        };
+        let physical_cwd = std::fs::canonicalize(&cwd).ok()?;
+        // Preserve a valid logical PWD (including symlinks), as sh does.
+        let pwd = env
+            .get(std::ffi::OsStr::new("PWD"))
+            .filter(|pwd| {
+                Path::new(pwd).is_absolute()
+                    && same_file::is_same_file(Path::new(pwd), &cwd).unwrap_or(false)
+            })
+            .cloned()
+            .unwrap_or_else(|| physical_cwd.into_os_string());
+        let mut command = Command::new(program);
+        command.arg0(words[0]).args(&words[1..]).args(forwarded);
+        command
+            .current_dir(cwd)
+            .env_clear()
+            .envs(env)
+            .env("PWD", pwd);
+        Some(command)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        #[test]
+        fn conservative_syntax() {
+            assert_eq!(
+                words(" node build.js --target=es2020 ").unwrap(),
+                ["node", "build.js", "--target=es2020"]
+            );
+            for body in [
+                "",
+                "echo hi",
+                "printf x",
+                "exit 7",
+                "X=1 node",
+                "./tool",
+                "node 'x'",
+                "node \"x\"",
+                "node $X",
+                "node *.js",
+                "node ~",
+                "node; other",
+                "node | other",
+                "node && other",
+                "node >out",
+                "node # comment",
+                "node\\ x",
+                "node\n",
+                "node\tx",
+                "node café",
+            ] {
+                assert!(words(body).is_none(), "{body:?}");
+            }
+            for word in SHELL_WORDS.split_ascii_whitespace() {
+                assert!(words(word).is_none(), "{word}");
+            }
+        }
+
+        #[test]
+        fn resolution_and_effective_environment() {
+            use std::os::unix::fs::{PermissionsExt, symlink};
+            let dir = tempfile::tempdir().unwrap();
+            let bin = dir.path().join("bin");
+            std::fs::create_dir(&bin).unwrap();
+            let tool = bin.join("tool");
+            std::fs::write(&tool, "#!/bin/sh\nexit 0\n").unwrap();
+            std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o755)).unwrap();
+            let mut shell = Command::new("not-a-real-shell");
+            shell.env_clear().env("PATH", &bin).env("KEEP", "value");
+            shell.env("REMOVE", "value").env_remove("REMOVE");
+            let planned = direct_command(&shell, false, "tool", &[], true).unwrap();
+            let env: BTreeMap<_, _> = planned.get_envs().collect();
+            assert_eq!(
+                env.get(std::ffi::OsStr::new("KEEP")),
+                Some(&Some(std::ffi::OsStr::new("value")))
+            );
+            assert!(!env.contains_key(std::ffi::OsStr::new("REMOVE")));
+            for key in [
+                "ENV",
+                "BASH_ENV",
+                "SHELLOPTS",
+                "BASHOPTS",
+                "BASH_FUNC_tool%%",
+            ] {
+                shell.env(key, "");
+                assert!(direct_command(&shell, false, "tool", &[], true).is_none());
+                shell.env_remove(key);
+            }
+            assert!(direct_command(&shell, false, "missing", &[], true).is_none());
+            for path in [
+                format!("{}:.", bin.display()),
+                format!("{}:", bin.display()),
+                String::new(),
+            ] {
+                shell.env("PATH", path);
+                assert!(direct_command(&shell, false, "tool", &[], true).is_none());
+            }
+            shell.env(
+                "PATH",
+                format!("{}:{}", dir.path().join("missing").display(), bin.display()),
+            );
+            assert!(direct_command(&shell, false, "tool", &[], true).is_some());
+            symlink(&tool, bin.join("linked-tool")).unwrap();
+            assert!(direct_command(&shell, false, "linked-tool", &[], true).is_some());
+            std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o644)).unwrap();
+            assert!(direct_command(&shell, false, "tool", &[], true).is_none());
+            shell.env_remove("PATH");
+            assert!(direct_command(&shell, false, "tool", &[], true).is_none());
+        }
+
+        #[test]
+        fn native_argv0_and_logical_pwd() {
+            use std::os::unix::fs::symlink;
+            let dir = tempfile::tempdir().unwrap();
+            let logical = dir.path().join("logical");
+            let physical = dir.path().join("physical");
+            std::fs::create_dir(&physical).unwrap();
+            symlink(&physical, &logical).unwrap();
+            let mut shell = Command::new("sh");
+            shell
+                .env_clear()
+                .env("PATH", "/usr/bin:/bin")
+                .env("PWD", &logical)
+                .current_dir(&physical);
+            let mut direct = direct_command(&shell, false, "env", &[], true).unwrap();
+            // std's Debug uses argv0, unlike get_program (the resolved executable).
+            assert!(format!("{direct:?}").contains("\"env\""));
+            let output = String::from_utf8(direct.output().unwrap().stdout).unwrap();
+            assert!(output.contains(&format!("PWD={}\n", logical.display())));
+        }
+
+        #[test]
+        fn preserves_child_context_and_falls_back() {
+            use std::os::unix::fs::PermissionsExt;
+            let dir = tempfile::tempdir().unwrap();
+            let tool = dir.path().join("tool");
+            std::fs::write(&tool, "#!/bin/sh\nprintf '%s\\n' \"$PWD\" \"$@\"\n").unwrap();
+            std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o755)).unwrap();
+            let mut shell = Command::new("sh");
+            shell
+                .env_clear()
+                .env("PATH", dir.path())
+                .current_dir(dir.path());
+            let mut direct = direct_command(
+                &shell,
+                false,
+                "tool first",
+                &["$literal space".into()],
+                true,
+            )
+            .unwrap();
+            assert_eq!(direct.get_program(), tool);
+            assert_eq!(
+                String::from_utf8(direct.output().unwrap().stdout).unwrap(),
+                format!("{}\nfirst\n$literal space\n", dir.path().display())
+            );
+            assert!(direct_command(&shell, false, "tool", &[], false).is_none());
+            shell.env("ENV", "");
+            assert!(direct_command(&shell, false, "tool", &[], true).is_none());
+            shell.env_remove("ENV");
+            std::fs::write(&tool, "echo no-shebang\n").unwrap();
+            assert!(direct_command(&shell, false, "tool", &[], true).is_none());
+            for body in [
+                "#!\necho empty-interpreter\n",
+                "#!/missing-inline-interpreter\n",
+                "#!/bin/sh",
+            ] {
+                std::fs::write(&tool, body).unwrap();
+                assert!(direct_command(&shell, false, "tool", &[], true).is_none());
+            }
+            shell.env("PATH", format!(":{}", dir.path().display()));
+            assert!(direct_command(&shell, false, "tool", &[], true).is_none());
+        }
+    }
+}

--- a/src/inline_command.rs
+++ b/src/inline_command.rs
@@ -330,7 +330,10 @@ mod unix {
             assert_eq!(direct.get_program(), tool);
             assert_eq!(
                 String::from_utf8(direct.output().unwrap().stdout).unwrap(),
-                format!("{}\nfirst\n$literal space\n", dir.path().display())
+                format!(
+                    "{}\nfirst\n$literal space\n",
+                    std::fs::canonicalize(dir.path()).unwrap().display()
+                )
             );
             assert!(direct_command(&shell, false, "tool", &[], false).is_none());
             shell.env("ENV", "");

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ mod timings;
 
 #[macro_use]
 mod cmd;
+mod inline_command;
 
 mod agecrypt;
 mod aqua;

--- a/src/system/deps.rs
+++ b/src/system/deps.rs
@@ -441,7 +441,17 @@ async fn check_command(cmd: &str) -> (bool, Option<String>, Option<String>) {
     } else {
         ("sh", vec!["-c", cmd])
     };
-    match run_capture(program, &args).await {
+    let mut command = std::process::Command::new(program);
+    command.args(&args);
+    let command = crate::inline_command::direct_command(
+        &command,
+        true,
+        cmd,
+        &[],
+        crate::config::Settings::get().implicit_inline_shell(),
+    )
+    .unwrap_or(command);
+    match capture_command(command).await {
         Some((true, _)) => (true, None, None),
         _ => (
             false,
@@ -460,11 +470,15 @@ async fn run_capture(
     program: impl AsRef<std::ffi::OsStr>,
     args: &[&str],
 ) -> Option<(bool, String)> {
-    let program = program.as_ref();
-    let fut = tokio::process::Command::new(program)
-        .args(args)
-        .stdin(std::process::Stdio::null())
-        .output();
+    let mut command = std::process::Command::new(program);
+    command.args(args);
+    capture_command(command).await
+}
+
+async fn capture_command(command: std::process::Command) -> Option<(bool, String)> {
+    let program = command.get_program().to_owned();
+    let mut command = tokio::process::Command::from(command);
+    let fut = command.stdin(std::process::Stdio::null()).output();
     let output = match tokio::time::timeout(std::time::Duration::from_secs(5), fut).await {
         Ok(Ok(output)) => output,
         Ok(Err(_)) => return None,

--- a/src/system/hooks.rs
+++ b/src/system/hooks.rs
@@ -172,6 +172,7 @@ pub(crate) async fn run_phase(
         info!("$ {run}");
         crate::cmd::CmdLineRunner::new(program)
             .cmd_body_args(shell_args, &run)
+            .optimize_inline(&run, &[], Settings::get().implicit_inline_shell())
             .raw(true)
             .execute_async()
             .await?;

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1247,9 +1247,16 @@ impl TaskExecutor {
             file::make_executable(&file)?;
             self.exec_with_text_file_busy_retry(&file, args, ctx).await
         } else {
-            let (program, args, cmd_verbatim) =
+            let (program, shell_args, cmd_verbatim) =
                 self.get_cmd_program_and_args(script, ctx.task, args)?;
-            self.exec_program(&program, &args, cmd_verbatim, ctx).await
+            self.exec_program(
+                &program,
+                &shell_args,
+                cmd_verbatim,
+                Some((script, args)),
+                ctx,
+            )
+            .await
         }
     }
 
@@ -1368,6 +1375,10 @@ impl TaskExecutor {
         Ok((program.to_string(), full_args[1..].to_vec(), false))
     }
 
+    fn implicit_inline_shell(&self, task: &Task) -> bool {
+        task.shell.is_none() && self.shell.is_none() && Settings::get().implicit_inline_shell()
+    }
+
     fn clone_default_inline_shell(&self) -> Result<Vec<String>> {
         if let Some(shell) = &self.shell {
             let mut shell = crate::path::split_shell_command(shell)?;
@@ -1446,7 +1457,8 @@ impl TaskExecutor {
                 .env_clear()
                 .envs(&filtered_env)
                 .with_timeout(timeout)
-                .with_sandbox(sandbox.clone());
+                .with_sandbox(sandbox.clone())
+                .optimize_inline(command, &[], self.implicit_inline_shell(task));
             runner.apply_sandbox().await?;
             let (stdout_hash, stderr_hash) = runner
                 .execute_hashes_async(COMMAND_INPUT_MAX_OUTPUT_BYTES)
@@ -1492,7 +1504,7 @@ impl TaskExecutor {
     async fn exec(&self, file: &Path, args: &[String], ctx: TaskExecContext<'_>) -> Result<()> {
         if runs_without_a_shell(file) {
             let program = file.display().to_string();
-            return self.exec_program(&program, args, false, ctx).await;
+            return self.exec_program(&program, args, false, None, ctx).await;
         }
         // Resolved once, from the file the user wrote, and then used for both decisions below.
         let shell = file_task_shell(file, ctx.task)?;
@@ -1501,7 +1513,7 @@ impl TaskExecutor {
         let shim = ps1_shim(file, &shell)?;
         let script = shim.as_deref().unwrap_or(file);
         let (program, args) = self.get_file_program_and_args(script, &shell, args)?;
-        self.exec_program(&program, &args, false, ctx).await
+        self.exec_program(&program, &args, false, None, ctx).await
     }
 
     async fn exec_with_text_file_busy_retry(
@@ -1539,6 +1551,7 @@ impl TaskExecutor {
         program: &str,
         args: &[String],
         cmd_verbatim: bool,
+        inline: Option<(&str, &[String])>,
         ctx: TaskExecContext<'_>,
     ) -> Result<()> {
         let TaskExecContext {
@@ -1613,6 +1626,15 @@ impl TaskExecutor {
             .redact(redactions.deref().clone())
             .raw(raw)
             .with_sandbox(sandbox);
+        if let Some((body, forwarded)) = inline {
+            cmd = cmd
+                .current_dir(task_cwd(task, &config).await?)
+                .optimize_inline(
+                    body,
+                    forwarded,
+                    audit.is_none() && self.implicit_inline_shell(task),
+                );
+        }
         if raw && !redactions.is_empty() {
             if task.interactive && !task.raw && !Settings::get().raw {
                 hint!(

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1479,7 +1479,14 @@ pub(crate) fn tera1_exec(
             if let Some(dir) = &dir {
                 expr = expr.dir(dir);
             }
-            Ok(expr.read()?)
+            Ok(crate::inline_command::optimize_expression(
+                expr,
+                command,
+                &env_no_shims,
+                dir.as_deref(),
+                Settings::get().implicit_inline_shell(),
+            )
+            .read()?)
         };
         Ok(json!(
             run_once().map_err(|e| tera1_err(format!("exec command: {e}")))?
@@ -1606,7 +1613,14 @@ pub(crate) fn tera_exec(
                     if let Some(dir) = &dir {
                         expr = expr.dir(dir);
                     }
-                    Ok(expr.read()?)
+                    Ok(crate::inline_command::optimize_expression(
+                        expr,
+                        &command,
+                        &env_no_shims,
+                        dir.as_deref(),
+                        Settings::get().implicit_inline_shell(),
+                    )
+                    .read()?)
                 };
                 let result = if cache.is_some() || cache_duration.is_some() {
                     let cachehash = hash::hash_blake3_to_str(

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -109,11 +109,22 @@ pub(crate) fn get_credential_command_token(
     {
         command = c;
     }
-    let result = command
+    command
         .env("PATH", &path_without_shims)
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("MISE_CREDENTIAL_HOST", host)
-        .env("MISE_CREDENTIAL_PROVIDER", provider)
+        .env("MISE_CREDENTIAL_PROVIDER", provider);
+    // The helper's $0/$1 belong to sh, not to a directly executed program.
+    if let Some(direct) = crate::inline_command::direct_command(
+        &command,
+        true,
+        cmd,
+        &[],
+        Settings::get().implicit_inline_shell(),
+    ) {
+        command = direct;
+    }
+    let result = command
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())

--- a/src/watch_files.rs
+++ b/src/watch_files.rs
@@ -81,6 +81,7 @@ async fn execute(
         .iter()
         .map(|f| f.to_string_lossy().replace(':', "\\:"))
         .join(":");
+    let direct_enabled = shell.is_none() && Settings::get().implicit_inline_shell();
     let mut shell = match shell {
         Some(shell) => crate::path::split_shell_command(shell)?,
         None => Settings::get().default_inline_shell()?,
@@ -129,11 +130,15 @@ async fn execute(
             return Ok(());
         }
     }
-    cmd(program, args)
-        .stdout_to_stderr()
-        // .dir(root)
-        .full_env(env)
-        .run()?;
+    crate::inline_command::optimize_expression(
+        cmd(program, args).full_env(&env),
+        run,
+        &env,
+        None,
+        direct_enabled,
+    )
+    .stdout_to_stderr()
+    .run()?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Follows #12949, which merged while this PR was being verified; rebased onto `main` after the portability branch was deleted. Related to [discussion #12935](https://github.com/jdx/mise/discussions/12935).

- Add a mise-local conservative Unix planner inspired by aube's allowlist. Only plain ASCII external commands qualify; syntax, quoting, expansion, assignments, builtins, keywords, and uncertain executable lookup retain the existing shell.
- Use the final child environment/PATH, preserve literal forwarded arguments, native argv0, cwd/logical PWD, and existing output handling and process supervision. Relative/empty PATH entries, inaccessible candidates, executable text without a usable shebang, and unresolved programs fall back.
- Integrate tasks/cache inputs, hooks/bootstrap hooks, watch commands, both template engines, dependency commands/checks, postinstall/SPM commands, and credential helpers. Credential helper `$0`/`$1` stay confined to shell invocations.
- Explicit shell settings (including a default-equal value), effective `ENV`/`BASH_ENV`, exported Bash options/functions, and sandboxed/audited tasks retain shell execution. Windows is unchanged.
- Trust implicit `sh` without inspecting its identity. A PATH-provided wrapper can be bypassed; explicitly configuring it forces its use.

No new setting or dependency. Embedded aube and its workspace crates already remain at 2.2.12. Vfox's internal subprocess implementation is unchanged.

## Verification

- `mise run lint-fix`
- `cargo check --locked`
- `cargo clippy --locked --workspace --all-features --all-targets -- -D warnings`
- Focused Cargo tests after rebasing onto current `main`: **271 passed** (inline planner, command runner, settings, tasks, dependencies, SPM, templates, credentials), including SPM install environment and direct-execution timeout/cancellation tests.
- `mise run test:e2e`: all nine focused tests passed before the rebase: `test_inline_direct`, `test_inline_direct_consumers`, `test_inline_shell_portable`, `test_hooks_postinstall_env`, `test_watch_files_shell`, `test_task_artifact_cache_command_inputs`, `test_task_timeout`, `test_task_interrupt_cleanup`, `test_task_raw_args`. The selected Rust suites were rechecked after the upstream merges.
- PATH-wrapper tests prove eligible commands actually skip the default shell, not merely reproduce its output.

The build cache hit an aws-lc-sys CMake compiler-cache mismatch. Verification completed with the documented `MBX_DISABLE=1` fallback (also clearing the globally configured Rust compiler wrapper); stale generated CMake state was moved aside. No repository build configuration was changed.

## Measurement

Linux, debug binary, one task containing 500 `basename /tmp/example` commands. Same binary, implicit default versus explicit `sh -o errexit -c`; alternating order, one warm-up plus seven samples each, after compilation was idle:

- Direct: median **1.212 s**
- Shell: median **1.370 s**
- **1.13x** throughput ratio, about **11.5% less elapsed time** for this short-command workload. This is a local microbenchmark, not a general workload guarantee.

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many command execution paths (tasks, hooks, credentials, deps) with intentional fallbacks, but subtle Unix semantics changes (PATH `sh` bypass, argv/env) could affect edge-case workflows.
> 
> **Overview**
> On **Unix**, mise now **executes plain inline commands directly** (e.g. `node build.js`) when a conservative planner decides they are safe, instead of always wrapping them in the default shell. Shell syntax, quoting, expansion, builtins, ambiguous `PATH` lookup, `ENV`/`BASH_ENV`, explicit task/`mise run --shell`/`unix_default_inline_shell_args` settings, sandboxed/audited tasks, and **Windows** still use the shell.
> 
> The planner lives in new **`inline_command`** logic and is wired through **`CmdLineRunner::optimize_inline`**, tasks (including cache command inputs), hooks, watch files, template `exec`, deps inline runs, install/postinstall/SPM commands, system dep checks, and GitHub credential helpers—**credential `$0`/`$1` semantics stay shell-only** when the helper is a shell one-liner. Task args are forwarded as **literal argv** under direct exec; docs describe when direct vs shell applies.
> 
> **Tests** add e2e coverage for direct execution and consumer integrations, plus unit tests for the planner and runner supervision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b16e8f322760b290e6b8f491e3119cf11d0063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Simple inline commands on Unix now run directly when safe, while retaining shell execution when required.
  - Direct execution also applies to inline hooks, templates, dependencies, installation commands, credentials, watch files, and cache inputs.
  - Explicit shells, sandboxed or audited tasks, and relevant shell environments continue using shell execution.
  - Forwarded arguments, environments, working directories, timeouts, cancellation, and exit codes are preserved. Windows behavior is unchanged.

- **Documentation**
  - Clarified argument forwarding and direct-versus-shell execution conditions.

- **Tests**
  - Added coverage for direct execution, shell selection, integrations, caching, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->