### PR TITLE
feat(bootstrap): name configuration adoption explicitly

### DIFF
--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -144,7 +144,7 @@ export const sidebar: SidebarItem[] = [
         link: "/bootstrap/files",
       },
       {
-        text: "System Services",
+        text: "Services",
         link: "/bootstrap/services",
       },
       {
@@ -162,6 +162,10 @@ export const sidebar: SidebarItem[] = [
       {
         text: "Dotfiles",
         link: "/dotfiles",
+      },
+      {
+        text: "Dotfiles History",
+        link: "/history",
       },
       {
         text: "Shell Activation",
@@ -182,10 +186,6 @@ export const sidebar: SidebarItem[] = [
       {
         text: "User Login Shell",
         link: "/bootstrap/user",
-      },
-      {
-        text: "Dotfiles history",
-        link: "/history",
       },
     ],
   },

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -48,11 +48,11 @@ Open a new shell after activation files change.
 
 Choose the command that matches what your repository contains:
 
-| Repository contents                                                      | Command                           | Where the files go                                       |
-| ------------------------------------------------------------------------ | --------------------------------- | -------------------------------------------------------- |
-| A bootstrap project with `mise.toml` and source files                    | `mise bootstrap --from <url>`     | A separate checkout, then targets defined by the project |
-| Global mise configuration such as `config.toml`, `conf.d/`, and `tasks/` | `mise bootstrap --from-git <url>` | Your global mise configuration directory                 |
-| Tracked dotfiles shared through `mise bootstrap dotfiles origin set`     | `mise bootstrap --from-git <url>` | Each tracked file's path on this machine                 |
+| Repository contents                                                      | Command                        | Where the files go                                       |
+| ------------------------------------------------------------------------ | ------------------------------ | -------------------------------------------------------- |
+| A bootstrap project with `mise.toml` and source files                    | `mise bootstrap --from <url>`  | A separate checkout, then targets defined by the project |
+| Global mise configuration such as `config.toml`, `conf.d/`, and `tasks/` | `mise bootstrap --adopt <url>` | Your global mise configuration directory                 |
+| Tracked dotfiles shared through `mise bootstrap dotfiles origin set`     | `mise bootstrap --adopt <url>` | Each tracked file's path on this machine                 |
 
 For a walkthrough of sharing tracked dotfiles, see
 [Set up a machine](/bootstrap/setup.html).
@@ -80,10 +80,10 @@ missing checkout and leaves it uncloned.
 
 ### Global mise configuration
 
-Use `--from-git` when the repository contains your global mise configuration:
+Use `--adopt` when the repository contains your global mise configuration:
 
 ```sh
-mise bootstrap --from-git example/mise-config
+mise bootstrap --adopt example/mise-config
 ```
 
 mise clones it into `$MISE_CONFIG_DIR`, normally `~/.config/mise`, and runs
@@ -102,7 +102,7 @@ A **setup repository** holds the dotfile history you share through
 `mise bootstrap dotfiles origin set`. On another machine, run:
 
 ```sh
-mise bootstrap --from-git you/setup
+mise bootstrap --adopt you/setup
 ```
 
 mise recognizes the repository's `.mise-history/format.toml` marker and:

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -144,8 +144,9 @@ preflight prevents a missing input from leaving a partially provisioned host.
 3. Built-in managers install missing [`[bootstrap.packages]`](/bootstrap/packages/).
 4. `mise bootstrap files apply` converges
    [`[bootstrap.files]` and `[bootstrap.directories]`](/bootstrap/files.html).
-5. `mise bootstrap services apply` converges existing systemd system units from
-   [`[bootstrap.services]`](/bootstrap/services.html).
+5. [`[bootstrap.services]`](/bootstrap/services.html) converges existing Linux
+   systemd system units and user services on Linux, macOS, and Windows.
+   User services with `requires_tools = true` wait until after tool installation.
 6. `mise bootstrap firewall apply` converges host firewall policy and rules from
    [`[bootstrap.linux.firewall]`](/bootstrap/firewall.html).
 7. `mise bootstrap compose apply` converges
@@ -165,7 +166,8 @@ preflight prevents a missing input from leaving a partially provisioned host.
     as configured.
 14. `mise bootstrap user apply` applies [`[bootstrap.user]`](/bootstrap/user.html).
 15. `mise install` installs missing `[tools]`.
-16. Plugin package managers apply after their host tools are available.
+16. Plugin package managers apply after their host tools are available, followed
+    by user services with `requires_tools = true`.
 17. `mise run bootstrap` runs a task named `bootstrap`, if one exists.
 18. `[bootstrap.hooks.final]` runs after the bootstrap task, if configured.
 
@@ -298,7 +300,7 @@ want to check one part without installing anything.
 | [`[bootstrap.secrets]`](/bootstrap/secrets.html)                        | Names of secret inputs consumed by managed file templates                   |
 | [`[bootstrap.users]`, `[bootstrap.groups]`](/bootstrap/accounts.html)   | Linux service accounts and groups                                           |
 | [`[bootstrap.files]`, `[bootstrap.directories]`](/bootstrap/files.html) | Managed system paths, content, ownership, and permissions                   |
-| [`[bootstrap.services]`](/bootstrap/services.html)                      | User services on all platforms, and existing Linux system services          |
+| [`[bootstrap.services]`](/bootstrap/services.html)                      | User services on Linux, macOS, and Windows; existing Linux system services  |
 | [`[bootstrap.compose]`](/bootstrap/compose.html)                        | Docker Compose project lifecycle                                            |
 | [`[bootstrap.plugins]`](/bootstrap/packages/plugins.html)               | Package manager plugins                                                     |
 | [`[bootstrap.packages]`](/bootstrap/packages/)                          | OS packages from apk, apt, dnf, pacman, brew, flatpak, mas, or winget       |

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -46,61 +46,88 @@ Open a new shell after activation files change.
 
 ## Starting from a repository
 
-On a new machine, mise can clone the repository containing that configuration
-before it starts:
+Choose the command that matches what your repository contains:
+
+| Repository contents                                                      | Command                           | Where the files go                                       |
+| ------------------------------------------------------------------------ | --------------------------------- | -------------------------------------------------------- |
+| A bootstrap project with `mise.toml` and source files                    | `mise bootstrap --from <url>`     | A separate checkout, then targets defined by the project |
+| Global mise configuration such as `config.toml`, `conf.d/`, and `tasks/` | `mise bootstrap --from-git <url>` | Your global mise configuration directory                 |
+| Tracked dotfiles shared through `mise bootstrap dotfiles origin set`     | `mise bootstrap --from-git <url>` | Each tracked file's path on this machine                 |
+
+For a walkthrough of sharing tracked dotfiles, see
+[Set up a machine](/bootstrap/setup.html).
+
+### A bootstrap project
+
+Use `--from` to clone a project and apply its `mise.toml`:
 
 ```sh
-mise -E work bootstrap --from git@github.com:example/dotfiles.git --yes
+mise bootstrap --from git@github.com:example/dotfiles.git
 ```
 
-The checkout defaults to `$MISE_DATA_DIR/bootstrap-repo`; use `--from-dir` to choose
-another location. The explicitly supplied checkout is trusted for this
-invocation, and the active `-E` environments are forwarded to it, so files such
-as `mise.home.toml` and `mise.work.toml` can select different profiles. Existing
-checkouts must have the requested URL as their `origin`. They are reused as-is
-unless `--update` is passed, in which case mise runs a fast-forward-only pull
-before applying the bootstrap configuration. During `--dry-run`, a missing
-checkout is reported but not cloned.
+The checkout defaults to `$MISE_DATA_DIR/bootstrap-repo`. Use `--from-dir`
+to choose another location. mise trusts the repository you supply for this
+invocation, so review it before running the command.
 
-If the repository is the global mise configuration itself, use `--from-git`
-instead:
+To select a mise environment, pass `-E`, for example
+`mise -E work bootstrap --from <url>`. The cloned project then loads the
+matching configuration, such as `mise.work.toml`.
+
+An existing checkout must have the requested URL as its `origin`. mise uses
+the current checkout unless you pass `--update` to pull newer commits first.
+That pull only accepts a fast-forward. With `--dry-run`, mise reports a
+missing checkout and leaves it uncloned.
+
+### Global mise configuration
+
+Use `--from-git` when the repository contains your global mise configuration:
 
 ```sh
-mise -E work bootstrap --from-git example/mise-config --yes
+mise bootstrap --from-git example/mise-config
 ```
 
-This clones the repository into `$MISE_CONFIG_DIR` (normally
-`~/.config/mise`). Files such as `config.toml`, `config.work.toml`, `conf.d/`,
-and `tasks/` are therefore loaded as global configuration during the first
-bootstrap and remain active for future mise invocations. If
-`$MISE_GLOBAL_CONFIG_FILE` selects an individual global config file, the repo
-is cloned into that file's parent directory instead and that file is loaded.
-As with `--from`, an existing non-empty destination must be a git checkout
-whose `origin` exactly matches the requested URL; pass `--update` to
-fast-forward it before bootstrap.
+mise clones it into `$MISE_CONFIG_DIR`, normally `~/.config/mise`, and runs
+bootstrap using that configuration. Files such as `config.toml`,
+`config.work.toml`, `conf.d/`, and `tasks/` stay available to future mise
+commands. Pass `-E work` to select `config.work.toml`.
 
-If the repository is a mise **setup repository** (one connected with
-`mise bootstrap dotfiles origin set`, recognizable by its
-`.mise-history/format.toml`), `--from-git` sets the machine up from it
-instead of cloning it: the branch is fetched into mise's own history store,
-this machine's explicitly enrolled files are written by the same recoverable pull as any other incoming
-change (a file that already exists and differs is held for a decision, never
-overwritten; `--dry-run` shows the plan), the connection is remembered for
-the history watcher, and the ordinary bootstrap then runs from the
-configuration that arrived. The repository's inventory is enough to restore
-tracked files without a global mise config. To recreate tools, services, or
-template deployments too, explicitly track their mise configuration and source
-files before publishing the setup. Merely referencing a source does not track it.
-An unresolved file conflict pauses the whole setup, including the bootstrap
-that would follow it. Nothing is cloned into `$MISE_CONFIG_DIR`, and an
-existing checkout there is not converted. See [history](/history.html) for
-what happens next.
+If you set `$MISE_GLOBAL_CONFIG_FILE`, mise clones into that file's parent
+directory and loads the selected file. An existing non-empty destination
+must be a Git checkout with the requested URL as its `origin`. Pass
+`--update` to fast-forward it before bootstrap.
 
-Setup repositories always fetch and reconcile their latest branch, with or
-without `--update`. That flag is still forwarded to the following bootstrap
-for package metadata and declared repository updates. If the global config
-directory is already a Git checkout, its origin must match the requested
-repository before setup can proceed.
+### Shared dotfile history
+
+A **setup repository** holds the dotfile history you share through
+`mise bootstrap dotfiles origin set`. On another machine, run:
+
+```sh
+mise bootstrap --from-git you/setup
+```
+
+mise recognizes the repository's `.mise-history/format.toml` marker and:
+
+1. Fetches the latest branch into its history store.
+2. Restores the tracked files to their paths on this machine.
+3. Remembers the origin for future synchronization.
+4. Runs bootstrap using the restored mise configuration.
+
+Track the mise configuration and any template sources on the first machine
+before sharing them. They let bootstrap recreate tools and services and
+render templates on the next machine. Tracked files can still be restored
+when the repository contains no global mise configuration.
+
+If an existing file differs, mise asks you to resolve the conflict before
+restoring files or running the remaining bootstrap steps. Use `--dry-run`
+to preview the plan. See [history](/history.html#sharing-across-machines)
+for synchronization and recovery details.
+
+This workflow stores Git history separately from `$MISE_CONFIG_DIR`; it
+leaves any existing checkout there as a checkout. If that directory is a
+Git checkout, its origin must match the requested repository.
+
+Setup repositories always fetch their latest branch. `--update` controls
+the subsequent bootstrap's package metadata and declared repository updates.
 
 ## How it runs
 
@@ -266,27 +293,27 @@ want to check one part without installing anything.
 
 ## What goes where
 
-| Config                                                                  | Use for                                                               |
-| ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| [`[bootstrap.secrets]`](/bootstrap/secrets.html)                        | Names of secret inputs consumed by managed file templates             |
-| [`[bootstrap.users]`, `[bootstrap.groups]`](/bootstrap/accounts.html)   | Linux service accounts and groups                                     |
-| [`[bootstrap.files]`, `[bootstrap.directories]`](/bootstrap/files.html) | Managed system paths, content, ownership, and permissions             |
-| [`[bootstrap.services]`](/bootstrap/services.html)                      | Existing Linux systemd system units and file-change handlers          |
-| [`[bootstrap.compose]`](/bootstrap/compose.html)                        | Docker Compose project lifecycle                                      |
-| [`[bootstrap.plugins]`](/bootstrap/packages/plugins.html)               | Package manager plugins                                               |
-| [`[bootstrap.packages]`](/bootstrap/packages/)                          | OS packages from apk, apt, dnf, pacman, brew, flatpak, mas, or winget |
-| [`[bootstrap.repos]`](/bootstrap/repos.html)                            | Git repos cloned before dotfiles are applied                          |
-| [`[dotfiles]`](/dotfiles.html)                                          | Whole-file dotfiles and small managed edits to existing files         |
-| [`[bootstrap.mise_shell_activate]`](/bootstrap/shell.html)              | mise activation snippets in shell startup files                       |
-| [`[bootstrap.macos.*]`](/bootstrap/macos-defaults.html)                 | Curated macOS preferences for Dock/Finder/keyboard/trackpad           |
-| [`[bootstrap.macos.defaults]`](/bootstrap/macos-defaults.html)          | macOS user preferences written through `defaults write`               |
-| [`[bootstrap.macos.launchd.agents]`](/bootstrap/launchd.html)           | macOS user LaunchAgents written and loaded with `launchctl`           |
-| [`[bootstrap.linux.systemd.units]`](/bootstrap/systemd.html)            | Linux systemd user services managed with `systemctl --user`           |
-| [`[bootstrap.linux.firewall]`](/bootstrap/firewall.html)                | Linux host firewall policy and managed rules                          |
-| [`[bootstrap.user]`](/bootstrap/user.html)                              | Current-user settings such as `login_shell`                           |
-| `[bootstrap.hooks]`                                                     | Commands that run at named bootstrap phases                           |
-| `[tools]`                                                               | Versioned dev tools managed by mise                                   |
-| `[tasks.bootstrap]`                                                     | Anything custom that should run after tools are installed             |
+| Config                                                                  | Use for                                                                     |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [`[bootstrap.secrets]`](/bootstrap/secrets.html)                        | Names of secret inputs consumed by managed file templates                   |
+| [`[bootstrap.users]`, `[bootstrap.groups]`](/bootstrap/accounts.html)   | Linux service accounts and groups                                           |
+| [`[bootstrap.files]`, `[bootstrap.directories]`](/bootstrap/files.html) | Managed system paths, content, ownership, and permissions                   |
+| [`[bootstrap.services]`](/bootstrap/services.html)                      | User services on all platforms, and existing Linux system services          |
+| [`[bootstrap.compose]`](/bootstrap/compose.html)                        | Docker Compose project lifecycle                                            |
+| [`[bootstrap.plugins]`](/bootstrap/packages/plugins.html)               | Package manager plugins                                                     |
+| [`[bootstrap.packages]`](/bootstrap/packages/)                          | OS packages from apk, apt, dnf, pacman, brew, flatpak, mas, or winget       |
+| [`[bootstrap.repos]`](/bootstrap/repos.html)                            | Git repos cloned before dotfiles are applied                                |
+| [`[dotfiles]`](/dotfiles.html)                                          | Tracking dotfiles, creating files from sources, and editing blocks or lines |
+| [`[bootstrap.mise_shell_activate]`](/bootstrap/shell.html)              | mise activation snippets in shell startup files                             |
+| [`[bootstrap.macos.*]`](/bootstrap/macos-defaults.html)                 | Curated macOS preferences for Dock/Finder/keyboard/trackpad                 |
+| [`[bootstrap.macos.defaults]`](/bootstrap/macos-defaults.html)          | macOS user preferences written through `defaults write`                     |
+| [`[bootstrap.macos.launchd.agents]`](/bootstrap/launchd.html)           | macOS user LaunchAgents written and loaded with `launchctl`                 |
+| [`[bootstrap.linux.systemd.units]`](/bootstrap/systemd.html)            | Linux systemd user services managed with `systemctl --user`                 |
+| [`[bootstrap.linux.firewall]`](/bootstrap/firewall.html)                | Linux host firewall policy and managed rules                                |
+| [`[bootstrap.user]`](/bootstrap/user.html)                              | Current-user settings such as `login_shell`                                 |
+| `[bootstrap.hooks]`                                                     | Commands that run at named bootstrap phases                                 |
+| `[tools]`                                                               | Versioned dev tools managed by mise                                         |
+| `[tasks.bootstrap]`                                                     | Anything custom that should run after tools are installed                   |
 
 Use declarative sections when mise can inspect and converge the state. Use
 `[tasks.bootstrap]` for imperative setup that does not fit those sections,
@@ -330,9 +357,8 @@ The `pre-dotfiles` and `post-dotfiles` phases also wrap
 
 ## Common workflows
 
-The whole path from installing mise to a second machine that shares the
-same setup, with the output each step prints, is
-[Set up a machine](/bootstrap/setup.html).
+For a walkthrough from your first tracked file to a second machine sharing
+its changes, see [Set up a machine](/bootstrap/setup.html).
 
 ### New machine
 
@@ -351,13 +377,20 @@ This writes `[bootstrap.packages]` and installs what is missing.
 
 ### Capture an edited dotfile
 
+For a file you already manage in `copy` mode, save edits back to its source:
+
 ```sh
 $EDITOR ~/.zshrc
 mise bootstrap dotfiles add ~/.zshrc
 ```
 
-`mise bootstrap dotfiles add` stores the live file under `dotfiles.root` and writes an
-explicit `[dotfiles]` entry with `mode`.
+`add` updates the managed source. For a file mise does not yet manage, it
+creates a source under `dotfiles.root`, writes a configuration entry, and
+applies it. See [capturing changes](/dotfiles.html#capturing-changes).
+
+For a file you edit in place and want to save in history, use
+`mise bootstrap dotfiles track ~/.zshrc`, then set up
+[automatic saves](/history.html#automatic-saves).
 
 ### Edit a managed dotfile
 

--- a/docs/bootstrap/remote.md
+++ b/docs/bootstrap/remote.md
@@ -311,7 +311,7 @@ mise configuration directory:
 
 ```sh
 # Authenticate on this machine first (for example, using gh auth login).
-mise bootstrap remote --host devbox --from-git jdx/dotfiles \
+mise bootstrap remote --host devbox --adopt jdx/dotfiles \
   --github-relay-read-only --github-relay-repo jdx/dotfiles
 ```
 
@@ -319,7 +319,7 @@ mise bootstrap remote --host devbox --from-git jdx/dotfiles \
 SSH syntax, and local paths on the initiating machine also work. Network repositories must use HTTPS or
 SSH; other transports and custom Git helpers are rejected. Source clones do not
 follow HTTP redirects, so use the repository's canonical URL.
-`--from-git` conflicts with `--source`.
+`--adopt` conflicts with `--source`.
 Targets still come from explicit `--host` or inventory selectors, never from the
 downloaded repository's inventory.
 
@@ -335,7 +335,7 @@ An existing matching checkout is reused unless `--update` requests a safe
 fast-forward. Dirty checkouts, mismatched origins, conflicting files, and source
 files ending in `.local.toml` require manual resolution. A nonempty non-Git
 directory can be adopted after confirmation: existing files and local overrides
-are preserved. With `--from-git`, `--dry-run` previews the whole operation the
+are preserved. With `--adopt`, `--dry-run` previews the whole operation the
 way `--source . --dry-run` does: the revision is fetched locally, the target is
 connected to, mise and the bundle are staged, and the target runs every check
 (dirty checkout, mismatched origin, adoption conflicts, `.local.toml` files) and
@@ -348,7 +348,7 @@ configuration and configuration-directory inputs needed to inspect bootstrap.
 Treat retained staging as sensitive; unrelated encrypted tracked files are not
 decrypted for this preview.
 
-`--from-git` uses the repository instead of the inventory's archive source and
+`--adopt` uses the repository instead of the inventory's archive source and
 copy-link settings. Explicit `--source`, `--copy-link`, `--copy-links`, and
 `--exclude` flags cannot be combined with it.
 
@@ -365,7 +365,7 @@ target shows that plan (the files it would write, and any held for a decision),
 records no connection, and keeps no fetched branch:
 
 ```sh
-mise bootstrap remote --host devbox --install-mise --from-git jdx/dotfiles \
+mise bootstrap remote --host devbox --install-mise --adopt jdx/dotfiles \
   --github-relay-read-only --github-relay-repo jdx/dotfiles --dry-run
 ```
 
@@ -437,7 +437,7 @@ mise ssh devbox --github-relay-read-only --github-relay-repo jdx/dotfiles \
   --github-relay-log-requests --github-relay-max-duration 1h
 
 # Structured relay events for troubleshooting or auditing:
-mise bootstrap remote --host devbox --from-git jdx/dotfiles \
+mise bootstrap remote --host devbox --adopt jdx/dotfiles \
   --github-relay-read-only --github-relay-repo jdx/dotfiles \
   --github-relay-log-requests --github-relay-log-format jsonl
 ```

--- a/docs/bootstrap/services.md
+++ b/docs/bootstrap/services.md
@@ -1,34 +1,55 @@
 ---
-description: "[bootstrap.services] declaratively manages systemd system units and cross-platform user services."
+description: "Run background services for your user, or manage existing Linux system services."
 ---
 
 # Services
 
-`[bootstrap.services]` declares services in two scopes:
+Use `[bootstrap.services]` to run a program in the background and start it
+again when you log in or reboot. Choose the kind of service you need:
 
-- **System services** (the default) manage the lifecycle of existing Linux
-  systemd system units: start, stop, enable, mask, and reload on change.
-- **User services** (`scope = "user"`) are services mise defines for the
-  current user, declared once and installed on every platform: a systemd user
-  unit on Linux, a LaunchAgent on macOS, a Scheduled Task on Windows.
+- [User services](#user-services) run programs as your current user on
+  Linux, macOS, and Windows. The dotfile history watcher is one example.
+- [System services](#system-services) start, stop, and configure existing
+  Linux systemd units. This is the default scope for entries without `builtin`.
 
 ## User services
 
-```toml
-[bootstrap.services.mise-history]        # the built-in history watcher
-builtin = "history-watch"                # implies scope = "user"
+To save edits to your [tracked dotfiles](/dotfiles.html) automatically, add
+this to your global mise configuration:
 
+```toml
+[bootstrap.services.mise-history]
+builtin = "history-watch"
+```
+
+Install the service and check it:
+
+```sh
+mise bootstrap services apply
+mise bootstrap dotfiles status
+```
+
+Once the watcher is running, keep editing your files normally. See
+[automatic saves](/history.html#automatic-saves) for saving behavior and
+[troubleshooting](#troubleshooting-user-services) if it fails to start.
+
+### Run your own program
+
+For a custom service, set `scope = "user"` and supply its command. This
+example assumes you have installed `my-agent` at the given path:
+
+```toml
 [bootstrap.services.my-agent]
 scope = "user"
 command = "~/.local/bin/my-agent --serve"
-description = "My agent"
-restart = "on-failure"                   # "always" | "on-failure" | "never"
-environment = { RUST_LOG = "info" }
-working_directory = "~"
-requires_tools = true                    # converge after [tools] are installed
 ```
 
-One declaration is rendered for the platform's user service manager:
+Run `mise bootstrap services apply`, then `mise bootstrap services status`.
+By default, the service starts at login and restarts after a failure.
+If its program comes from `[tools]`, add `requires_tools = true` and run
+the full `mise bootstrap` to install those tools first.
+
+mise creates a service definition for your platform:
 
 | platform | definition                                                                            | manager            |
 | -------- | ------------------------------------------------------------------------------------- | ------------------ |
@@ -40,60 +61,27 @@ One declaration is rendered for the platform's user service manager:
 
 - `command`: the command line to run. `~` and `~/` are expanded. Required
   unless `builtin` is set.
-- `builtin`: a definition mise supplies. `"history-watch"` runs
-  `mise bootstrap dotfiles watch` through a durable mise executable with
-  `restart = "on-failure"` and a low priority. A builtin implies
-  `scope = "user"`; `command` cannot be combined with it.
-  To avoid a tight failure loop, Linux allows three starts within five
-  minutes; macOS spaces repeated launches at least five minutes apart.
-  If Linux stops retrying, fix the problem reported by `mise doctor` or
-  the service logs, then rerun `mise bootstrap` to reset its failure budget
-  and restart it. You can also reset and start it directly
-  (`systemctl --user reset-failed dev.mise.<name>.service` followed by
-  `systemctl --user start dev.mise.<name>.service`). Ordinary custom
-  services retain their existing restart behavior.
+- `builtin`: a service supplied by mise. `"history-watch"` runs
+  `mise bootstrap dotfiles watch` at low priority. It sets `scope = "user"`
+  and `restart = "on-failure"`. Use it without `command`.
 - `description`: shown by the service manager.
-- `restart`: `"on-failure"` (default), `"always"`, or `"never"`. On Linux this
-  is `Restart=`; on macOS `KeepAlive` (`{ SuccessfulExit = false }` for
-  on-failure). Task Scheduler restarts only failed runs, so on Windows
-  `"always"` and `"on-failure"` both restart up to three times a minute apart
-  after a failure and run again at logon (when `enabled = true`); a clean
-  exit is not restarted. Strict `"always"` semantics are a Linux and macOS
-  feature; a service that must survive a clean exit on Windows should loop
-  inside its own program.
-- `environment` and `working_directory` map directly to the platform
-  definition. On Windows, environment variables are set through `cmd.exe`,
-  so values containing characters it would reinterpret (`%`, `"`, `&`, `|`,
-  `<`, `>`, `^`) are rejected, and so is a `command` containing `%`, `&`,
-  `|`, `<`, `>`, or `^` once `environment` is set (without `environment`
-  the command runs directly). Move such a command into a script, or set the
-  variables inside the program.
+- `restart`: `"on-failure"` (default), `"always"`, or `"never"`. Windows
+  restarts after failures only; see [platform differences](#platform-differences).
+- `environment`: environment variables passed to the program, for example
+  `{ LOG_LEVEL = "info" }`.
+- `working_directory`: the directory where the program runs.
 - `state`: `"running"` (default), `"stopped"` (installed but not running), or
   `"absent"` (the installed definition is removed and stays removed while
   declared so).
-- `enabled`: whether the service starts at login (default `true`). On macOS
-  this is `RunAtLoad`, which launchd also honours when the agent is loaded,
-  so a stopped agent is written without it (it starts at login again once it
-  is set running). launchd reads any `KeepAlive` as run-at-load too, so an
-  agent with `enabled = false` is written without one: it is started once by
-  the apply but neither starts at login nor is restarted after a failure
-  until it is enabled again.
-- `requires_tools`: converge in a second pass after `[tools]` and plugin
-  package managers, so a service that runs a tool starts after it exists. The
-  built-in watcher needs only mise and converges in the services step.
+- `enabled`: whether the service starts at login (default `true`). On macOS,
+  setting this to `false` also disables restarting after a failure.
+- `requires_tools`: install and start the service after `[tools]` and plugin
+  package managers during bootstrap. The built-in watcher starts in the
+  earlier services step because it only needs mise.
 
 Names must contain only letters, numbers, `.`, `_`, or `-`, and must not also
 appear in `[bootstrap.linux.systemd.units]` or
 `[bootstrap.macos.launchd.agents]`: both would write the same definition.
-
-### Durable executable
-
-A builtin is written with an absolute path to the mise that installed it.
-mise uses the running executable unless it lives in a temporary directory or
-in the staging directory of `mise bootstrap remote`, and otherwise a `mise`
-found on `PATH` outside those. When only a staged binary exists the service is
-reported as `unknown: no durable mise executable; install mise on this host
-first` and is never written with a path that will be deleted.
 
 ### Remove and disable
 
@@ -119,9 +107,60 @@ as `unknown` and skipped with a follow-up note; nothing is written.
 
 Fields that only apply to user services (`command`, `builtin`, `description`,
 `restart`, `environment`, `working_directory`, `requires_tools`, and
-`state = "absent"`) are rejected on a system-scope entry, so a missing
-`scope = "user"` cannot silently turn a service definition into a lookup of a
-system unit. Managed-file notifications apply to system services only.
+`state = "absent"`) require user scope. If you see an error about one of these
+fields, check that the entry has `scope = "user"` or `builtin`.
+Managed-file notifications apply to system services only.
+
+### Troubleshooting user services
+
+If the history watcher stops, run `mise doctor` and inspect the service logs.
+On Linux, it allows three starts within five minutes before stopping retries.
+On macOS, repeated launches are spaced at least five minutes apart.
+These limits apply to the built-in watcher.
+
+After fixing the cause on Linux, rerun `mise bootstrap` to reset the limit
+and start the watcher. You can also restart it directly:
+
+```sh
+systemctl --user reset-failed dev.mise.mise-history.service
+systemctl --user start dev.mise.mise-history.service
+```
+
+If you used another service name, replace `mise-history` in those commands.
+
+#### Install mise at a permanent path {#durable-executable}
+
+The watcher needs a mise executable that will still exist after setup ends.
+If status reports `unknown: no durable mise executable; install mise on this
+host first`, install mise on that host and apply the service again. For
+remote bootstrap, use `--install-mise`.
+
+mise writes an absolute executable path into built-in service definitions.
+It uses the running binary unless that binary is in a temporary directory or
+remote staging directory. In that case it looks for a permanent mise binary
+on `PATH`. If it cannot find one, it leaves the service unwritten.
+
+### Platform differences
+
+On Linux, `restart` maps to systemd's `Restart`. On macOS it maps to
+launchd's `KeepAlive`; `"on-failure"` uses `{ SuccessfulExit = false }`.
+
+On Windows, `"always"` and `"on-failure"` both retry failed runs up to three
+times, one minute apart. With `enabled = true`, the service also starts
+again at logon. A successful exit leaves it stopped. If a Windows program
+needs to keep running after completing its work, make it loop internally.
+
+On macOS, `enabled` controls `RunAtLoad`. launchd also treats `KeepAlive` as
+a request to start when loaded. mise omits `RunAtLoad` for a stopped service
+and omits `KeepAlive` when `enabled = false`. A running service with
+`enabled = false` starts once on apply, then stays stopped after an exit
+until you start it again or re-enable it.
+
+On Windows, setting `environment` uses `cmd.exe`. Values containing `%`,
+`"`, `&`, `|`, `<`, `>`, or `^` are rejected. When `environment` is set,
+`command` also rejects `%`, `&`, `|`, `<`, `>`, and `^`. Move such a command
+into a script or set variables in the program. Without `environment`, the
+command runs directly.
 
 ## System services
 

--- a/docs/bootstrap/setup.md
+++ b/docs/bootstrap/setup.md
@@ -169,7 +169,7 @@ export PATH="$HOME/.local/bin:$PATH"
 mise use -g gh
 mise x gh -- gh auth login --hostname github.com --git-protocol https --web
 mise x gh -- gh auth setup-git --hostname github.com
-mise bootstrap --from-git you/setup
+mise bootstrap --adopt you/setup
 ```
 
 Review the proposed files before confirming. Bootstrap restores the tracked
@@ -190,7 +190,7 @@ Choose `manual` or `fetch-only` here if you want a different mode on this machin
 For setup over SSH, see [remote bootstrap](/bootstrap/remote.html). For a private GitHub repository, borrow read-only access from this machine:
 
 ```sh
-mise bootstrap remote --host devbox --install-mise --from-git you/setup \
+mise bootstrap remote --host devbox --install-mise --adopt you/setup \
   --github-relay-read-only --github-relay-repo you/setup
 ```
 

--- a/docs/bootstrap/setup.md
+++ b/docs/bootstrap/setup.md
@@ -28,8 +28,9 @@ mise bootstrap dotfiles track ~/.zshrc
 On Omarchy with Bash, use `~/.bashrc` instead. Choose a file that already exists;
 the remaining examples use `~/.zshrc`.
 
-Tracking saves a baseline and adds a declaration to `~/.config/mise/config.toml`.
-The file stays in place:
+Tracking saves the file's current contents as a **checkpoint**, a version you
+can restore later. It leaves the file in place and adds this entry to
+`~/.config/mise/config.toml`:
 
 ```toml
 [dotfiles]
@@ -48,24 +49,24 @@ builtin = "history-watch"
 Install the service and check that it is running:
 
 ```sh
-mise bootstrap
+mise bootstrap services apply
 mise bootstrap dotfiles status
 ```
 
-The watcher runs as a systemd user service on Linux or a LaunchAgent on macOS.
-It commits edits to the local Git history. No origin connection is needed.
-The repository is stored separately from your live files.
+The watcher saves edits to local Git history. It runs as a systemd user
+service on Linux, a LaunchAgent on macOS, or a Scheduled Task on Windows.
+The history repository is stored separately from the files you edit.
 
 If you prefer to save manually, skip the service and run
 `mise bootstrap dotfiles save` after editing.
 
 ## Inspect and restore a change
 
-Edit your tracked file, then save a checkpoint explicitly so you can inspect it
+Edit your tracked file, then save a checkpoint now so you can inspect it
 without waiting for the watcher:
 
 ```sh
-mise bootstrap dotfiles save
+mise bootstrap dotfiles save ~/.zshrc
 mise bootstrap dotfiles history --path ~/.zshrc
 ```
 
@@ -81,20 +82,22 @@ To restore the previous version:
 mise bootstrap dotfiles rollback ~/.zshrc
 ```
 
-Review the proposed changes before confirming. Rollback saves a protective
-checkpoint first. To reverse the rollback:
+Rollback selects the latest saved version that differs from the current
+file. Review the proposed changes before confirming. It saves the current
+contents first, so you can reverse the rollback:
 
 ```sh
 mise bootstrap dotfiles undo
 ```
 
 A rollback creates a new commit, preserving the versions you left behind.
-A connected origin receives that commit according to your sync mode.
+If you enable sharing below, the restored version can reach your other machines.
 
 ## Share your setup (optional)
 
-Explicitly track the bootstrap configuration too, so another machine can recreate
-your tools and watcher service. Managing `.zshrc` did not enroll this file:
+To share changes between computers, connect a private Git repository, called
+an **origin**. First, track your mise configuration so the next machine can
+also install your tools and start the watcher:
 
 ```sh
 mise bootstrap dotfiles track ~/.config/mise/config.toml
@@ -112,32 +115,38 @@ The credential helper lets background synchronization authenticate without an
 interactive prompt. You can also use an SSH remote with credentials available
 to the watcher.
 
-Replace `you/setup` with your repository. This example chooses manual sync:
+Before connecting, review your tracked files and their history. Every saved
+version will be shared, including earlier local edits. Deleting a credential
+from a file later leaves it in old commits. For files that need encryption,
+configure [encrypted tracking](/history.html#encrypted-shared-files) before
+their first save and keep private decryption keys outside tracking.
+
+Replace `you/setup` with your repository. This example enables automatic
+sharing:
 
 ```sh
-mise bootstrap dotfiles origin set https://github.com/you/setup.git --sync manual
+mise bootstrap dotfiles origin set https://github.com/you/setup.git --sync sync
 ```
 
-Before confirming, review your tracked files and their history. Connecting an
-origin makes every committed version eligible for synchronization, including
-earlier local saves. There is no separate backup or per-file local-only mode.
+Review the connection preview before confirming. With the watcher running,
+saved edits are pushed within five minutes by default. It checks for changes
+from other machines every fifteen minutes and applies them to your files.
+After you set up a second machine below, edits can travel in both directions.
 
-For encrypted contents in the repository, use `encrypt = true` on an explicitly
-tracked file and configure public recipients before its first capture. Keep
-the decryption identity outside tracking. See [encrypted files](/history.html#encrypted-shared-files).
+### Choose when to sync
 
-Choose the mode that fits your workflow:
+Use `--sync manual` when connecting if you want to decide when to exchange
+changes. You can change the mode later with
+`mise settings set history.sync MODE`:
 
 | Mode         | Watcher behavior                                                |
 | ------------ | --------------------------------------------------------------- |
-| `manual`     | Saves locally; does not use the network automatically.          |
-| `fetch-only` | Fetches remote changes; does not publish or apply them.         |
 | `sync`       | Publishes saved changes, fetches, and applies incoming changes. |
+| `manual`     | Saves locally; waits for you to run the network commands.       |
+| `fetch-only` | Fetches remote changes for you to inspect and apply.            |
 
-Change modes with `mise settings set history.sync MODE`.
-
-Manual mode postpones network publication, not local commits. A later sync
-pushes the accumulated commits unchanged, then you can apply fetched changes:
+In manual mode, mise keeps saving locally. Run these commands to save your
+latest edits, push all accumulated commits, fetch remote changes, and apply them:
 
 ```sh
 mise bootstrap dotfiles save
@@ -145,9 +154,9 @@ mise bootstrap dotfiles sync
 mise bootstrap dotfiles pull
 ```
 
-`sync` exchanges saved changes with the repository; `pull` applies fetched
-changes to your files. Applying changes does not run bootstrap tasks or render
-templates. Run `mise bootstrap` when updated declarations need to be applied.
+These commands also work in automatic mode when you want to sync immediately.
+When a shared change updates tools, services, or template sources, run
+`mise bootstrap` to apply that configuration and render templates.
 
 ## Set up another machine
 
@@ -163,16 +172,20 @@ mise x gh -- gh auth setup-git --hostname github.com
 mise bootstrap --from-git you/setup
 ```
 
-Review the proposed files before confirming. Bootstrap reads enrollment from
-the repository, restores the tracked files, and applies the explicitly tracked
-configuration, including the watcher declaration added earlier. If configuration
-or required template sources were not enrolled, bootstrap reports the missing
-prerequisites rather than silently tracking them.
+Review the proposed files before confirming. Bootstrap restores the tracked
+files and applies the saved mise configuration, including the watcher service.
+If configuration or required template sources are missing from history,
+bootstrap reports which files you need to track and share from the first machine.
 
-If an existing file differs, mise holds it for a decision instead of silently
-overwriting it. Follow the reported conflict instructions. Check this machine's
-sync mode with `mise bootstrap dotfiles status` and choose its mode explicitly
-with `mise settings set history.sync MODE`.
+If an existing file differs, follow the reported conflict instructions before
+setup can continue. Enable automatic sharing on this machine and check its state:
+
+```sh
+mise settings set history.sync sync
+mise bootstrap dotfiles status
+```
+
+Choose `manual` or `fetch-only` here if you want a different mode on this machine.
 
 For setup over SSH, see [remote bootstrap](/bootstrap/remote.html). For a private GitHub repository, borrow read-only access from this machine:
 
@@ -186,10 +199,11 @@ credentials for ongoing synchronization.
 
 ## Resolve a conflict
 
-If two machines change the same lines, mise preserves both versions and pauses
-publication and incoming application for the entire setup. Local commits and
-fetching continue. Desktop notifications are enabled by default; status and
-`mise doctor` report the pause even without a working notifier.
+If two machines change the same lines, mise keeps both versions and pauses
+pushing and applying incoming changes for all tracked files. It continues
+saving locally and fetching updates. Desktop notifications are enabled by
+default on supported Linux and macOS installations. `status` and `mise doctor`
+also report the pause, including on Windows or headless machines.
 
 Inspect the conflict:
 
@@ -218,7 +232,7 @@ Use tracking for files you edit directly. Use a template when you want mise to
 render a file from configuration values.
 
 Add these entries to `~/.config/mise/config.toml`, merging them into any existing
-`[vars]` and `[dotfiles]` tables:
+`[vars]` and `[dotfiles]` tables. Use an unused target path for this example:
 
 ```toml
 [vars]
@@ -226,19 +240,20 @@ email = "you@example.com"
 
 [dotfiles]
 "~/templates" = { mode = "track" }
-"~/.gitconfig" = { source = "~/templates/gitconfig.tera", mode = "template" }
+"~/.config/mise-template-example.ini" = { source = "~/templates/example.ini.tera", mode = "template" }
 ```
 
-Create `~/templates/gitconfig.tera` (create `~/templates` first if needed):
+Create `~/templates/example.ini.tera` (create `~/templates` first if needed):
 
 ```ini
 [user]
     email = {{ vars.email }}
 ```
 
-Run `mise bootstrap` to render `~/.gitconfig`. Edit the template or its variables
-for future changes. The explicitly enrolled template directory is committed and synchronized.
-The rendered file is not tracked unless you explicitly enroll it too.
+Run `mise bootstrap` to render `~/.config/mise-template-example.ini`.
+It will contain the email address from `[vars]`. Edit the template or its variables
+for future changes. Tracking `~/templates` saves and shares those source files.
+To also save the rendered file's history, add a tracking entry for it.
 
 See [dotfiles](/dotfiles.html) for templates and OS-specific variants.
 
@@ -246,7 +261,8 @@ See [dotfiles](/dotfiles.html) for templates and OS-specific variants.
 
 On Omarchy, start with individual configuration files you edit. Inspect a
 directory before tracking it: themes, plugins, backgrounds, and application state
-may not belong in your dotfile history. Nested Git repositories are recorded as Git pointers, not copied recursively.
+may not belong in your dotfile history. For a nested Git repository, history
+records the commit it points to; keep that repository backed up separately.
 
 Before an update, save the current tracked files:
 
@@ -254,7 +270,8 @@ Before an update, save the current tracked files:
 mise bootstrap dotfiles save --best-effort
 ```
 
-This saves dotfiles, not installed packages or the rest of the operating system.
+This saves your tracked dotfiles. Use your operating system's backup tools
+for packages and other system state.
 
 On macOS, you can keep a tracked file separate from its Linux counterpart:
 
@@ -268,6 +285,6 @@ On either platform, check tracking and watcher status with:
 mise bootstrap dotfiles status
 ```
 
-For directory exclusions and capture policies, see [dotfiles](/dotfiles.html).
+For directory exclusions and save options, see [dotfiles](/dotfiles.html).
 For service management and other platforms, see
 [user services](/bootstrap/services.html).

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -34,7 +34,7 @@ repeated or comma-separated parts and cannot be combined.
 
 ## Flags
 - **`--from <GIT_URL>`** — Clone a git repository and bootstrap from its configuration
-- **`--from-git <GIT_URL>`** — Clone a git repository into the global mise config directory and bootstrap
+- **`--adopt <GIT_URL|OWNER/REPO>`** — Adopt global configuration or shared dotfile history from a Git repository, then bootstrap
 - **`--from-dir <DIR>`** — Directory used for the repository cloned by --from
 - **`-n --dry-run`** — Print what would happen without installing anything
 - **`-y --yes`** — Skip confirmation prompts
@@ -59,7 +59,7 @@ repeated or comma-separated parts and cannot be combined.
 ```
 mise bootstrap                    # packages + repos + dotfiles + tools + bootstrap task
 mise -E work bootstrap --from git@github.com:example/dotfiles.git --yes
-mise bootstrap --from-git git@github.com:example/mise-config.git --yes
+mise bootstrap --adopt git@github.com:example/mise-config.git --yes
 mise bootstrap --force-dotfiles   # replace conflicting dotfile targets
 mise bootstrap --skip tools,task  # skip tool installation and the bootstrap task
 mise bootstrap --only tools       # run just tool installation

--- a/docs/cli/bootstrap/remote.md
+++ b/docs/cli/bootstrap/remote.md
@@ -12,14 +12,14 @@ description: "Bootstrap one or more machines over OpenSSH"
 Bootstrap one or more machines over OpenSSH
 
 Select inventory hosts by name, tag, or `--all`, or supply ad-hoc `--host` targets.
-The source is staged on each target and bootstrap runs there. `--from-git` instead
+The source is staged on each target and bootstrap runs there. `--adopt` instead
 installs persistent global configuration; preview that choice with `--dry-run`.
 
 ## Arguments
 - **`[TARGET]…`** — Inventory host names from `[bootstrap.remote.hosts]`
 
 ## Flags
-- **`--from-git <GIT_URL|OWNER/REPO>`** — Install a Git repository as persistent global configuration on each target
+- **`--adopt <GIT_URL|OWNER/REPO>`** — Adopt global configuration or shared dotfile history on each target
 - **`--github-relay-read-only`** — Borrow read-only GitHub access for this invocation
 - **`--github-relay-repo <OWNER/REPO>`** — Approved GitHub repository; repeat for multiple repositories
 - **`--github-relay-all-repos`** — Explicitly authorize all repositories accessible locally

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -1,194 +1,213 @@
 ---
-description: "Declare dotfiles in [dotfiles] to manage complete files and directories, or a named block or line in a file shared with other tools."
+description: "Save the history of your configuration files, or use mise to copy, link, and generate them."
 ---
 
 # Dotfiles
 
-`[dotfiles]` declares how each of your configuration files is managed. The
-recommended way to adopt a file you already edit in place is to **track** it:
-the file stays where it is, nothing is copied or linked, and
-[history](/history.html) saves a checkpoint of it right away and after every
-change it sees.
+Dotfiles are configuration files such as `~/.zshrc` and `~/.gitconfig`.
+Keep editing them with your usual editor; mise can save changes in the
+background so you can return to an earlier version. With synchronization
+enabled on your machines, an edit on your laptop can reach your desktop,
+and edits on the desktop flow back.
 
-For an introduction, read [Dotfiles that save themselves](https://jdx.dev/posts/2026-09-07-dotfiles-that-save-themselves/).
+Start by [tracking a file you already use](#tracking-files-in-place). If you
+want mise to copy or link files into place, start with
+[one managed file](#start-with-one-managed-file).
+
+For an introduction to this workflow, read
+[Dotfiles That Save Themselves](https://jdx.dev/posts/2026-09-07-dotfiles-that-save-themselves/).
+
+## Tracking files in place
+
+With Git installed, start saving the history of a file you already have.
+For example, if you use zsh:
 
 ```sh
-mise bootstrap dotfiles track ~/.zshrc ~/.config/hypr
-mise bootstrap                                  # packages, tools, shell activation, …
-mise bootstrap dotfiles status                             # what is protected, and how
+mise bootstrap dotfiles track ~/.zshrc
 ```
+
+mise leaves the file where it is and saves a **checkpoint**, a version you
+can inspect or restore later. It also adds this entry to your global mise
+configuration (`~/.config/mise/config.toml` by default):
 
 ```toml
 [dotfiles]
 "~/.zshrc" = { mode = "track" }
-"~/.config/hypr" = { mode = "track" }
-"~/.config/app/state.json" = { mode = "track", autosave = false }   # saved only on request
-"~/templates" = { mode = "track" }                                # includes new descendants
 ```
 
-Templates, symlinks, copies, inline content, and managed edits are the
-complementary techniques for files mise generates or places for you. They keep
-working as before. Referencing or managing a file does not enroll it:
+### Save edits automatically
+
+Add the watcher service to the same global configuration file:
 
 ```toml
-[dotfiles]
-"~/.gitconfig" = { source = "~/templates/gitconfig.tera", mode = "template" }
-"~/.config/alacritty.toml" = { mode = "copy" }                       # ~/.dotfiles/.config/alacritty.toml
-"~/.config/nvim" = "dotfiles/nvim"                                   # symlink the directory itself
-"~/.local/bin" = { source = "dotfiles/bin", mode = "symlink-each" }  # symlink each file within
-"~/.config/tool.conf" = { content = "enabled = true\n" }              # inline whole-file content
-"~/.zshrc/activate" = { block = 'eval "$(mise activate zsh)"' }      # a managed block in a tracked file
-"~/hosts/dev" = { line = "127.0.0.1 dev.local" }                     # edit one line in ~/hosts
+[bootstrap.services.mise-history]
+builtin = "history-watch"
 ```
 
-Source-managed entries are captured and applied by `mise bootstrap dotfiles add`
-(pass `--no-apply` to only capture them) and applied explicitly with
-`mise bootstrap dotfiles apply` or as part of [`mise bootstrap`](/bootstrap.html).
-They are never applied implicitly by `mise install` or `mise bootstrap packages`.
-The nested apply command runs the configured `pre-dotfiles` and
-`post-dotfiles` bootstrap hooks.
+Install and start it, then check that it is running:
 
-## Command compatibility
-
-> [!WARNING]
-> The top-level `mise dotfiles` command is deprecated and hidden from help. It
-> will begin warning in mise 2027.2.0 and be removed in mise 2028.2.0. Use
-> `mise bootstrap dotfiles` instead.
-
-## Tracking files in place
-
-`mise bootstrap dotfiles track <path>…` writes a `mode = "track"` entry for
-each path (a file or a directory) into the global `config.toml`, saves a
-baseline checkpoint of it immediately, and reports whether anything saves
-later edits automatically. Tracking never infers a source under
-`dotfiles.root`, never moves the file, and never replaces it with a symlink.
-`mise bootstrap dotfiles untrack <path>` removes the declaration and stops
-future captures. The live file stays in place; future commit trees stop
-including it, while its previously committed versions remain in Git.
-
-A track entry takes no `source`, `content`, `exclude`, or `manifest`: a
-declaration combining them is reported by `mise bootstrap dotfiles paths` as invalid and
-never counted as protection, and `track` exits non-zero when the entry it
-wrote is not active.
-
-### Policies
-
-| Field      | Default | Meaning                                                                                                        |
-| ---------- | ------- | -------------------------------------------------------------------------------------------------------------- |
-| `autosave` | `true`  | Commit edits automatically. With `false`, save the path explicitly with `mise bootstrap dotfiles save <path>`. |
-| `encrypt`  | `false` | Encrypt contents before Git stores them, for `[history.encryption].recipients`. Live files stay native.        |
-
-`mise bootstrap dotfiles track <path> --no-autosave` selects manual saving.
-Every tracked file is eligible for origin synchronization. Manual sync delays
-pushing, not committing: the eventual push includes accumulated intermediate
-commits. There are no per-file sharing switches or separate backup policies.
-
-Enrollment accepts exact files and directories, not glob patterns. A directory
-includes new descendants subject to exclusions. Tracking a symlink records
-the link, not its target. Neither the global mise config directory nor
-`dotfiles.root` is implicitly enrolled.
-
-Tracking a path through a symlinked parent directory is rejected, because
-resolving that alias would silently change its destination on another machine.
-Explicitly track the link itself and its real target instead. Aliases in the
-home or mise configuration root are handled by the portable root mapping.
-
-To keep a file out of the origin, do not track it. Untracking or excluding a
-file does not erase versions that are already committed.
-
-### Variants
-
-A tracked file can hold different contents on different machines while
-keeping the same live path. Variants use the same selectors as bootstrap
-packages (`os`, with an optional `/arch`) and mise environments (`profile`):
-
-```toml
-[dotfiles]
-"~/.zshrc" = { mode = "track", variants = [{ os = "macos" }, { os = "linux" }] }
-"~/.gitconfig-work" = { mode = "track", variants = [{ profile = "work" }, { default = true }] }
+```sh
+mise bootstrap services apply
+mise bootstrap dotfiles status
 ```
 
-`mise bootstrap dotfiles track ~/.zshrc --os macos` adds a variant. The most
-specific matching variant wins (`profile` over an arch-qualified `os` over an
-`os` alone); two matching equally are reported as ambiguous and the path is
-left out until fixed. A machine matching no variant does not capture or apply that path unless a
-variant is marked `default = true`. Its commits preserve the other platforms'
-streams without saving this machine's live file into them.
+`status` shows the file as `tracked` and the watcher as running. Edit the
+file normally from now on. The watcher saves changes to local Git history.
+See [automatic saves](/history.html#automatic-saves) for service details.
 
-### Ownership
+To save by hand, skip the service and run
+`mise bootstrap dotfiles save ~/.zshrc` after editing.
 
-Deployment ownership and tracking observation are separate. A tracked directory
-may contain managed files or template sources; observing them does not take
-over their deployment. Explicit tracking and a managed declaration can coexist.
-Genuine conflicts between two deployment declarations are still rejected.
+### Try restoring a change
 
-`mise bootstrap dotfiles track <managed-file>` keeps the deployment declaration
-and writes its tracking entry separately under `conf.d/dotfiles-tracking.toml`.
-Untracking removes the tracking entry without removing the deployment or live file.
+Add an alias to `~/.zshrc` in your editor:
 
-Tracking also coexists with managed edits and shell activation:
-`mise bootstrap mise-shell-activate` can edit a tracked `~/.zshrc`.
+```sh
+alias ll='ls -lah'
+```
 
-`enabled = false` on a later layer switches an inherited declaration off on
-this machine, which is what `untrack` writes for entries declared by the
-system configuration. Tracking is enrolled from the system and global
-configuration only: a `mode = "track"` entry in a project config is ignored
-with a warning, so no project can enroll files in your history.
+Save a checkpoint now so you can try restoring it without waiting for the
+watcher, then inspect the file's history:
 
-`*.local.toml` files and protected credential-file defaults are excluded from
-capture entirely, not retained in a separate private history. Use explicit
-encrypted tracking for credential files that should be committed as ciphertext.
+```sh
+mise bootstrap dotfiles save ~/.zshrc
+mise bootstrap dotfiles history --path ~/.zshrc
+```
 
-`mise bootstrap dotfiles status` reports tracked entries as `tracked` and
-source-managed ones as `applied`, `missing`, `differs`, or `source missing`
-— deployment drift. History and sync state live in `mise bootstrap dotfiles status`.
+If that was your only edit, rolling back removes the new alias. Preview
+the restore, then apply it:
+
+```sh
+mise bootstrap dotfiles rollback ~/.zshrc --dry-run
+mise bootstrap dotfiles rollback ~/.zshrc
+```
+
+Rollback restores the latest saved version that differs from the current
+file. It saves the current contents first, so you can reverse the rollback
+with `mise bootstrap dotfiles undo`. See [rolling back](/history.html#rolling-back)
+to choose a particular checkpoint.
+
+### Share with another machine
+
+History is stored locally in Git until you configure a remote repository,
+called an **origin**. Connect your own repository and enable automatic
+synchronization to share saved edits in both directions. The watcher needs
+Git credentials on each machine. Follow
+[sharing across machines](/history.html#sharing-across-machines) to connect
+the repository, or [set up another machine](/bootstrap/setup.html) to bring
+your configuration to a new computer.
+
+Use a private repository: synchronization sends earlier checkpoints too,
+so temporary edits can become part of the shared history. Configure
+[encryption](/history.html#encrypted-shared-files) before first saving files
+that need it.
 
 ## Start with one managed file
 
-Create `dotfiles/example.conf` next to your `mise.toml`, then add an entry for an unused target:
+mise can also create configuration files from a **source** file that you
+maintain. The **target** is the path where an application reads the configuration.
+
+Create `dotfiles/example.conf` next to your `mise.toml` with this content:
+
+```ini
+enabled = true
+```
+
+Add the following to `mise.toml`. Choose an unused target path for this example:
 
 ```toml
 [dotfiles]
-"~/.config/mise-dotfiles-example.conf" = {
-    source = "dotfiles/example.conf",
-    mode = "copy",
-}
+"~/.config/mise-dotfiles-example.conf" = { source = "dotfiles/example.conf", mode = "copy" }
 ```
 
-Inspect the declaration, preview its application, and then apply it:
+Preview the copy, apply it, and check the result:
 
 ```sh
-mise bootstrap dotfiles status
 mise bootstrap dotfiles apply --dry-run
 mise bootstrap dotfiles apply
-mise bootstrap dotfiles status --missing
+mise bootstrap dotfiles status
 ```
 
-The last command exits successfully only when all selected entries match their sources.
-Editing a copy's target does not update the source: a later apply overwrites it. Use
-[`add` to capture changes](#capturing-changes), or edit the managed source with
-`mise bootstrap dotfiles edit <target>`.
+The target now contains `enabled = true`, and `status` reports it as `applied`.
+For future changes, edit `dotfiles/example.conf` and run `apply` again.
 
-To adopt an existing file as a managed source, use `mise bootstrap dotfiles add <target>`.
-This captures the live file into `dotfiles.root`, writes a declaration, and applies it.
-Start with `--no-apply` when you want to review the captured source and configuration
-first. To keep the file where it is instead, [track it](#tracking-files-in-place).
-The nested apply command runs the configured `pre-dotfiles` and
-`post-dotfiles` bootstrap hooks.
+> [!WARNING]
+> In `copy` mode, applying overwrites changes made directly to the target.
+> Use [`add` to save those changes back to the source](#capturing-changes)
+> before applying again.
+
+To start from an existing file, run `mise bootstrap dotfiles add <target>`.
+This saves the file under `dotfiles.root` (`~/.dotfiles` by default), adds a
+configuration entry, and applies it. The default mode is `symlink`, so the
+original path becomes a link to the saved source. Use `--no-apply` to review
+the source and configuration before changing the original file.
+
+`apply` also runs as part of [`mise bootstrap`](/bootstrap.html), with the
+configured `pre-dotfiles` and `post-dotfiles` hooks. `mise install` and
+`mise bootstrap packages` leave dotfiles alone.
+
+To save history for a source or target you manage this way, [track that
+path](#tracking-files-in-place) too.
+
+## Modes
+
+Choose how mise creates a target from its source:
+
+| Mode           | What happens when you apply                                       | Use when                                                              |
+| -------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `symlink`      | Create one link to a file or entire directory; the default.       | Edits through the target should change the source.                    |
+| `symlink-each` | Create directories and link each file within them.                | The target directory also holds files you want mise to leave alone.   |
+| `copy`         | Copy a file or directory, overwriting matching files.             | The application needs a regular file or writes its own configuration. |
+| `template`     | Render a source file with the [template engine](/templates.html). | The output depends on machine-specific variables.                     |
+
+For example, to link a directory:
+
+```toml
+[dotfiles]
+"~/.config/nvim" = { source = "dotfiles/nvim", mode = "symlink" }
+```
+
+`symlink-each` requires a directory source. When you delete or exclude a
+source file, the next apply removes its link. Other files in the target
+directory stay in place. mise records these links under
+`$MISE_STATE_DIR/dotfiles`; keep that directory so later applies can update
+or remove previously created links.
+
+Directory copies keep existing target files when you delete or exclude their
+sources. Review and remove those leftover copies yourself.
+
+### Templates
+
+```toml
+[dotfiles]
+"~/.gitconfig" = { source = "dotfiles/gitconfig.tera", mode = "template" }
+```
+
+Templates can use `env`, `vars`, `exec()`, and the rest of the
+[template context](/templates.html). Applying a template writes its rendered
+content and gives the target the source file's permissions. A later apply
+also repairs changed permissions.
+
+`status`, `diff`, and `apply` render templates to check their output. This
+executes any `exec()` calls in those templates, using your trusted config.
+With `--dry-run`, mise skips rendering dotfile templates and labels them
+`(if changed)`. Other configuration expressions can still run during a dry
+run, so use it with trusted configuration.
+
+See [Windows](#windows) for differences in link behavior on that platform.
 
 ## Whole-file entries
 
-Whole-file entries are keyed by the target path — absolute or starting with
-`~/` — and may point at a source file or directory. If `source` is omitted,
-mise mirrors the home-relative target path under `dotfiles.root`: `~/.zshrc`
-uses `~/.dotfiles/.zshrc`, and `~/.config/foo.toml` uses
-`~/.dotfiles/.config/foo.toml`. Targets outside `$HOME` must specify `source`
-or inline `content`.
+Each entry in `[dotfiles]` uses the target path as its key. Use an absolute
+path or one starting with `~/`. A source can be a file or a directory.
 
-String entries are shorthand for an explicit source with
-`dotfiles.default_mode`. `mise bootstrap dotfiles add` omits an implied source
-and the built-in `symlink` mode, while preserving a mode explicitly selected
-with `--mode`:
+When you omit `source`, mise looks under `dotfiles.root`, which defaults to
+`~/.dotfiles`. It uses the same path relative to your home directory:
+`~/.zshrc` gets its source from `~/.dotfiles/.zshrc`, and
+`~/.config/foo.toml` gets it from `~/.dotfiles/.config/foo.toml`.
+For targets outside your home directory, specify `source` or inline `content`.
+
+These entries use an inferred source and an explicit source, respectively:
 
 ```toml
 [dotfiles]
@@ -196,28 +215,32 @@ with `--mode`:
 "~/.ssh/config" = { source = "ssh/config", mode = "copy" }
 ```
 
-Relative explicit sources resolve against the directory of the config file
-that declares the entry, so a global `~/.config/mise/config.toml` can manage
-dotfiles kept next to it, and a project config can ship machine setup from
-the repo.
+Relative source paths start from the directory containing the configuration
+file. For example, `source = "ssh/config"` in
+`~/.config/mise/config.toml` refers to `~/.config/mise/ssh/config`.
 
-`mise bootstrap dotfiles status --json` includes an `origin` object for every
-entry. It reports the declaring config, its `config_root`, any configuration
-environment encoded by that config filename, and the resolved source path.
-Paths are ordinary strings when they are valid UTF-8. On Unix, a path containing
-non-UTF-8 bytes uses `mise:path-bytes:<base64url>` so provenance remains lossless.
-This makes layered dotfile declarations inspectable without reconstructing
-their precedence by hand.
+You can also write a source as a string, such as
+`"~/.config/nvim" = "dotfiles/nvim"`. This uses `dotfiles.default_mode`.
+When `add` writes an entry, it leaves out the source if it can infer it, and
+leaves out the built-in `symlink` mode. A mode you select with `--mode` is
+always written explicitly.
+
+### Inline content
 
 Use `content` to declare a literal whole file inline instead of keeping a
-separate source file. Inline content is written as a private regular file
-(`0600` on Unix). Use `content` on its own, without `source`, `mode`, `exclude`, `manifest`,
-or the edit options `block`, `line`, `template`, and `comment`:
+separate source file. On Unix, the resulting file has permissions `0600`,
+so only its owner can read and write it:
 
 ```toml
 [dotfiles]
 "~/.config/example.conf" = { content = "enabled = true\n" }
 ```
+
+Use `content` on its own. It cannot be combined with `source`, `mode`,
+`exclude`, `manifest`, or the edit options `block`, `line`, `template`, and
+`comment`.
+
+### Matching multiple source files
 
 Source paths may contain glob wildcards like `*`, `**`, `?`, or `[ab]`.
 When a wildcard source matches multiple paths, the target path must contain
@@ -277,37 +300,6 @@ the previous source. This makes `mise bootstrap -E home` and
 profile are removed, shared paths are repointed, and unmanaged neighbors are
 preserved.
 
-## Modes
-
-| Mode           | Target behavior                                                      | Use when                                                       |
-| -------------- | -------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `symlink`      | One link to a file or entire directory; the default.                 | Edits to the target should edit the source.                    |
-| `symlink-each` | Recreate directories and link individual files.                      | A target directory also contains unmanaged neighbors.          |
-| `copy`         | Copy a file or directory; overwrite matching files.                  | The application needs a regular file or writes its own config. |
-| `template`     | Render a source file through the [template engine](/templates.html). | The output depends on machine-specific variables.              |
-
-`symlink-each` requires a directory source. It records managed links under
-`$MISE_STATE_DIR/dotfiles`, so subsequent applies can remove links for deleted or excluded
-sources without recursively scanning a shared target. Unmanaged neighbors are preserved.
-Keep that state directory when you want mise to reconcile previously applied profiles.
-
-Directory copies are additive and **never pruned**: deleting or excluding a source leaves
-its old copy behind. Review and remove those leftovers yourself. Templates use the source
-file's permissions and repair permission drift when applied. See [Windows](#windows) for
-platform-specific link behavior.
-
-Templates get the same context as other mise templates (`env`, `vars`,
-`exec()`, etc.), which is the main reason to use them: one source file,
-per-machine output.
-
-Detecting whether a template's output has drifted requires rendering it, so
-`mise bootstrap dotfiles status`, `mise bootstrap dotfiles diff`, and a real
-apply evaluate templates — including any `exec()` calls — from your trusted
-config, just like `[env]` templates. Dotfile `--dry-run` skips rendering the dotfile
-templates and lists those entries as `(if changed)`. It does not suppress unrelated
-configuration evaluation, so this is a preview of dotfile writes, not a sandbox for
-untrusted configuration.
-
 ## Edit entries
 
 Edit entries manage one piece of a file: the `mise activate` block in your
@@ -339,9 +331,8 @@ eval "$(mise activate zsh)"
 # <<< mise:activate <<<
 ```
 
-The markers are the ownership record, stored in the file itself, so the
-design stays stateless: applying replaces only what's between them or
-appends the block if absent, and everything else in the file is untouched.
+Applying replaces the content between the markers. If the block is missing,
+mise appends it. Everything else in the file stays as it is.
 
 Ids may contain letters, digits, `_`, `-`, and `.`. The marker comment
 prefix is inferred from the file extension (`#` for shell/config files,
@@ -350,25 +341,24 @@ be overridden with `comment = "..."`. Files that can't hold line comments
 at all (strict JSON, XML) aren't a fit for blocks — use a whole-file entry
 instead.
 
-A `line` ensures an exact line exists somewhere in the file. A missing line is
-appended by default; set `position = "prepend"` to put it at the beginning
-instead. An existing exact match is left wherever it is. Applying a line edit
-preserves all other bytes, including the file's existing line endings. The
-value must be a single line; use a block for multi-line content.
+A `line` inserts the given text if that exact line is missing. By default,
+mise appends it; set `position = "prepend"` to insert it at the beginning.
+Running apply again leaves an existing match wherever it is. Other bytes,
+including line endings, stay unchanged. The value must be a single line;
+use a block for multi-line content.
 
-## Semantics
+## How configuration is applied {#semantics}
 
-- **Declarative and additive** — entries merge across the
-  [config hierarchy](/configuration.html) (global → project). Whole-file
-  entries merge by target path; edit entries merge by `(path, id)`.
-- **Explicit application** — `mise bootstrap dotfiles add` applies the entries
-  it captures unless `--no-apply` is set. Entries not captured by `add` are
-  applied by `mise bootstrap dotfiles apply` or [`mise bootstrap`](/bootstrap.html).
-- **Skip unchanged output** — entries already in their desired state are skipped.
-  Templates may still execute while checking their output, and copy/template entries
-  overwrite changed targets on apply.
-- **Unknown modes and operations are ignored with a warning** so configs
-  using features from newer mise versions still parse.
+- Entries merge across the [config hierarchy](/configuration.html).
+  Whole-file entries merge by target path; edit entries merge by `(path, id)`.
+  Tracking uses only system and global configuration.
+- `mise bootstrap dotfiles add` applies the entries it captures unless you
+  pass `--no-apply`. Use `mise bootstrap dotfiles apply` or
+  [`mise bootstrap`](/bootstrap.html) to apply the rest.
+- Applying skips targets that already match. Templates may still execute
+  while mise checks their output. Copy and template entries overwrite
+  changed targets.
+- mise warns and skips entries with unknown modes or operations.
 
 ## Conflicts
 
@@ -377,28 +367,23 @@ directory where a symlink should go, or a directory where a file should go,
 is an error listing the conflicting paths. Pass
 `mise bootstrap dotfiles apply --force` to replace them.
 
-Real files and directories always require `--force` during a standalone
-symlink apply, even when their visible content and permissions match. Portable
-filesystem APIs cannot compare ownership, ACLs, extended attributes, flags,
-and security labels. `mise bootstrap dotfiles add` avoids that destructive
-comparison by moving each captured real path to its source before creating the
-symlink; cross-filesystem moves fall back to a symlink- and
-permission-preserving copy.
+Replacing a real file or directory with a symlink requires `--force`, even
+when its contents and permissions match the source. To adopt an existing
+file, use `mise bootstrap dotfiles add`: it moves the file to its source
+path before creating the link. When the source is on another filesystem,
+mise copies it while preserving symlinks and permissions.
 
-Content updates in writing modes are not conflicts: a `copy` or `template` entry overwrites
-the target file's content without `--force` — that is the declared intent of
-those modes. Existing symlinks can be repointed; inspect the diff before changing which source a target uses.
+A `copy` or `template` entry overwrites the target's content without
+`--force`. Existing symlinks can also be repointed. Inspect the diff before
+changing which source a target uses.
 
-Edit entries never need `--force`: a block owns only what's between its
-markers, and a line only inserts when its exact content is absent. Two cases are refused with an error
-instead of guessed at: corrupted markers and targets that are symlinks. An
-edit through a symlink would modify whatever the link points at, often a
-`[dotfiles]` source, so point the edit at the real file instead.
+Blocks and lines can be applied without `--force`. mise reports an error
+if a block's markers are corrupted or an edit's target is a symlink.
+For a symlink, point the edit at the real file you want to change.
 
-Removing an entry from config leaves its file, block, or line in place
-because the active config still defines which state belongs to an entry. Run
-`mise bootstrap dotfiles unapply` before removing the entry when you want mise
-to clean up its observable footprint.
+Removing an entry from config leaves its file, block, or line in place.
+To remove them too, run `mise bootstrap dotfiles unapply` before deleting
+the entry from your config.
 
 ## Unapplying
 
@@ -417,16 +402,15 @@ filesystem, and recorded `symlink-each` state to determine what the entry owns:
 - Marker-delimited blocks are removed with their markers. Plain line edits have
   no ownership marker and require `--force`.
 
-Unapply is deliberately conservative because `copy` and `template` entries have
-no apply manifest. In particular, a copied file whose source was deleted can no
-longer be identified inside an additive directory copy. Remove such leftovers
-by hand. Use `--dry-run` to inspect the identifiable removals first; template
-dry-runs do not render or execute template functions.
+If you deleted a source file from a copied directory, unapply cannot
+identify its old copy. Remove that leftover file yourself. Use `--dry-run`
+to preview removals first. Template dry-runs skip rendering and template
+function calls.
 
 ## Commands
 
 ```sh
-mise bootstrap dotfiles status            # shows applied/missing/differs/source missing
+mise bootstrap dotfiles status            # show tracked files and the state of managed files
 mise bootstrap dotfiles status --missing  # exit 1 if anything is out of sync
 mise bootstrap dotfiles diff              # show changes needed to apply
 mise bootstrap dotfiles diff ~/.zshrc     # show changes for one target
@@ -450,21 +434,32 @@ mise bootstrap dotfiles edit --apply ~/.zshrc
 
 mise bootstrap dotfiles save                    # checkpoint the tracked files now
 mise bootstrap dotfiles history                 # browse checkpoints; `history show`, `history diff`
-mise bootstrap dotfiles paths                   # what history tracks, under which policies
+mise bootstrap dotfiles paths                   # list tracked paths and their save settings
 ```
 
 `mise bootstrap dotfiles status` reports each entry as `tracked`, `applied`,
 `missing`, `differs` with a reason, or `source missing`, followed by the
 history state: what is tracked, the latest checkpoint, unfinished
-operations, and whether edits are saved automatically. JSON uses
-`source_missing` for the last state and includes
-[origin information](#whole-file-entries). `--missing` changes the exit status
-when any selected entry is out of sync; it does not filter the displayed list.
+operations, and whether edits are saved automatically.
+
+Use `status --missing` in scripts to exit with status 1 when any selected
+entry is out of sync. It displays the same list as `status`.
 
 Every `apply`, `add`, `unapply`, and `edit --apply` records a pair of
 [history checkpoints](/history.html) — the tracked files before and after the
-change, with a journal of every path it touched — and `mise bootstrap dotfiles history` lists
-them.
+change. mise also records which paths the operation touched. Run
+`mise bootstrap dotfiles history` to browse these checkpoints.
+
+### JSON output
+
+`mise bootstrap dotfiles status --json` uses `source_missing` for the
+`source missing` state. Each entry also includes an `origin` object
+describing where its configuration came from: the config file, its
+`config_root`, any mise environment in the config filename, and the resolved
+source path.
+
+Paths are strings when they are valid UTF-8. On Unix, paths containing
+non-UTF-8 bytes use `mise:path-bytes:<base64url>`.
 
 ## Capturing changes
 
@@ -476,16 +471,126 @@ $EDITOR ~/.config/starship.toml
 mise bootstrap dotfiles add ~/.config/starship.toml
 ```
 
-Use `mise bootstrap dotfiles add --changed` to update every changed regular file
-managed in `copy` mode at once. Directory copies are excluded because reversing
-an additive copy could delete source files intentionally excluded from the live
-tree. Symlinks already edit their source directly, and templates and inline
-content cannot be reverse-rendered, so they are not included. Bulk capture also
-requires the configuration declaring each selected file to be trusted.
+Use `mise bootstrap dotfiles add --changed` to update the sources of all
+changed regular files managed in `copy` mode. Each selected file's
+configuration must be trusted. The command skips directory copies,
+symlinks, templates, and inline content.
 
 For an unmanaged target, `add` creates a `[dotfiles]` entry and seeds the
 source under `dotfiles.root`. For an already-managed target, it updates the
 existing source from the live target.
+
+## Tracking options
+
+### Saving and encryption {#policies}
+
+| Field      | Default | Meaning                                                                                                                   |
+| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `autosave` | `true`  | Let the history watcher save edits automatically. With `false`, save the path with `mise bootstrap dotfiles save <path>`. |
+| `encrypt`  | `false` | Encrypt contents before saving them to Git, using `[history.encryption].recipients`. The file you edit stays unencrypted. |
+
+For a file you want to save manually:
+
+```sh
+mise bootstrap dotfiles track ~/.config/app/state.json --no-autosave
+mise bootstrap dotfiles save ~/.config/app/state.json
+```
+
+The first command saves the initial version. Later edits wait for an
+explicit save. See [saving](/history.html#saving) for how commands that
+modify tracked files save their before and after versions.
+
+Saving and sharing have separate settings. With manual synchronization,
+mise continues making local commits. Your next push sends all accumulated
+commits to the origin. Sharing applies to the entire history; to keep a
+file out of it, leave it untracked. Untracking or excluding a file keeps
+its previously committed versions in history.
+
+### Files, directories, and symlinks
+
+Track exact file or directory paths under your home directory or mise
+configuration directory. Glob patterns are supported by
+[history exclusions](/history.html#explicit-tracking-and-exclusions), but
+cannot be used as tracking entries. Tracking a directory includes files
+added beneath it later, subject to those exclusions.
+
+Start with individual configuration files so you can choose what to save.
+Leave logs, caches, databases, and application session state out of history.
+Credential files and `*.local.toml` files are excluded by default; see
+[encrypted tracking](/history.html#encrypted-shared-files) to save credentials.
+
+Tracking a symlink saves the link itself. Track its target separately to
+save the target's contents. If a parent directory is a symlink, track that
+link and use the real directory path to track files beneath it.
+
+Your home directory and mise configuration directory can themselves be
+symlinks. mise maps these roots to the corresponding directories on each
+machine when sharing history.
+
+Add an explicit tracking entry for each file or directory you want to
+save, including the mise configuration directory or `dotfiles.root`.
+Track entries cannot contain `source`, `content`, `exclude`, or `manifest`.
+`mise bootstrap dotfiles paths` reports such combinations as invalid and
+leaves them out of history. The `track` command exits non-zero if the
+entry it writes is not active.
+
+### Stop tracking a file
+
+```sh
+mise bootstrap dotfiles untrack ~/.zshrc
+```
+
+The file stays in place. Its earlier checkpoints remain in Git, but future
+checkpoints leave it out.
+
+### Different contents on different machines {#variants}
+
+A **variant** lets a tracked file have different contents on different
+machines, using the same path on each one. For example, keep separate
+versions of `~/.zshrc` for macOS and Linux:
+
+```toml
+[dotfiles]
+"~/.zshrc" = { mode = "track", variants = [{ os = "macos" }, { os = "linux" }] }
+```
+
+Add this to your global configuration, or use
+`mise bootstrap dotfiles track ~/.zshrc --os macos` to add one variant.
+The `os` selector accepts an optional `/arch`, as in bootstrap packages.
+Use `profile` to select a [mise environment](/configuration/environments.html):
+
+```toml
+[dotfiles]
+"~/.gitconfig-work" = { mode = "track", variants = [{ profile = "work" }, { default = true }] }
+```
+
+When several variants match, mise scores each one: `profile` adds two
+points, `os` adds one, and an architecture adds one more. The highest
+score wins. A profile-only variant therefore ties with an OS-and-architecture
+variant. If the highest score is tied, mise reports the ambiguity and
+skips the path until you fix it.
+
+When nothing matches, mise uses the variant marked `default = true`.
+Without a default, it skips saving and applying the path on that machine.
+Checkpoints preserve the versions saved by other machines.
+
+### Tracking files that mise also manages {#ownership}
+
+You can save the history of a file that mise copies, links, templates, or
+edits. For example, tracking `~/.zshrc` also saves changes made by a managed
+activation block or `mise bootstrap mise-shell-activate`.
+
+When you track an already-managed file, mise keeps its existing entry and
+adds the tracking entry to `conf.d/dotfiles-tracking.toml`. Untracking
+removes only that tracking entry. A tracked directory can also contain
+managed files or template sources; their copy, link, or template settings
+continue to apply. Conflicting entries that try to create the same target
+are still rejected.
+
+Tracking entries belong in system or global configuration. mise warns and
+ignores `mode = "track"` in project configuration. To turn off an entry
+inherited from another configuration file, set `enabled = false` in a
+later configuration layer. `untrack` does this for system entries.
 
 ## Self-managing mise config
 
@@ -524,3 +629,10 @@ is not available, so entries keep applying either way.
 `mise bootstrap dotfiles status` reads whichever form is on disk.
 
 `symlink-each` still copies files on Windows. Directory symlinks use junctions.
+
+## Command compatibility
+
+> [!WARNING]
+> The top-level `mise dotfiles` command is deprecated and hidden from help. It
+> will begin warning in mise 2027.2.0 and be removed in mise 2028.2.0. Use
+> `mise bootstrap dotfiles` instead.

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -138,9 +138,11 @@ For future changes, edit `dotfiles/example.conf` and run `apply` again.
 
 To start from an existing file, run `mise bootstrap dotfiles add <target>`.
 This saves the file under `dotfiles.root` (`~/.dotfiles` by default), adds a
-configuration entry, and applies it. The default mode is `symlink`, so the
-original path becomes a link to the saved source. Use `--no-apply` to review
-the source and configuration before changing the original file.
+configuration entry, and applies it using `dotfiles.default_mode`. That
+setting defaults to `symlink`, which makes the original path a link to the
+saved source. Select another mode with `--mode`, such as `--mode copy` to
+keep a regular file at the target. Use `--no-apply` to review the source
+and configuration before changing the original file.
 
 `apply` also runs as part of [`mise bootstrap`](/bootstrap.html), with the
 configured `pre-dotfiles` and `post-dotfiles` hooks. `mise install` and

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,486 +1,417 @@
 ---
-description: "Track, inspect, synchronize, and restore dotfiles with mise's Git-backed history."
+description: "Save, inspect, restore, and share the history of your tracked dotfiles."
 ---
 
 # Dotfiles history
 
-mise automatically commits changes to files you explicitly track, then
-synchronizes those same commits with your origin. Edit native files with
-your editor or an agent; there is no separate source format to maintain.
+mise saves versions of your tracked configuration files in Git so you can
+inspect changes and restore an earlier version. History stays local until
+you connect a remote repository for sharing.
 
-Only exact files and directories declared with `mode = "track"` are enrolled.
-Directories include new descendants, subject to exclusions. The global mise
-configuration, `dotfiles.root`, deployment outputs, template sources, and
-symlink targets are not automatically tracked. A tracked symlink records the
-link itself; enroll its target separately if you want its contents in history.
-
-`mise bootstrap dotfiles history` browses the ordinary Git history. Automatic
-saves and explicitly labeled before/after operation boundaries are commits
-in that same history, retained indefinitely.
-
-A checkpoint holds files, not machine state. It does not journal other mise
-activity and does not reverse system effects: restoring a package
-declaration does not uninstall a package, and restoring a service definition
-does not restore whether that service was running. Applying configuration
-stays an explicit bootstrap action.
-
-```sh
-mise bootstrap dotfiles track ~/.zshrc ~/.config/hypr   # adopt files where they are
-mise bootstrap dotfiles history                                            # newest first
-mise bootstrap dotfiles history --path ~/.config/hypr/bindings.lua        # only where that file changed
-mise bootstrap dotfiles history diff                                       # what changed by hand since the latest checkpoint
-mise bootstrap dotfiles save --description "before the theme change"
-```
-
-The bare repository lives under `$MISE_STATE_DIR/history/repo.git`, separate
-from your live files. mise does not create `.git` in your home or application
-configuration directories. Without an origin it stays local. Connecting an
-origin makes **all committed versions** eligible for synchronization, including
-commits made before connecting. There is no per-file local-only history mode.
-
-Untracking stops future capture and removes the path from future committed
-trees, without deleting its live contents. It does not erase previously
-committed versions.
-
-This also applies inside `capture -- command`: if the command untracks a file,
-the outcome commit does not save its later contents. The before commit remains
-available, and interrupted-command recovery does not enroll the file again.
-
-## What a checkpoint records
-
-Each commit contains the tracked files plus minimal repository metadata for
-portable paths, enrollment, variants, encryption, and permissions. Files remain
-ordinary Git tree entries, not a wrapper snapshot or filtered publication copy.
-
-Symlinks are stored as links and nested Git repositories as pointers. Oversized
-files, special files, and unreadable paths are reported rather than silently
-claimed as saved. If a file cannot be captured, its previously saved version
-remains in the tree while other files can still be saved; this does not claim
-that its current contents were captured. Explicit exclusions still remove it
-from future trees. Encryption failures stop capture instead of storing plaintext.
-Operation boundaries carry labels and pairing information;
-raw arguments, environment contents, and untracked recovery copies are not
-published as operation metadata.
-
-`mise bootstrap dotfiles history show <ref>` shows a saved version; `--files`
-lists its files and `--json` returns the record.
-
-### Descriptions from an agent
-
-`settings.history.describe_command` names a command that describes the
-checkpoints the watcher saves. It gets one JSON object on stdin, `uuid`,
-`trigger`, the computed `description`, the changed paths that are not
-excluded (`added`, `modified`, `removed`), and `diff`, a unified diff of the
-changed unencrypted files (at most 64 KiB, `diff_truncated` says
-when it was cut), and prints one line of at most 200 characters, which
-becomes the description (`description_source: command`). With Claude Code:
-
-```toml
-[settings]
-history.describe_command = "claude -p --output-format text --no-session-persistence 'Describe this change to my configuration files in one line of at most 120 characters, plain text, no quotes.'"
-```
-
-The checkpoint is saved before the command runs and keeps its computed
-description when the command fails, prints nothing, or takes longer than 30
-seconds. The command runs once per checkpoint the watcher saved, one at a
-time, never per filesystem event or retry, and never with a shell
-interpolation of file contents (the JSON is its stdin). A private file
-(`*.local.toml`, a credential store) is never named, and an encrypted file never has its contents sent.
-
-## Referring to checkpoints
-
-Commands take a numeric ID, `latest`, `latest~N`, or `commit:<sha>` (a full hash
-or an unambiguous prefix). Plain numbers always mean checkpoint IDs, never
-commit prefixes; nonnumeric unambiguous commit prefixes also work directly. With
-`--path`, `latest~N` counts only the checkpoints where that path changed, so
-`mise bootstrap dotfiles history show latest~1 --path ~/.zshrc` is the state before its most
-recent change however many other checkpoints came in between.
-
-Numeric ids are local handles and can change when the index is rebuilt.
-Git commit identities are stable.
-
-Commit metadata contains only portable file information and operation labels.
-Raw command arguments, environment values, and temporary recovery copies are
-not part of the committed history.
-
-## Comparing
-
-```sh
-mise bootstrap dotfiles history diff                        # working tree against the latest checkpoint
-mise bootstrap dotfiles history diff 12                     # what checkpoint 12 changed
-mise bootstrap dotfiles history diff 11 12 --patch --path ~/.config/hypr
-mise bootstrap dotfiles history diff --exit-code            # exit 1 when something differs
-```
+If you are starting with your first file, follow the
+[dotfiles guide](/dotfiles.html#tracking-files-in-place) to track it and
+start automatic saves. This page covers everyday history commands, sharing,
+and the detailed behavior to consult when something needs attention.
 
 ## Saving
 
-`mise bootstrap dotfiles save` records a checkpoint now. It fails when nothing could be
-saved — git missing, history disabled, a path that is not tracked — so a
-script or an agent gets a trustworthy answer; `--best-effort` turns that into
-a warning for `set -e` update scripts. Saving again without changes records
-nothing, while a save with `--description`, `--label`, or `--task` always does.
-
-A file tracked with `autosave = false` is a **manual-save** file: automatic
-checkpoints carry its last saved version forward, and only
-`mise bootstrap dotfiles save <path>` (or an operation that names it) promotes what is on
-disk. `mise bootstrap dotfiles history diff --path <file>` shows saved against live. The last saved version is in the ordinary parent commit, not a separate
-promotion history.
-
-## Rolling back
+A **checkpoint** is a saved version of your tracked files, stored as a Git
+commit. To save the current contents of one file:
 
 ```sh
-mise bootstrap dotfiles rollback ~/.config/hypr/bindings.lua        # its most recent saved version that differs from disk
-mise bootstrap dotfiles rollback ~/.zshrc --to 42                    # that checkpoint's version
-mise bootstrap dotfiles rollback --to latest~3 --all --dry-run       # everything the checkpoint covers
-mise bootstrap dotfiles undo                                         # reverse the newest tracked-file operation
+mise bootstrap dotfiles save ~/.zshrc
 ```
 
-A rollback is planned first: for every selected path, `write` when the
-checkpoint holds a different version, `delete` when the checkpoint knows the
-path was absent, `unchanged`, `skip` when the checkpoint never covered or
-omitted it, or `conflict` when the path changed type (a file became a
-directory or a symlink) — conflicts need `--force`. Without `--to`, a
-checkpoint that knew the path was absent counts as a version to return to,
-so a file created since rolls back to "missing". `--dry-run` stops after the
-plan.
-
-Rolling back a parent directory leaves unrecorded empty folders alone: Git
-does not record empty directories.
-
-Then the current state of the affected paths is saved in a protective
-checkpoint (`rollback-before`); the plan is verified against the working tree
-again (an editor may have written meanwhile) and every path about to change
-must be captured in that checkpoint as it is now, or the rollback stops
-without touching anything. Files are written one at a time, each journaled
-and recorded as affected as soon as it is written, and each checked once
-more right before it is replaced (a file that appeared meanwhile stops the
-rollback there). Only afterwards do `[history.reload]` commands run — once per matching
-glob, resolved from the system and global configuration before the operation
-began, so nothing a rollback writes can change which commands run:
-
-```toml
-[history.reload]
-"~/.config/hypr/**" = "hyprctl reload"
-```
-
-A rollback is a new forward change: the outcome is a new checkpoint, the
-version you left is still recoverable, and nothing is rewritten. Restoring a
-mise configuration file never runs bootstrap; the outcome says when
-declarations may differ from the applied setup.
-
-`mise bootstrap dotfiles undo` restores the tracked paths an operation changed,
-using its before commit and leaving unrelated work alone. Undo itself creates
-a new commit. Untracked files have no historical undo: temporary recovery
-copies exist only to complete or safely recover interrupted writes, and are
-deleted afterwards. Unresolved recovery is never expired; concurrent edits are
-preserved and reported for action.
-
-When bootstrap changes a tracked file with `autosave = false`, its actual
-pre-operation contents are saved in the ordinary before history. Unrelated
-manual edits stay unsaved. Repeated writes within the operation preserve the
-first preimage, and encrypted preimages are encrypted before entering Git.
-
-Ordinary bootstrap deployments warn and continue if a temporary preimage cannot
-be captured, for example for an oversized destination. Such a write cannot be
-automatically recovered after interruption. History-driven pull, rollback, and
-undo instead refuse writes without the required recovery data. Disabling history
-recording also removes ordinary bootstrap's dependency on the history store;
-explicit history-driven writes retain their recovery safeguards.
-
-Run `mise bootstrap dotfiles recover` to retry interrupted writes safely. If
-later edits prevent recovery, inspect the reported paths first. You can then
-explicitly accept the live files with
-`mise bootstrap dotfiles recover <operation> --keep-current`. After confirmation,
-this discards only that operation's temporary recovery copies; it does not
-change the live files or erase committed history. Ordinary retries keep both
-the later edits and recovery copies when they cannot proceed safely.
-
-## Capturing an external command
+To save all tracked files with a description:
 
 ```sh
-mise bootstrap dotfiles capture --label "omarchy update" -- omarchy-update
-mise bootstrap dotfiles history --label "omarchy update"
-mise bootstrap dotfiles history diff --operation --patch
-mise bootstrap dotfiles history diff 42 --operation --patch
+mise bootstrap dotfiles save --description "before changing my theme"
 ```
 
-`capture` saves tracked files before and after the command and records the link
-between those checkpoints, the label, and whether the command succeeded. It runs
-the command directly with inherited input, output, and environment; raw command arguments and environment contents are not committed. Use
-`-- sh -c '...'` for shell syntax. Capture failures warn and the command still
-runs with its own exit status. No-op and failed runs retain their checkpoint
-pairs. Files with `autosave = false` are explicitly saved by this command too.
+An ordinary save with no changes creates no commit. Supplying
+`--description`, `--label`, or `--task` creates a checkpoint even when the
+files have not changed.
 
-`history diff --operation` compares the newest operation with its own protective
-checkpoint, even if later saves exist. Supply one checkpoint reference to select
-an older operation. The paired commits remain in the ordinary history.
+For a file tracked with `autosave = false`, save its edits by naming it:
+`mise bootstrap dotfiles save <path>`. Automatic checkpoints keep that
+file's last saved version. Commands that explicitly modify or capture it
+can also save it; see [operation checkpoints](#operation-checkpoints).
 
-The operation lock keeps the watcher and other history writers from inserting
-checkpoints into the pair. Concurrent changes by editors or other programs are
-still part of the observed interval. An abruptly terminated wrapper leaves a
-pending operational record for recovery by the next history mutation. Capture does
-not journal external writes individually: `undo` restores the tracked-file
-changes observed over the whole interval, including concurrent edits. To restore
-selected files instead, use `history show` to find its **Before** checkpoint, then
-`rollback <path> --to <before-ref>`. Package changes,
-service restarts, and files outside the tracked set are not restored.
+`save` fails if it cannot save anything, for example because Git is missing,
+history is disabled, or the requested path is untracked. Use `--best-effort`
+in a script if saving should warn and let the script continue.
 
 ## Automatic saves
 
-`mise bootstrap dotfiles watch` saves tracked files as they change, whatever
-wrote them: an editor, a script, an agent, a distro update, or mise itself.
-Declare it once as the built-in user service and `mise bootstrap` installs
-and starts it on every platform (a systemd user unit, a LaunchAgent, or a
-Scheduled Task):
+The **watcher** is a background service that saves changes to tracked files,
+including edits made by your editor, an application, or another command.
+Add it to your global mise configuration:
 
 ```toml
 [bootstrap.services.mise-history]
 builtin = "history-watch"
 ```
 
+Install it and check that it is running:
+
 ```sh
-mise bootstrap services apply        # or the full `mise bootstrap`
-mise bootstrap dotfiles status       # watcher: running
+mise bootstrap services apply
+mise bootstrap dotfiles status
 ```
 
-The watcher installs filesystem watches for every autosaved entry (a tracked
-directory recursively, a tracked file through its parent, a path that does
-not exist yet through its nearest existing ancestor). Manual-save entries
-(`autosave = false`) are never watched.
+mise uses a systemd user service on Linux, a LaunchAgent on macOS, or a
+Scheduled Task on Windows. The full `mise bootstrap` also installs it.
+See [user services](/bootstrap/services.html#user-services) if it fails to start.
 
-### Adaptive scheduling
+Ordinary edits are saved after the file has been quiet for two seconds by
+default. Constantly changing files are saved less often, so a busy file
+can have unsaved edits while other files have already been saved. Explicit
+`save` commands still save immediately. See
+[watcher scheduling](#adaptive-scheduling) for timing and settings.
 
-Every file is scheduled on its own. An ordinary edit is saved once the file
-has been quiet for `history.watch.debounce` (2s). A file that is rewritten
-constantly is not saved on every change: when a save follows the previous
-one without the file ever settling, that file's own interval doubles, up to
-`history.watch.max_interval` (24h). It is still saved periodically at that
-interval for as long as it keeps changing; nothing is ever excluded or
-switched to manual saving automatically, and a checkpoint another file
-triggers carries the throttled file's last saved version, not its live
-content, so a whole-set reconciliation never defeats the throttling. As soon
-as the file stops changing its final state is captured promptly (after a
-fraction of its interval, at most five minutes), and a sustained quiet
-period (four intervals, at least five minutes) resets it to the base interval.
-A busy file never delays an ordinary one. Throttling does not delay explicit
-saves or protective captures before bootstrap, rollback, or undo.
-
-The thresholds are fixed: an interval doubles when a file changed again
-within its settle time of the previous save and at least two changes
-arrived since. A person saving from an editor every few seconds leaves gaps
-longer than the settle time, so ordinary editing is never stretched. The
-schedule is persisted (`watch-schedule.json` in the history store) with
-each throttled file's last save and pending changes, so a restart of the
-service continues where it stopped: the startup capture holds a throttled
-file at its saved version until its next save is due, and a file rewritten
-while the service was down is pending, not saved early. Editing
-`history.watch.debounce`, `history.watch.max_interval`, or
-`history.watch.reconcile` in the global configuration takes effect while
-the service runs.
-
-Constantly rewritten application state, logs, caches, and databases are
-better excluded, and a file that genuinely holds configuration but changes
-constantly can be tracked with `autosave = false` and saved explicitly:
+To see files being saved less often:
 
 ```sh
-mise bootstrap dotfiles paths --noisy                      # what is throttled right now
-mise bootstrap dotfiles exclude '~/.config/hypr/plugins/**' # [history] exclude
-mise bootstrap dotfiles include '~/.config/hypr/plugins/**'
+mise bootstrap dotfiles paths --noisy
+```
+
+Logs, caches, databases, and session state usually belong outside your
+tracked files. For a configuration file you want to save only on request:
+
+```sh
 mise bootstrap dotfiles track ~/.config/app/state.json --no-autosave
 mise bootstrap dotfiles save ~/.config/app/state.json
 ```
 
-Enrollment saves the initial version even with `autosave = false`, including
-when a new declaration is first picked up by reconciliation. Later edits to
-that entry require an explicit save; ordinary reconciliation carries its saved
-version forward.
+Tracking saves the first version immediately. Later edits wait for an
+explicit save. Check [watcher health](#health) if expected saves are missing.
 
-### Reconciliation and failures
+## Comparing
 
-The whole tracked set is reconciled at startup, every
-`history.watch.reconcile` (10m; `0` disables), when the configuration
-changes (an edit to `~/.config/mise/*.toml` or `conf.d/` reloads the
-declarations and replans the watches; `history.enabled = false` stops the
-watcher), and on shutdown, so an edit no watch reported is still saved.
-`mise bootstrap dotfiles watch --once` runs one reconcile and exits, for a
-timer or cron instead of the service.
+List the checkpoints where a file changed, newest first:
 
-A capture that fails is retried with backoff (1s to 5min) and never drops
-the pending changes; one that would overlap another history operation (a
-running bootstrap, rollback, or undo) is deferred and retried until that
-operation finishes, whether or not any other save is due. The shutdown
-capture waits a moment for a running operation and says what stays unsaved
-if it cannot. `mise bootstrap dotfiles watch --once` exits 1 when nothing
-could be saved (deferred or failed), so a timer notices. One watcher runs
-per store: a second one exits 0 immediately.
-`--json` prints one object per line (`started`, `captured`, `unchanged`,
-`deferred`, `replan`, `throttled`, `settled`, `degraded`, `error`,
-`stopped`).
+```sh
+mise bootstrap dotfiles history --path ~/.zshrc
+```
 
-### Health
+Run `mise bootstrap dotfiles history` without `--path` to see all checkpoints.
+Use an ID from the list to inspect one. The examples below use checkpoint 12:
 
-The watcher speaks up only when sharing pauses for a conflict (a desktop
-notification on Linux and macOS, on by default; see
-[Sharing across machines](#sharing-across-machines) below). Otherwise it persists its
-health (`health.json` in the history store) and two commands read it, without
-starting a sync, applying anything, or prompting:
+```sh
+mise bootstrap dotfiles history show 12
+mise bootstrap dotfiles history diff 12 --patch --path ~/.zshrc
+```
 
-- `mise doctor` prints a concise `dotfiles` section: a watcher that is
-  declared but not running (with the command that starts it), repeated
-  capture failures or an unusable store, and heavily throttled files. A
-  throttled file is informational, not a warning. Health older than a few
-  reconcile intervals is reported as stale rather than current.
-- `mise bootstrap dotfiles status` prints the detail: the watcher state
-  (`running`, `declared but not running`, `not declared`), the last capture
-  and reconcile, the last failure, and for every throttled file its
-  effective interval, last save, and unsaved changes (changes seen since the
-  last save, kept current as they happen).
+`history show` displays checkpoint details, including what triggered it and
+which files changed. Add `--files` to list all its files or `--json` for
+structured output. `history diff 12` shows what changed in that checkpoint.
+To compare two checkpoints, supply both IDs:
+
+```sh
+mise bootstrap dotfiles history diff 11 12 --patch --path ~/.zshrc
+```
+
+To compare your current file with its latest saved version:
+
+```sh
+mise bootstrap dotfiles history diff --path ~/.zshrc
+```
+
+This also shows unsaved edits in files with `autosave = false`. Add
+`--exit-code` to make a difference return exit status 1, or omit `--path`
+to compare all tracked files.
+
+## Referring to checkpoints
+
+Use a checkpoint ID from `history`, or one of these references:
+
+| Reference      | Meaning                                                            |
+| -------------- | ------------------------------------------------------------------ |
+| `12`           | Checkpoint with local ID 12                                        |
+| `latest`       | Most recent checkpoint                                             |
+| `latest~1`     | Checkpoint before the most recent one; use `~N` to go farther back |
+| `commit:<sha>` | Git commit identified by a full hash or an unambiguous prefix      |
+
+With `--path`, `latest~N` counts only checkpoints where that path changed.
+For example:
+
+```sh
+mise bootstrap dotfiles history show latest~1 --path ~/.zshrc
+```
+
+This selects the checkpoint before the file's most recent change, even if
+other files have changed since then.
+
+Numeric IDs are local and may change if mise rebuilds its index. Use a Git
+commit hash when you need a stable reference. Plain numbers always select
+checkpoint IDs; nonnumeric, unambiguous commit prefixes also work without
+`commit:`.
+
+## Rolling back
+
+To restore a file to its most recent saved version that differs from its
+current contents, preview the change and then apply it:
+
+```sh
+mise bootstrap dotfiles rollback ~/.zshrc --dry-run
+mise bootstrap dotfiles rollback ~/.zshrc
+```
+
+mise saves the current contents before replacing them. To reverse that
+rollback, run:
+
+```sh
+mise bootstrap dotfiles undo
+```
+
+`undo` restores the tracked files changed by the operation. Other files
+keep their current contents. Both rollback and undo create new commits,
+so earlier versions remain available and the restored version can sync to
+other machines.
+
+To choose a checkpoint, use an ID from `history` or a
+[checkpoint reference](#referring-to-checkpoints):
+
+```sh
+mise bootstrap dotfiles rollback ~/.zshrc --to 42
+mise bootstrap dotfiles rollback --to latest~3 --all --dry-run
+```
+
+`--all` selects everything covered by the chosen checkpoint. If that
+checkpoint recorded a file as absent, rollback deletes the file. This can
+also happen without `--to`: an earlier saved state where the file was
+absent counts as a version to restore.
+
+The preview reports each path as:
+
+| Action      | Meaning                                                                                       |
+| ----------- | --------------------------------------------------------------------------------------------- |
+| `write`     | Replace the file with different saved contents                                                |
+| `delete`    | Remove a file recorded as absent                                                              |
+| `unchanged` | Keep a file that already matches                                                              |
+| `skip`      | Leave a path the checkpoint did not cover or omitted                                          |
+| `conflict`  | Resolve a changed path type, such as a file becoming a directory; replacement needs `--force` |
+
+Git does not record empty directories, so rolling back a directory leaves
+unrecorded empty folders alone. Restoring configuration files leaves
+installed packages and running services as they are. Run `mise bootstrap`
+when you want to apply the restored configuration.
+
+### Reload an application after restoring files
+
+Add commands to global configuration to reload an application after its
+files change:
+
+```toml
+[history.reload]
+"~/.config/hypr/**" = "hyprctl reload"
+```
+
+Each matching command runs once, after the files have been restored. mise
+loads these commands from system and global configuration before starting
+the operation. See [recovery details](#recovery-details) for interrupted
+writes and concurrent edits.
 
 ## Sharing across machines
 
-One ordinary repository holds your committed tracked files. Connect it once
-per machine ([Set up a machine](/bootstrap/setup.html) walks through the workflow):
+Connect a private Git repository, called an **origin**, to share tracked
+files between machines. Install the [watcher](#automatic-saves) first and
+make sure it can use your Git credentials. See
+[repository authentication](#repository-authentication) if you need to set them up.
+
+Before connecting, review your tracked files and their earlier checkpoints.
+All committed versions are shared. Deleting a secret from the current file
+leaves it in older commits. Configure [encryption](#encrypted-shared-files)
+before first saving a file that needs it.
+
+Create an empty private repository and replace `you/setup` with its name:
 
 ```sh
-mise bootstrap dotfiles origin set https://github.com/jdx/dotfiles.git
+mise bootstrap dotfiles origin set https://github.com/you/setup.git --sync sync
 mise bootstrap dotfiles status
+```
+
+Review the connection preview before confirming. With `--sync sync`, the
+watcher pushes saved changes and periodically fetches and applies changes
+from other machines. To bring another machine into this workflow, follow
+[Set up a machine](/bootstrap/setup.html#set-up-another-machine).
+
+### Choose a sync mode
+
+The `history.sync` setting controls what the watcher does automatically:
+
+| Mode         | Behavior                                                                                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sync`       | Push saved changes within `history.sync_interval` (5 minutes by default). Fetch and apply incoming changes every `history.fetch_interval` (15 minutes). |
+| `manual`     | Keep saving locally. Exchange and apply changes when you run the commands below.                                                                        |
+| `fetch-only` | Fetch remote changes. Wait for an explicit command to push or apply anything.                                                                           |
+
+Set a mode with `--sync manual|sync|fetch-only` when connecting, or change
+it later with `mise settings set history.sync MODE`.
+
+Without `--sync`, interactive `origin set` asks whether to enable automatic
+sharing. Declining selects `manual`. `--yes` uses the configured mode,
+which defaults to `sync`; specify `--sync` in scripts to choose explicitly.
+
+### Sync immediately
+
+These commands work in every mode:
+
+```sh
 mise bootstrap dotfiles sync
 mise bootstrap dotfiles pull
 ```
 
-`pull` and `apply` are different commands on purpose: `mise bootstrap
-dotfiles apply` keeps deploying your own `[dotfiles]` declarations (symlinks,
-copies, templates, edits), while `pull` writes what other machines shared
-through the setup repository.
+`sync` pushes saved commits and fetches remote changes. `pull` applies
+pending changes to your files. In automatic mode, use them when you want
+to sync before the next scheduled run.
 
-When `--sync` is omitted, interactive `origin set` asks whether to publish saved
-edits and apply incoming changes automatically. Answering no selects `manual`;
-local autosave continues. `--sync manual|sync|fetch-only` selects a mode directly.
-`--yes` accepts the configured mode (default `sync`) without this question, so
-scripts should specify `--sync` explicitly.
+Each push includes all accumulated commits, including intermediate saves
+made in manual mode. Files waiting for a manual save or a delayed watcher
+save contribute their last saved contents.
 
-`origin set` previews the connection before publication. Every tracked file
-is eligible to be pushed, including its accumulated history. Files that must
-never reach origin must not be tracked. Protected credential-file defaults
-exclude capture entirely; they do not create private recovery history.
+When incoming changes update tools, services, or template sources, run
+`mise bootstrap` to apply that configuration. `pull` restores shared file
+contents; `mise bootstrap dotfiles apply` creates files from the sources,
+templates, and edits in your `[dotfiles]` configuration.
 
-The connection is recorded in `[history.origin]` in `config.local.toml`,
-with the synchronization mode in `settings.history.sync`.
+A conflict or an unsaved edit can pause pushing and applying incoming
+changes for all tracked files. Local saves and fetching continue. If a
+network or authentication attempt fails, automatic sync retries with
+increasing delays from one minute to one hour. `status` and `mise doctor`
+show the last error.
 
-The repository uses portable `home/…` and `config/…` paths; variant streams
-have a root suffix such as `home@macos/…`. Mapping does not change when a file
-is also a template source or managed output. A README or other repository-owned
-file stays in Git, not in a live configuration directory.
+### Resolve a conflict
 
-Encrypted tracked files enter Git as ciphertext from their very first capture.
-Filenames and public metadata remain visible. See [Encrypted shared files](#encrypted-shared-files).
-
-**Another machine.** `mise bootstrap --from-git <url>` on a machine that has
-nothing yet recognizes the marker and sets the machine up from the
-repository: the branch goes into mise's own store (no checkout in
-`~/.config/mise`), the shared configuration, its sources, and this machine's
-tracked files are written by one recoverable pull (the configuration first,
-then what it declares; a file that already exists and differs is held for a
-decision), the connection is remembered, and the ordinary bootstrap runs:
-packages, tools, templates rendered from the sources that just arrived, the
-watcher service. From then on the machine syncs like any other. Over SSH the
-same happens through `mise bootstrap remote`; see
-[remote bootstrap](/bootstrap/remote.html).
-
-**How a sync decides.** Synchronization uses Git ancestry, fast-forwards,
-and merge commits. It pushes the same local commits, without squashing
-intermediate saves or constructing a separate publication history. A rejected
-push fetches and reconciles again; mise never silently force-pushes or discards
-divergent history. Unrelated nonempty histories must be reconciled explicitly,
-not automatically replaced.
-
-Incoming application is preflighted as a complete batch, including enrolled
-configuration and required sources. Both committed and unsaved local versions
-are checked again before writing. An unresolved conflict pauses publication
-and incoming application for the entire setup; local commits and fetching
-continue.
-
-**Modes** (`settings.history.sync`) say what the watcher does on its own:
-
-- `sync` (the default, recommended): after a save the watcher publishes
-  within `history.sync_interval` (5 minutes); every `history.fetch_interval`
-  (15 minutes) it fetches and applies incoming changes, with
-  a protective checkpoint first. A conflict or an unsaved edit pauses
-  publication and incoming application for the complete setup.
-- `fetch-only`: the watcher fetches; nothing is ever published and no live
-  file changes until you run `mise bootstrap dotfiles pull`.
-- `manual`: no automatic network activity. Local commits continue; the next
-  explicit sync pushes all accumulated intermediate commits unchanged.
-
-`mise bootstrap dotfiles sync` (publish and fetch now) and `mise bootstrap
-dotfiles pull` (write what is pending now, decide conflicts) work on request
-in every mode: they are for when you do not want to wait, not something the
-background mode needs you to run. A failed sync (the repository unreachable,
-credentials missing) backs off from a minute to an hour and is retried;
-saving continues meanwhile, and `mise bootstrap dotfiles status` and
-`mise doctor` show the last error. The watcher never publishes a throttled
-file's unsaved churn or a manual-save entry's unsaved edits: what it
-publishes is what it saved. Applying never runs `mise bootstrap`, installs
-or removes packages, or renders templates: when incoming configuration
-changes declarations, `mise bootstrap dotfiles status` says to run
-`mise bootstrap`.
-
-**Conflict notifications** are on by default. A desktop notification
-(`notify-send` on Linux, a bundled mise helper app on macOS) reports when sharing pauses
-for the setup. Retries and additional conflicts during the same pause stay
-silent; a later pause can notify again after recovery. Set
-`settings.history.notify = false` to opt out. Missing or failing notifiers
-never hold up history or sync.
-
-On Linux, notifications require `notify-send`. On macOS, allow notifications
-for mise when prompted; change this later in System Settings → Notifications →
-mise. Unofficial macOS builds, such as Homebrew, warn when connecting a setup
-repository because notifications are unavailable. Notification failures never
-block sync. Alerts point to
-`mise bootstrap dotfiles status` for resolution steps.
-
-**Applying.** `mise bootstrap dotfiles pull` writes pending changes as one recoverable
-transaction (a protective checkpoint first, each file journaled, reload
-hooks afterwards, `mise bootstrap dotfiles undo` to reverse it). Any conflict
-pauses publishing and incoming application for the entire setup. Local
-commits and fetching continue. Invalid incoming
-configuration or unsafe local files block the complete application batch.
-Status and doctor name the blocking paths and the last successful application.
-Choose per file with `--take-remote <path>` or `--keep-local <path>`; choices
-are recorded without partially applying the setup. Once every conflict is
-resolved, mise recomputes the plan before sharing resumes. A later local or
-remote edit invalidates a choice based on an older version. This is
-all-or-nothing application with recovery, not atomic filesystem writes.
-
-The per-file choices apply to active tracked files. Conflicting enrollment or
-encryption policies, files belonging to an inactive platform variant, and
-histories with multiple merge bases require reconciliation with Git in a
-separate checkout. Status reports the repository-level failure instead of
-offering a native-file choice that cannot resolve it. Sharing stays paused;
-mise never force-pushes or discards either history to get past the conflict.
-
-There are no separate machine-recovery refs or backup uploads. Git is the
-durable history; every pushed commit carries the normal Git author identity.
-
-**Private repositories.** Network commands run with your normal git
-configuration (credential helpers, ssh, URL rewrites). For a private GitHub
-repository the recommended path is the GitHub CLI through mise; `gh auth
-setup-git` writes the helper into `~/.gitconfig`, so pin `gh` globally to
-keep that path valid for the watcher's service environment:
+Inspect the reported files:
 
 ```sh
-curl https://mise.run | sh
-export PATH="$HOME/.local/bin:$PATH"
+mise bootstrap dotfiles status
+```
+
+Choose the remote version of a file, or keep the local version:
+
+```sh
+mise bootstrap dotfiles pull --take-remote ~/.zshrc
+mise bootstrap dotfiles pull --keep-local ~/.zshrc
+```
+
+Run the command for the choice you want. mise records each decision and
+waits until every conflict is resolved before applying the incoming files.
+It checks the plan again before continuing. A newer local or remote edit
+can invalidate a decision, in which case you must choose again.
+
+Invalid incoming configuration or unsafe local paths also block the
+complete batch. `status` and `doctor` identify the paths and the last
+successful application. For conflicts involving tracking or encryption
+settings, inactive platform variants, or multiple Git merge bases, follow
+the reported Git-level repair instructions in a separate checkout.
+
+Pull saves a checkpoint first, records each file it writes, and runs reload
+hooks afterwards. You can reverse it with `mise bootstrap dotfiles undo`.
+Writes happen one file at a time; interrupted work uses the
+[recovery process](#recovery-details).
+
+### Conflict notifications
+
+Desktop notifications are enabled by default for sharing conflicts. They
+point to `mise bootstrap dotfiles status` for resolution steps. A pause
+produces one notification; further retries during the same pause stay quiet.
+A new pause after recovery can notify again.
+
+On Linux, install `notify-send`. On macOS, allow notifications for mise
+when prompted, or enable them in System Settings → Notifications → mise.
+Unofficial macOS builds, including Homebrew, warn when connecting because
+notifications are unavailable. Use `status` or `doctor` on Windows and
+headless systems. Missing or failing notifications leave history and sync
+running. Set `settings.history.notify = false` to disable notifications.
+
+### Repository authentication
+
+Network commands use your Git configuration, including credential helpers,
+SSH, and URL rewrites. For a private GitHub repository, install the GitHub
+CLI globally through mise and configure its credential helper:
+
+```sh
 mise use -g gh
 mise x gh -- gh auth login --hostname github.com --git-protocol https --web
 mise x gh -- gh auth setup-git --hostname github.com
-mise bootstrap dotfiles origin set https://github.com/you/setup.git
 ```
 
-Existing working credentials skip the two `gh` steps. SSH remotes work when
-the service environment can reach an agent or an unencrypted key.
+The helper is written to `~/.gitconfig`. Keeping `gh` installed globally
+keeps it available to the background watcher. If Git authentication already
+works in the service's environment, you can use it as-is. SSH remotes need
+an accessible agent or an unencrypted key in that environment.
+
+### How shared history is stored
+
+The origin is recorded in `[history.origin]` in `config.local.toml`.
+The sync mode is recorded in `settings.history.sync`.
+
+Git stores paths relative to `home/` or `config/`, so each machine can
+restore them beneath its own home or mise configuration directory. Variants
+use a suffix such as `home@macos/`. These mappings also apply to tracked
+template sources and managed files. Repository files such as a README stay
+in Git rather than being restored as live configuration.
+
+`mise bootstrap --from-git <url>` recognizes this setup repository and
+fetches it into the history store. It restores the shared configuration
+first, then the tracked files it selects for this machine, and remembers
+the origin. Once conflicts are resolved, it runs bootstrap to install
+packages, tools, and services and render templates. The configuration and
+required sources must have been tracked and shared for those steps to work.
+See [repository bootstrap](/bootstrap.html#starting-from-a-repository) for
+how this differs from cloning a global configuration repository.
+
+Synchronization uses Git ancestry, fast-forwards, and merge commits. Pushes
+retain the saved commits and their Git author identities. A rejected push
+triggers another fetch and reconciliation. mise leaves divergent or
+unrelated histories intact for you to resolve; it does not force-push.
+Before writing incoming changes, it checks the complete batch, including
+configuration, required sources, committed files, and unsaved local edits.
+
+## Capturing an external command
+
+To inspect what an update changed in your tracked dotfiles, wrap it with
+`capture`. For example, on Omarchy:
+
+```sh
+mise bootstrap dotfiles capture --label "omarchy update" -- omarchy-update
+mise bootstrap dotfiles history --label "omarchy update"
+mise bootstrap dotfiles history diff --operation --patch
+```
+
+`capture` saves tracked files before and after the command, including files
+with `autosave = false`. It records the label and whether the command
+succeeded. The diff compares those two checkpoints, even if other saves
+happened later. To inspect an older operation, supply its checkpoint ID:
+
+```sh
+mise bootstrap dotfiles history diff 42 --operation --patch
+```
+
+The command runs directly with inherited input, output, and environment.
+Use `-- sh -c '...'` when you need shell syntax. A capture failure warns
+and lets the command run with its own exit status. Failed commands and
+commands that make no changes still retain their checkpoint pairs.
+
+Other history writers wait until the pair is complete. Editors and other
+programs can still change files during that time, and their edits appear
+in the comparison too. `undo` restores tracked-file changes across the
+whole interval. To restore selected files, find the operation's **Before**
+checkpoint with `history show`, then use `rollback <path> --to <before-ref>`.
+Packages, service state, and untracked files are outside this recovery.
+
+If the wrapper is abruptly terminated, the next command that changes
+history recovers its pending operation record. External writes are not
+journaled individually. If the wrapped command untracks a file, the after
+checkpoint leaves it out; its earlier checkpoint remains available, and
+recovery keeps it untracked.
 
 ## Explicit tracking and exclusions
+
+Use `mode = "track"` for every file or directory you want to save in history.
+For example, in your global configuration:
 
 ```toml
 [dotfiles]
@@ -489,21 +420,272 @@ the service environment can reach an agent or an unencrypted key.
 "~/.gitconfig" = { mode = "template", source = "~/templates/gitconfig.tera" }
 ```
 
-Only `.zshrc` and the template directory are tracked here. Rendering
-`.gitconfig` does not enroll it. A tracking directory may contain managed
-files or sources without taking over their deployment declarations.
+Here, history saves `.zshrc` and the files in `~/templates`. The template
+creates `.gitconfig`; track that output separately if you want its history
+too. You can track files mise also copies, links, or edits.
 
-Enrollment accepts files and directories, not globs. `[history] exclude`
-accepts glob patterns; a later `!glob` can reverse an earlier exclusion.
-`mise bootstrap dotfiles paths` lists enrolled paths and capture omissions.
+Tracking takes exact file or directory paths. Directories include new
+files added beneath them. Symlinks record the link itself; track their
+targets separately to save those contents. To share tools, services, and
+template setup, track the relevant mise configuration and sources too.
+Bootstrap reports required files missing from history.
 
-Use `autosave = false` for a configuration file you want to save manually.
-Logs, caches, databases, and frequently rewritten application state are usually
-better left untracked. Exclusions stop capture, not merely publication.
+Use glob patterns to exclude files from history:
 
-To recreate tools, services, and templates on another machine, explicitly
-track the relevant mise configuration and template sources as well. Bootstrap
-reports missing prerequisites instead of silently enrolling them.
+```sh
+mise bootstrap dotfiles exclude '~/.config/hypr/plugins/**'
+mise bootstrap dotfiles include '~/.config/hypr/plugins/**'
+mise bootstrap dotfiles paths
+```
+
+Exclusions are stored in `[history] exclude`. A later `!glob` reverses an
+earlier matching exclusion. `paths` lists tracked paths and files omitted
+from saves. Protected credential files and `*.local.toml` are excluded by
+default; use [encrypted tracking](#encrypted-shared-files) for credentials
+you want to save.
+
+Logs, caches, databases, and constantly rewritten session state usually
+belong outside history. Use `autosave = false` for configuration you want
+to save manually. An excluded file is left out of future saves entirely.
+
+To stop tracking a file:
+
+```sh
+mise bootstrap dotfiles untrack ~/.zshrc
+```
+
+The file stays in place, while future checkpoints leave it out. Earlier
+committed versions remain in Git and can still be shared. There is no
+per-file local-only history setting.
+
+## Encrypted shared files
+
+Configure encryption before saving a file's private contents for the first
+time. Add public recipients and mark the file or directory for encryption:
+
+```toml
+[history.encryption]
+recipients = ["<age-or-plugin-public-recipient>", "<recovery-public-recipient>"]
+
+[dotfiles]
+"~/.config/app/credentials" = { mode = "track", encrypt = true }
+```
+
+Replace the placeholders with public recipients for your machines and an
+independent recovery key. Keep private decryption keys outside tracking.
+Configure local identities with `settings.age.identity_files`,
+`settings.age.key_file`, or the supported SSH identity settings. Public
+recipients travel with the repository.
+
+mise encrypts contents before storing them in Git. Filenames and public
+metadata remain visible. The files you edit or restore stay unencrypted.
+Missing keys or recipients stop the operation; mise never falls back to
+saving plaintext.
+
+You can also encrypt tracked template sources:
+
+```toml
+[dotfiles]
+"~/templates/private" = { mode = "track", encrypt = true }
+"~/.config/app/config" = { mode = "template", source = "~/templates/private/app.tera" }
+```
+
+The rendered output stays unencrypted. Configure its permissions and any
+tracking separately.
+
+Adding encryption later leaves earlier plaintext versions in Git. Before a
+push, mise checks all reachable commits, including intermediate saves and
+merge parents, for violations of encrypted-path settings. An earlier
+plaintext version blocks the push even if the newest version is encrypted.
+You must explicitly rewrite or replace that history. This checks encryption
+settings; it does not scan arbitrary unencrypted files for secrets.
+
+## Checking watcher health {#health}
+
+If files are not being saved or shared, start with:
+
+```sh
+mise doctor
+mise bootstrap dotfiles status
+```
+
+`doctor` summarizes a watcher that is declared but stopped, repeated save
+failures, an unusable history store, and files being saved less often because
+they change constantly. It includes the command to start a stopped watcher.
+
+`status` gives more detail: whether the watcher is running, declared but
+stopped, or not declared; the latest save and full scan; the last failure;
+and each busy file's save interval, last save, and pending edits.
+
+These commands read the watcher's saved health report without starting
+synchronization or changing files. The report lives in `health.json` in the
+history store. Old reports are marked stale after a few full-scan intervals.
+A busy file's longer save interval is informational.
+
+The watcher sends desktop notifications when a sharing conflict needs
+attention. See [conflict notifications](#conflict-notifications) for setup
+and platform support.
+
+## What a checkpoint records
+
+History lives in a bare Git repository at `$MISE_STATE_DIR/history/repo.git`,
+separate from the files you edit. Each checkpoint contains the tracked files
+and metadata for their paths, tracking settings, variants, encryption, and
+permissions. The files are ordinary Git tree entries.
+
+A symlink is saved as a link. A nested Git repository is saved as a pointer
+to its commit. mise reports oversized files, special files, and unreadable
+paths it cannot save. It keeps their previous saved versions while saving
+other files, so check reported omissions before relying on a checkpoint.
+Explicit exclusions remove paths from future checkpoints. Encryption
+failures stop a save rather than storing plaintext.
+
+Commands that modify or capture tracked files save checkpoints before and
+after their work. Their metadata includes operation labels and the link
+between the two checkpoints. Raw command arguments, environment contents,
+and temporary recovery copies are left out of committed metadata.
+
+Checkpoints restore file contents. They do not restore installed packages
+or the running state of a service. Use your system's backup tools for that
+state, and run bootstrap explicitly to apply restored configuration.
+
+### Descriptions from an agent
+
+`settings.history.describe_command` can run a command to describe each
+checkpoint saved by the watcher. For example, with Claude Code installed:
+
+```toml
+[settings]
+history.describe_command = "claude -p --output-format text --no-session-persistence 'Describe this change to my configuration files in one line of at most 120 characters, plain text, no quotes.'"
+```
+
+This sends change details, including unencrypted file diffs, to the command
+you configure. Excluded private files are not named, and encrypted file
+contents are not sent.
+
+The command receives one JSON object on stdin. Its fields are `uuid`,
+`trigger`, the computed `description`, the `added`, `modified`, and `removed`
+paths, and a unified `diff` of changed unencrypted files. The diff is limited
+to 64 KiB; `diff_truncated` reports truncation.
+
+Print one line of at most 200 characters. mise uses it as the checkpoint
+description and records `description_source: command`. The checkpoint is
+saved before the command runs. If the command fails, returns no text, or
+exceeds 30 seconds, mise keeps its computed description.
+
+Commands run one at a time, once per checkpoint saved by the watcher.
+Filesystem events and retries do not trigger separate descriptions.
+Contents are passed through stdin without shell interpolation.
+
+## Recovery details
+
+Before rollback changes any file, mise saves the current contents in a
+`rollback-before` checkpoint. If it cannot save every file it would change,
+it stops before writing. It checks the plan again after the checkpoint,
+then checks each path immediately before replacing it. A concurrent edit
+that invalidates the plan stops the operation.
+
+Files are written one at a time, with a journal recording each affected
+path. An interruption can leave some writes completed. Use
+`mise bootstrap dotfiles recover` to retry unfinished writes. If later edits
+prevent recovery, inspect the reported paths. To accept the current files:
+
+```sh
+mise bootstrap dotfiles recover <operation> --keep-current
+```
+
+After confirmation, this discards that operation's temporary recovery
+copies. It keeps your current files and committed history. An ordinary
+recovery retry preserves later edits and recovery copies when it cannot
+continue. Unresolved recovery data is kept until you resolve it.
+
+### Operation checkpoints
+
+When bootstrap modifies a tracked file with `autosave = false`, it saves
+that file's actual contents before the operation. Unrelated manual edits
+stay unsaved. If the operation writes a file repeatedly, the before version
+still holds the contents from before the first write. Encrypted files are
+also encrypted in these checkpoints.
+
+`undo` uses an operation's before checkpoint to restore the tracked paths
+it changed. For untracked files, temporary recovery copies only support
+completing or recovering interrupted writes; they are deleted afterwards.
+Those files have no historical undo.
+
+Ordinary bootstrap writes warn and continue if they cannot save temporary
+recovery contents, for example for an oversized destination. Such a write
+cannot be recovered automatically after interruption. Pull, rollback, and
+undo refuse writes without the required recovery data. Disabling history
+lets ordinary bootstrap run without the history store; explicit history
+commands still require their recovery data.
+
+## Watcher reference
+
+The watcher watches tracked directories recursively. For a tracked file it
+watches the parent directory; for a missing path it watches the nearest
+existing ancestor. Files with `autosave = false` are left for explicit saves.
+
+### Adaptive scheduling
+
+mise schedules each tracked file separately. **Throttling** means waiting
+longer between automatic saves for a file that changes constantly.
+
+1. An ordinary edit is saved after `history.watch.debounce` of quiet time
+   (two seconds by default).
+2. If a file keeps changing without settling between saves, its save
+   interval doubles, up to `history.watch.max_interval` (24 hours by default).
+3. When the file stops changing, mise saves its final contents after a
+   fraction of that interval, at most five minutes.
+4. After a quiet period of four intervals, with a minimum of five minutes,
+   the file returns to the base interval.
+
+The longer interval affects only that file. Other files save normally, and
+explicit saves and checkpoints before bootstrap, rollback, or undo still
+run immediately. Throttled files continue to be saved periodically; they
+are never automatically excluded or switched to manual saving.
+
+When another file triggers a checkpoint, or mise scans the full tracked
+set, a throttled file keeps its last saved contents until its own save is due.
+
+The interval doubles when at least two changes have arrived since the
+previous save and the file changed again within its settling period.
+Ordinary editor saves spaced beyond that period keep the usual interval.
+
+The watcher stores schedules in `watch-schedule.json`, including each busy
+file's last save and pending edits. Restarting preserves these schedules.
+At startup, a throttled file keeps its saved version until its next save is
+due, including when it changed while the service was stopped.
+
+Changes to `history.watch.debounce`, `history.watch.max_interval`, and
+`history.watch.reconcile` in global configuration take effect while the
+watcher is running.
+
+When a full scan discovers a new tracking entry, it saves the initial
+version even with `autosave = false`. Later scans carry that saved version
+forward until you explicitly save the path.
+
+### Reconciliation and failures
+
+The watcher also scans all tracked files to catch changes missed by
+filesystem notifications. It does this at startup, at shutdown, when
+configuration changes, and every `history.watch.reconcile` (ten minutes by
+default). Set that interval to `0` to disable periodic scans.
+
+Edits to global TOML configuration or `conf.d/` reload the tracked paths
+and update their watches. Setting `history.enabled = false` stops the watcher.
+To run one scan from a timer or cron job, use
+`mise bootstrap dotfiles watch --once`.
+
+Failed saves remain pending and are retried with increasing delays from
+one second to five minutes. A save that overlaps bootstrap, rollback, or
+undo waits and retries after that operation finishes. At shutdown, the
+watcher waits briefly for a running operation and reports anything it
+could not save.
+
+`watch --once` exits 1 if its save was deferred or failed. Only one watcher
+can run per history store; starting another exits successfully immediately.
+`--json` prints one object per line (`started`, `captured`, `unchanged`,
+`deferred`, `replan`, `throttled`, `settled`, `degraded`, `error`, `stopped`).
 
 ## Retention
 
@@ -524,30 +706,3 @@ Keep your repository and decryption identities recoverable independently.
 Repository authentication and an age identity serve different purposes:
 a replacement machine needs both Git access and a matching identity to
 restore encrypted files. Test fresh-machine setup before relying on it.
-
-## Encrypted shared files
-
-Set `encrypt = true` on an explicitly tracked file or directory:
-
-```toml
-[history.encryption]
-recipients = ["<age-or-plugin-public-recipient>", "<recovery-public-recipient>"]
-
-[dotfiles]
-"~/.config/app/credentials" = { mode = "track", encrypt = true }
-"~/templates/private" = { mode = "track", encrypt = true }
-"~/.config/app/config" = { mode = "template", source = "~/templates/private/app.tera" }
-```
-
-Contents are encrypted before they enter the repository's object database,
-not just before upload. Live files and rendered outputs remain native files.
-Missing keys or recipients fail safely; plaintext is never a fallback.
-
-Every commit reachable from a proposed push is checked for encrypted-path
-policy violations, including intermediate commits and merge parents. Earlier
-plaintext blocks publication even if the latest tree is encrypted. mise does
-not rewrite that history automatically.
-
-Keep private decryption keys outside tracking. Configure local identities with
-`settings.age.identity_files`, `settings.age.key_file`, or the supported SSH
-identity settings. Public recipients travel with the repository.

--- a/docs/history.md
+++ b/docs/history.md
@@ -363,7 +363,7 @@ use a suffix such as `home@macos/`. These mappings also apply to tracked
 template sources and managed files. Repository files such as a README stay
 in Git rather than being restored as live configuration.
 
-`mise bootstrap --from-git <url>` recognizes this setup repository and
+`mise bootstrap --adopt <url>` recognizes this setup repository and
 fetches it into the history store. It restores the shared configuration
 first, then the tracked files it selects for this machine, and remembers
 the origin. Once conflicts are resolved, it runs bootstrap to install

--- a/docs/history.md
+++ b/docs/history.md
@@ -60,7 +60,8 @@ mise bootstrap dotfiles status
 ```
 
 mise uses a systemd user service on Linux, a LaunchAgent on macOS, or a
-Scheduled Task on Windows. The full `mise bootstrap` also installs it.
+Scheduled Task on Windows. On these platforms, the full `mise bootstrap`
+also installs the watcher as a user service, without requiring root.
 See [user services](/bootstrap/services.html#user-services) if it fails to start.
 
 Ordinary edits are saved after the file has been quiet for two seconds by
@@ -270,10 +271,13 @@ Each push includes all accumulated commits, including intermediate saves
 made in manual mode. Files waiting for a manual save or a delayed watcher
 save contribute their last saved contents.
 
-When incoming changes update tools, services, or template sources, run
-`mise bootstrap` to apply that configuration. `pull` restores shared file
-contents; `mise bootstrap dotfiles apply` creates files from the sources,
-templates, and edits in your `[dotfiles]` configuration.
+`pull` applies the complete incoming file set, including configuration and
+its shared sources together; partial pulls are not supported. It does not
+install tools or services, or render templates. When those declarations or
+their sources change, run `mise bootstrap` to deploy them. If only dotfile
+deployment is needed, use `mise bootstrap dotfiles apply` to create files
+from the sources, templates, and edits in `[dotfiles]`. A separate `apply`
+is not needed merely to restore shared tracked-file contents.
 
 A conflict or an unsaved edit can pause pushing and applying incoming
 changes for all tracked files. Local saves and fetching continue. If a
@@ -340,8 +344,13 @@ mise x gh -- gh auth setup-git --hostname github.com
 
 The helper is written to `~/.gitconfig`. Keeping `gh` installed globally
 keeps it available to the background watcher. If Git authentication already
-works in the service's environment, you can use it as-is. SSH remotes need
-an accessible agent or an unencrypted key in that environment.
+works in the service's environment, you can use it as-is. For SSH remotes,
+prefer a passphrase-protected key loaded into an SSH agent that the service
+can access. If unattended syncing needs a key without a passphrase, use a
+dedicated deploy key scoped to this repository, grant write access only
+when pushing is needed, and restrict the private-key file to your user
+(for example, mode `0600` on Unix or an equivalent Windows ACL). Do not
+reuse an unrestricted personal key.
 
 ### How shared history is stored
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -83,17 +83,17 @@
 - [Package Plugins](https://mise.jdx.dev/bootstrap/packages/plugins.html): Package manager plugins extend [bootstrap.packages] without adding a manager to mise core. They are useful for machine-global state owned by another tool, such as VS Code extensions, Helm plugins,…
 - [Linux Users and Groups](https://mise.jdx.dev/bootstrap/accounts.html): [bootstrap.groups] and [bootstrap.users] declaratively manage local Linux accounts. mise applies groups before users and applies accounts before privileged files, so a managed file can safely refer to…
 - [System Files](https://mise.jdx.dev/bootstrap/files.html): [bootstrap.files] and [bootstrap.directories] declaratively manage absolute paths that may require root privileges. They are separate from [dotfiles], which manages files in a user's home directory.
-- [System Services](https://mise.jdx.dev/bootstrap/services.html): [bootstrap.services] declares services in two scopes.
+- [Services](https://mise.jdx.dev/bootstrap/services.html): Use [bootstrap.services] to run a program in the background and start it again when you log in or reboot. Choose the kind of service you need.
 - [Docker Compose Projects](https://mise.jdx.dev/bootstrap/compose.html): [bootstrap.compose] declaratively manages long-running Docker Compose projects after packages, privileged files, directories, and system services have converged.
 - [Secret Inputs](https://mise.jdx.dev/bootstrap/secrets.html): [bootstrap.secrets] declares the sensitive inputs a bootstrap configuration needs without storing their values in mise configuration.
 - [Repos](https://mise.jdx.dev/bootstrap/repos.html): mise can declare git repositories in [bootstrap.repos] and apply them with mise bootstrap repos apply or as part of mise bootstrap.
-- [Dotfiles](https://mise.jdx.dev/dotfiles.html): [dotfiles] declares how each of your configuration files is managed. The recommended way to adopt a file you already edit in place is to track it: the file stays where it is, nothing is copied or…
+- [Dotfiles](https://mise.jdx.dev/dotfiles.html): Dotfiles are configuration files such as ~/.zshrc and ~/.gitconfig. Keep editing them with your usual editor; mise can save changes in the background so you can return to an earlier version.
+- [Dotfiles History](https://mise.jdx.dev/history.html): mise saves versions of your tracked configuration files in Git so you can inspect changes and restore an earlier version. History stays local until you connect a remote repository for sharing.
 - [Shell Activation](https://mise.jdx.dev/bootstrap/shell.html): mise can declaratively add shell activation snippets for bash, zsh, and fish with [bootstrap.mise_shell_activate], applied by mise bootstrap mise-shell-activate apply or as part of mise bootstrap.
 - [macOS Defaults](https://mise.jdx.dev/bootstrap/macos-defaults.html): mise can declare macOS user defaults (preferences) in the [bootstrap.macos.defaults] section of mise.toml and apply them with mise bootstrap macos defaults apply or as part of mise bootstrap.
 - [launchd](https://mise.jdx.dev/bootstrap/launchd.html): mise can declare macOS user LaunchAgents in [bootstrap.macos.launchd.agents] and apply them with mise bootstrap macos launchd-agents apply or as part of mise bootstrap.
 - [systemd](https://mise.jdx.dev/bootstrap/systemd.html): mise can declare Linux systemd user services and timers in [bootstrap.linux.systemd.units] and apply them with mise bootstrap linux systemd-units apply or as part of mise bootstrap.
 - [User Login Shell](https://mise.jdx.dev/bootstrap/user.html): mise can declare the current user's login shell in [bootstrap.user] and apply it with mise bootstrap user apply or as part of mise bootstrap.
-- [Dotfiles history](https://mise.jdx.dev/history.html): mise automatically commits changes to files you explicitly track, then synchronizes those same commits with your origin.
 
 ## Environments
 

--- a/e2e/cli/test_bootstrap_from
+++ b/e2e/cli/test_bootstrap_from
@@ -7,6 +7,16 @@ global_source_repo="$PWD/bootstrap-global-source"
 relative_global_source_repo="$PWD/bootstrap-relative-global-source"
 bare_global_checkout="$PWD/bootstrap-bare-global-checkout"
 
+# Only the canonical spelling is discoverable in help and completions.
+for command in "bootstrap" "bootstrap remote"; do
+  assert_contains "mise $command --help" "--adopt"
+  assert_not_contains "mise $command --help" "--from-git"
+  assert_contains "mise __complete_word__ --shell fish --line 'mise $command --'" "--adopt"
+  assert_not_contains "mise __complete_word__ --shell fish --line 'mise $command --'" "--from-git"
+done
+assert_fail "mise bootstrap --adopt new.git --from-git old.git --dry-run"
+assert_fail "mise bootstrap remote --host devbox --adopt new.git --from-git old.git --dry-run"
+
 mkdir -p "$source_repo"
 git -C "$source_repo" init -q -b main
 git -C "$source_repo" config user.email test@example.com
@@ -41,14 +51,18 @@ echo global >"$global_source_repo/global-profile"
 git -C "$global_source_repo" add .
 git -C "$global_source_repo" commit -qm initial
 
-# --from-git checks out a global config repository directly into the mise
+# --adopt checks out a global config repository directly into the mise
 # config directory, so its config participates in the first bootstrap and
 # remains the global config for later invocations.
-assert_succeed "mise -E work bootstrap --from-git '$global_source_repo' --yes --only dotfiles,task"
+assert_succeed "mise -E work bootstrap --adopt '$global_source_repo' --yes --only dotfiles,task"
 assert "git -C '$MISE_CONFIG_DIR' remote get-url origin" "$global_source_repo"
 assert "cat ~/.bootstrap-from-global" "global"
 assert "cat ~/bootstrap-from-global-task" "global"
 assert_contains "mise -E work config ls" "~/.config/mise/config.work.toml"
+
+# The hidden spelling keeps working during the one-month migration window.
+assert_contains "mise -E work bootstrap --from-git='$global_source_repo' --yes --only dotfiles 2>&1" 'This will be removed in mise 2026.10.0.'
+assert_not_contains "mise -E work bootstrap --adopt='$global_source_repo' --yes --only dotfiles 2>&1" 'deprecated'
 
 mkdir -p "$relative_global_source_repo"
 git -C "$relative_global_source_repo" init -q -b main
@@ -64,14 +78,14 @@ git -C "$relative_global_source_repo" commit -qm initial
 # A relative MISE_GLOBAL_CONFIG_FILE is resolved before the child changes into
 # the checkout and remains the selected global config during re-execution.
 rm -f "$HOME/bootstrap-from-relative-global-task"
-assert_succeed "MISE_GLOBAL_CONFIG_FILE=relative-global/config.toml mise bootstrap --from-git '$relative_global_source_repo' --yes --only task"
+assert_succeed "MISE_GLOBAL_CONFIG_FILE=relative-global/config.toml mise bootstrap --adopt '$relative_global_source_repo' --yes --only task"
 assert "cat ~/bootstrap-from-relative-global-task" "relative-global"
 
 # A relative MISE_CONFIG_DIR is resolved before the child changes into the
 # checkout and remains the config directory during re-execution.
 relative_config_checkout="bootstrap-relative-config-checkout"
 rm -f "$HOME/bootstrap-from-relative-global-task"
-assert_succeed "MISE_CONFIG_DIR='$relative_config_checkout' mise bootstrap --from-git '$relative_global_source_repo' --yes --only task"
+assert_succeed "MISE_CONFIG_DIR='$relative_config_checkout' mise bootstrap --adopt '$relative_global_source_repo' --yes --only task"
 assert "git -C '$relative_config_checkout' remote get-url origin" "$relative_global_source_repo"
 assert "cat ~/bootstrap-from-relative-global-task" "relative-global"
 
@@ -79,7 +93,7 @@ assert "cat ~/bootstrap-from-relative-global-task" "relative-global"
 # rather than silently falling back to the default global config directory.
 mkdir "$bare_global_checkout"
 rm -f "$HOME/bootstrap-from-relative-global-task"
-assert_succeed "cd '$bare_global_checkout' && MISE_GLOBAL_CONFIG_FILE=config.toml mise bootstrap --from-git '$relative_global_source_repo' --yes --only task"
+assert_succeed "cd '$bare_global_checkout' && MISE_GLOBAL_CONFIG_FILE=config.toml mise bootstrap --adopt '$relative_global_source_repo' --yes --only task"
 assert "git -C '$bare_global_checkout' remote get-url origin" "$relative_global_source_repo"
 assert "cat ~/bootstrap-from-relative-global-task" "relative-global"
 

--- a/e2e/cli/test_bootstrap_remote_git
+++ b/e2e/cli/test_bootstrap_remote_git
@@ -81,14 +81,15 @@ echo '# machine local' >remotes/one/.config/mise/config.local.toml
 # A dry run connects, inspects, and says what it would do without writing the
 # checkout (a clone on an empty host, an adoption on one with files already);
 # the bootstrap that follows is previewed too.
-assert_contains "mise bootstrap remote --host two --from-git '$source_repo' --remote-mise '$binary' --only dotfiles --dry-run 2>&1" 'Would clone'
+assert_contains "mise bootstrap remote --host two --adopt '$source_repo' --remote-mise '$binary' --only dotfiles --dry-run 2>&1" 'Would clone'
 assert_contains "cat '$SSH_LOG'" '--repository-dry-run'
 assert_contains "cat '$SSH_LOG'" 'bootstrap --dry-run'
 test ! -e remotes/two/.config/mise/.git
-assert_contains "mise bootstrap remote --host one --from-git '$source_repo' --remote-mise '$binary' --only dotfiles --dry-run 2>&1" 'Would adopt'
+assert_contains "mise bootstrap remote --host one --adopt '$source_repo' --remote-mise '$binary' --only dotfiles --dry-run 2>&1" 'Would adopt'
+assert_contains "mise bootstrap remote --host one --from-git='$source_repo' --remote-mise '$binary' --only dotfiles --dry-run 2>&1" 'This will be removed in mise 2026.10.0.'
 test ! -e remotes/one/.config/mise/.git
 assert "cat remotes/one/.config/mise/config.local.toml" '# machine local'
-mise bootstrap remote --host one --host two --from-git "$source_repo" --remote-mise "$binary" --only dotfiles --yes
+mise bootstrap remote --host one --host two --adopt "$source_repo" --remote-mise "$binary" --only dotfiles --yes
 assert "git -C remotes/one/.config/mise rev-parse HEAD" "$first_revision"
 assert "git -C remotes/two/.config/mise rev-parse HEAD" "$first_revision"
 assert "git -C remotes/one/.config/mise config remote.origin.url" "$source_repo"
@@ -100,22 +101,22 @@ echo '# second' >>seed/config.toml
 git -C seed add .
 git -C seed -c core.hooksPath=/dev/null commit -m second
 second_revision=$(git -C seed rev-parse HEAD)
-mise bootstrap remote --host one --from-git "$source_repo" --remote-mise "$binary" --only dotfiles --yes
+mise bootstrap remote --host one --adopt "$source_repo" --remote-mise "$binary" --only dotfiles --yes
 assert "git -C remotes/one/.config/mise rev-parse HEAD" "$first_revision"
 # an update is previewed against the existing checkout without moving it
-assert_contains "mise bootstrap remote --host one --from-git '$source_repo' --remote-mise '$binary' --only dotfiles --yes --update --dry-run 2>&1" 'Would fast-forward'
+assert_contains "mise bootstrap remote --host one --adopt '$source_repo' --remote-mise '$binary' --only dotfiles --yes --update --dry-run 2>&1" 'Would fast-forward'
 assert "git -C remotes/one/.config/mise rev-parse HEAD" "$first_revision"
 assert_fail "git -C remotes/one/.config/mise cat-file -e $second_revision^{commit}"
-mise bootstrap remote --host one --from-git "$source_repo" --remote-mise "$binary" --only dotfiles --yes --update
+mise bootstrap remote --host one --adopt "$source_repo" --remote-mise "$binary" --only dotfiles --yes --update
 assert "git -C remotes/one/.config/mise rev-parse HEAD" "$second_revision"
 assert "git -C remotes/one/.config/mise rev-parse '@{upstream}'" "$second_revision"
 assert "cat remotes/one/.config/mise/config.local.toml" '# machine local'
 echo '# dirty' >>remotes/one/.config/mise/config.toml
-assert_fail "mise bootstrap remote --host one --from-git '$source_repo' --remote-mise '$binary' --only dotfiles --yes --update" 'uncommitted changes'
-assert_fail "mise bootstrap remote --host one --from-git '$source_repo' --remote-mise '$binary' --only dotfiles --yes --update --dry-run" 'uncommitted changes'
+assert_fail "mise bootstrap remote --host one --adopt '$source_repo' --remote-mise '$binary' --only dotfiles --yes --update" 'uncommitted changes'
+assert_fail "mise bootstrap remote --host one --adopt '$source_repo' --remote-mise '$binary' --only dotfiles --yes --update --dry-run" 'uncommitted changes'
 
 # A failed forwarding request must prevent bootstrap and close the owned master.
-assert_fail "MISE_GITHUB_TOKEN=fake-local-relay-token mise bootstrap remote --host two --from-git '$source_repo' --remote-mise '$binary' --only dotfiles --yes --github-relay-read-only --github-relay-repo owner/repo" 'forwarding failed'
+assert_fail "MISE_GITHUB_TOKEN=fake-local-relay-token mise bootstrap remote --host two --adopt '$source_repo' --remote-mise '$binary' --only dotfiles --yes --github-relay-read-only --github-relay-repo owner/repo" 'forwarding failed'
 assert_contains "cat '$SSH_LOG'" '-O exit'
 assert_not_contains "cat '$SSH_LOG'" 'fake-local-relay-token'
 
@@ -124,7 +125,7 @@ for step in archive provision; do
   if test "$step" = archive; then
     source_args=(--source "$source_repo")
   else
-    source_args=(--from-git "$source_repo")
+    source_args=(--adopt "$source_repo")
   fi
   BLOCK_PROVISION_STEP=1 mise bootstrap remote --host "$step" "${source_args[@]}" --remote-mise "$binary" --only dotfiles --yes &
   bootstrap_pid=$!
@@ -138,7 +139,7 @@ for step in archive provision; do
 done
 
 # A stalled bundle transfer must not block cancellation or leave its SSH child alive.
-BLOCK_BUNDLE_UPLOAD=1 mise bootstrap remote --host stalled --from-git "$source_repo" --remote-mise "$binary" --only dotfiles --yes &
+BLOCK_BUNDLE_UPLOAD=1 mise bootstrap remote --host stalled --adopt "$source_repo" --remote-mise "$binary" --only dotfiles --yes &
 bootstrap_pid=$!
 wait_for_file "$FAKE_REMOTE_BASE/upload.pid" 'blocked bundle upload' 10 "$bootstrap_pid"
 upload_pid=$(cat "$FAKE_REMOTE_BASE/upload.pid")
@@ -151,12 +152,12 @@ done
 assert_fail "kill -0 '$upload_pid' 2>/dev/null"
 
 # Failed cleanup is retried before closing the owned control session.
-FAIL_CLEANUP_ONCE=1 mise bootstrap remote --host retry-cleanup --from-git "$source_repo" --remote-mise "$binary" --only dotfiles --yes
+FAIL_CLEANUP_ONCE=1 mise bootstrap remote --host retry-cleanup --adopt "$source_repo" --remote-mise "$binary" --only dotfiles --yes
 assert "cat '$FAKE_REMOTE_BASE/cleanup-attempts'" 'attempt
 attempt'
 
 # Cleanup and control-close commands themselves cannot hang cancellation.
-BLOCK_BUNDLE_UPLOAD=1 BLOCK_CLEANUP=1 mise bootstrap remote --host blocked-cleanup --from-git "$source_repo" --remote-mise "$binary" --only dotfiles --yes &
+BLOCK_BUNDLE_UPLOAD=1 BLOCK_CLEANUP=1 mise bootstrap remote --host blocked-cleanup --adopt "$source_repo" --remote-mise "$binary" --only dotfiles --yes &
 bootstrap_pid=$!
 for _ in {1..100}; do
   test -f "$FAKE_REMOTE_BASE/upload.pid" && test "$(cat "$FAKE_REMOTE_BASE/upload.pid")" != "$upload_pid" && break
@@ -185,7 +186,7 @@ fi
 exec "$REAL_GIT" "$@"
 EOF
 chmod +x fakebin/git
-BLOCK_FETCH=1 mise bootstrap remote --host fetch-cancel --from-git "$source_repo" --remote-mise "$binary" --yes &
+BLOCK_FETCH=1 mise bootstrap remote --host fetch-cancel --adopt "$source_repo" --remote-mise "$binary" --yes &
 bootstrap_pid=$!
 wait_for_file "$FAKE_REMOTE_BASE/fetch.pid" 'blocked repository fetch' 10 "$bootstrap_pid"
 fetch_pid=$(cat "$FAKE_REMOTE_BASE/fetch.pid")
@@ -204,7 +205,7 @@ redirect_pid=$!
 trap 'kill "$redirect_pid" 2>/dev/null || true' EXIT
 wait_for_file redirect-port 'HTTPS redirect fixture' 10 "$redirect_pid"
 # This test certificate is self-signed; disable verification only for this fixture.
-assert_fail "GIT_SSL_NO_VERIFY=1 mise bootstrap remote --host redirect --from-git 'https://127.0.0.1:$(cat redirect-port)/repo' --remote-mise '$binary' --yes" 'could not fetch setup repository'
+assert_fail "GIT_SSL_NO_VERIFY=1 mise bootstrap remote --host redirect --adopt 'https://127.0.0.1:$(cat redirect-port)/repo' --remote-mise '$binary' --yes" 'could not fetch setup repository'
 
 # Local and remote tracking work without experimental opt-in.
 export MISE_EXPERIMENTAL=0
@@ -215,16 +216,16 @@ assert_succeed "mise bootstrap dotfiles origin set file://$PWD/tracked-origin.gi
 assert_succeed 'mise bootstrap dotfiles sync'
 # Local tracked files do not interfere with an unrelated source archive.
 assert_succeed "mise bootstrap remote --host ordinary-source --source seed --remote-mise '$binary' --only dotfiles --yes"
-assert_succeed "mise bootstrap remote --host tracked --from-git file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --dry-run"
+assert_succeed "mise bootstrap remote --host tracked --adopt file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --dry-run"
 assert_fail 'test -f remotes/tracked/.config/mise/config.local.toml'
-assert_succeed "mise bootstrap remote --host tracked --from-git file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --yes"
+assert_succeed "mise bootstrap remote --host tracked --adopt file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --yes"
 assert_not_contains 'cat remotes/tracked/.config/mise/config.local.toml' 'experimental = true'
 assert 'cat remotes/tracked/.remote-tracked' 'tracked contents'
 assert_contains 'cat remotes/tracked/.config/mise/config.local.toml' '[history.origin]'
 assert "ssh tracked 'unset MISE_EXPERIMENTAL; $binary settings get experimental'" 'false'
 mkdir -p remotes/conflicted
 printf 'keep my edit\n' >remotes/conflicted/.remote-tracked
-assert_fail "mise bootstrap remote --host conflicted --from-git file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --yes"
+assert_fail "mise bootstrap remote --host conflicted --adopt file://$PWD/tracked-origin.git --remote-mise '$binary' --only dotfiles --yes"
 assert_not_contains 'cat remotes/conflicted/.config/mise/config.local.toml' 'experimental = true'
 test -f redirect-requested
 test ! -e redirect-followed

--- a/e2e/cli/test_bootstrap_remote_setup_repository
+++ b/e2e/cli/test_bootstrap_remote_setup_repository
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# `mise bootstrap remote --from-git` on a history-managed setup repository sets
+# `mise bootstrap remote --adopt` on a history-managed setup repository sets
 # the target up from it over the transferred bundle. A dry run connects,
 # inspects the target and the repository, and shows the plan without writing
 # configuration, recording a connection, or keeping the fetched branch; the
@@ -63,7 +63,7 @@ assert_succeed "mise bootstrap dotfiles origin set file://$origin --yes"
 assert_contains "git --git-dir=$origin ls-tree -r --name-only main" "home/.config/hypr/bindings.lua"
 
 # ---- a dry run on a fresh host previews and leaves no trace
-out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only repos,dotfiles --dry-run 2>&1)" || {
+out="$(mise bootstrap remote --host fresh --adopt "file://$origin" --remote-mise "$binary" --only repos,dotfiles --dry-run 2>&1)" || {
   printf '%s\n' "$out"
   exit 1
 }
@@ -82,7 +82,7 @@ assert "find remotes/fresh -path '*/refs/setup/*' | wc -l | tr -d ' '" "0"
 assert "find remotes/fresh -name config.local.toml | wc -l | tr -d ' '" "0"
 
 # ---- the real run writes what the dry run showed
-assert_succeed "mise bootstrap remote --host fresh --from-git file://$origin --remote-mise '$binary' --only repos,dotfiles --yes"
+assert_succeed "mise bootstrap remote --host fresh --adopt file://$origin --remote-mise '$binary' --only repos,dotfiles --yes"
 assert_directory_exists "remotes/fresh/preview-only-repo/.git"
 assert "cat remotes/fresh/preview-only-repo/README" "cloned by bootstrap"
 assert_fail "test -e remotes/fresh/.config/mise/.git"
@@ -94,7 +94,7 @@ assert_contains "cat '$SSH_LOG'" '/.config/mise bootstrap'
 
 # ---- a dry run on a set-up host previews the bootstrap against its configuration
 : >"$SSH_LOG"
-out="$(mise bootstrap remote --host fresh --from-git "file://$origin" --remote-mise "$binary" --only dotfiles --dry-run 2>&1)"
+out="$(mise bootstrap remote --host fresh --adopt "file://$origin" --remote-mise "$binary" --only dotfiles --dry-run 2>&1)"
 assert_contains 'printf "%s\n" "$out"' "Dry run: nothing was changed"
 assert_contains "cat '$SSH_LOG'" 'bootstrap --dry-run'
 assert "cat remotes/fresh/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"

--- a/e2e/cli/test_dotfiles_bootstrap_from_git
+++ b/e2e/cli/test_dotfiles_bootstrap_from_git
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# `mise bootstrap --from-git` on a history-managed setup repository sets a
+# `mise bootstrap --adopt` on a history-managed setup repository sets a
 # fresh machine up from it with one command: the branch goes into mise's own
 # store (no checkout in the configuration directory), the shared configuration,
 # its sources, and this machine's tracked files are written by a recoverable
@@ -47,7 +47,7 @@ preview_home="$(dirname "$HOME")/conflict-preview-home"
 wrapper "$preview_home" "$PWD/conflict-preview"
 mkdir -p "$preview_home/.config/hypr"
 echo local >"$preview_home/.config/hypr/bindings.lua"
-preview="$("$PWD/conflict-preview" bootstrap --from-git "file://$origin" --dry-run 2>&1)"
+preview="$("$PWD/conflict-preview" bootstrap --adopt "file://$origin" --dry-run 2>&1)"
 [[ $preview == *bindings.lua* ]] || fail "preview omits tracked file"
 [[ $preview == *'held: unresolved conflict'* ]] || fail "preview omits conflict"
 [[ $preview == *config.toml* ]] || fail "preview omits enrolled configuration"
@@ -59,7 +59,7 @@ wrapper "$C" "$PWD/c"
 c="$PWD/c"
 assert_directory_not_exists "$C/.local/state/mise/history"
 assert_fail "test -e $C/.config/mise/config.toml"
-out="$($c bootstrap --from-git "file://$origin" --dry-run 2>&1)"
+out="$($c bootstrap --adopt "file://$origin" --dry-run 2>&1)"
 [[ $out == *'is a mise setup repository'* ]] || fail "preview omits repository type"
 [[ $out == *config.toml* ]] || fail "preview omits configuration"
 [[ $out == *'Dry run: nothing was changed'* ]] || fail "preview omits dry-run assurance"
@@ -67,7 +67,7 @@ assert_fail "test -e $C/.config/mise/config.toml"
 # a preview leaves no connection, pending changes, or fetched branch behind
 assert "find $C -name sync.json | wc -l | tr -d ' '" "0"
 assert "find $C -path '*/refs/setup/*' | wc -l | tr -d ' '" "0"
-assert_succeed "$c bootstrap --from-git file://$origin --yes --only dotfiles"
+assert_succeed "$c bootstrap --adopt file://$origin --yes --only dotfiles"
 assert_fail "test -e $C/.config/mise/.git"
 assert "cat $C/.config/hypr/bindings.lua" "bind = SUPER, Q, exec, kitty"
 assert_contains "cat $C/.config/mise/config.toml" '"~/.config/hypr" = { mode = "track" }'
@@ -78,7 +78,7 @@ assert_contains "cat $C/.config/mise/config.local.toml" 'url = "file://'
 assert_contains "$c bootstrap dotfiles status" "mode sync"
 assert "$c bootstrap dotfiles history --json | jq -r '[.[].trigger] | index(\"apply\") != null'" "true"
 # running it again is a sync, not a second setup
-assert_succeed "$c bootstrap --from-git file://$origin --yes --only dotfiles"
+assert_succeed "$c bootstrap --adopt file://$origin --yes --only dotfiles"
 # C's edits reach A through the usual sync
 echo 'bind = SUPER, Q, exec, foot' >"$C/.config/hypr/bindings.lua"
 assert_contains "$c bootstrap dotfiles sync 2>&1" "published"
@@ -93,8 +93,8 @@ mkdir -p "$D/.config/mise"
 printf '[env]\nD_ONLY = "1"\n' >"$D/.config/mise/config.toml"
 # the differing configuration is held, so nothing is bootstrapped from the
 # old one: the command says what to decide and fails
-assert_fail "$d bootstrap --from-git file://$origin --yes --only dotfiles 2>&1" "need a decision"
-assert_fail "$d bootstrap --from-git file://$origin --yes --only dotfiles 2>&1" "nothing was bootstrapped"
+assert_fail "$d bootstrap --adopt file://$origin --yes --only dotfiles 2>&1" "need a decision"
+assert_fail "$d bootstrap --adopt file://$origin --yes --only dotfiles 2>&1" "nothing was bootstrapped"
 assert "cat $D/.config/mise/config.toml" $'[env]\nD_ONLY = "1"'
 assert_contains "$d bootstrap dotfiles status" "sharing is paused for the entire setup"
 assert_succeed "$d bootstrap dotfiles pull --take-remote $D/.config/mise/config.toml --yes"
@@ -113,7 +113,7 @@ git -C "$seed" push -q "file://$plain" main
 E="$(dirname "$HOME")/e-home"
 wrapper "$E" "$PWD/e"
 e="$PWD/e"
-assert_succeed "MISE_EXPERIMENTAL=0 $e bootstrap --from-git file://$plain --yes --only task"
+assert_succeed "MISE_EXPERIMENTAL=0 $e bootstrap --adopt file://$plain --yes --only task"
 # Ordinary bootstrap may checkpoint configuration, but keeps the ordinary
 # checkout and does not connect it as a shared setup repository.
 assert_succeed "test -d $E/.config/mise/.git"
@@ -130,4 +130,4 @@ git --git-dir="$other" update-ref refs/heads/main "$(git --git-dir="$other" rev-
 F="$(dirname "$HOME")/f-home"
 wrapper "$F" "$PWD/f"
 f="$PWD/f"
-assert_contains "$f bootstrap --from-git file://$other --dry-run 2>&1" "branch setup"
+assert_contains "$f bootstrap --adopt file://$other --dry-run 2>&1" "branch setup"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1212,8 +1212,8 @@ repeated or comma\-separated parts and cannot be combined.
 \fB\-\-from\fR \fI<GIT_URL>\fR
 Clone a git repository and bootstrap from its configuration
 .TP
-\fB\-\-from\-git\fR \fI<GIT_URL>\fR
-Clone a git repository into the global mise config directory and bootstrap
+\fB\-\-adopt\fR \fI<GIT_URL|OWNER/REPO>\fR
+Adopt global configuration or shared dotfile history from a Git repository, then bootstrap
 .TP
 \fB\-\-from\-dir\fR \fI<DIR>\fR
 Directory used for the repository cloned by \-\-from
@@ -1254,7 +1254,7 @@ Print help
 .RS 4
 mise bootstrap                    # packages + repos + dotfiles + tools + bootstrap task
 mise \-E work bootstrap \-\-from git@github.com:example/dotfiles.git \-\-yes
-mise bootstrap \-\-from\-git git@github.com:example/mise\-config.git \-\-yes
+mise bootstrap \-\-adopt git@github.com:example/mise\-config.git \-\-yes
 mise bootstrap \-\-force\-dotfiles   # replace conflicting dotfile targets
 mise bootstrap \-\-skip tools,task  # skip tool installation and the bootstrap task
 mise bootstrap \-\-only tools       # run just tool installation
@@ -2881,7 +2881,7 @@ Print help
 Bootstrap one or more machines over OpenSSH
 
 Select inventory hosts by name, tag, or `\-\-all`, or supply ad\-hoc `\-\-host` targets.
-The source is staged on each target and bootstrap runs there. `\-\-from\-git` instead
+The source is staged on each target and bootstrap runs there. `\-\-adopt` instead
 installs persistent global configuration; preview that choice with `\-\-dry\-run`.
 .PP
 \fBUsage:\fR mise bootstrap remote [OPTIONS] [<TARGET>] ...
@@ -2889,8 +2889,8 @@ installs persistent global configuration; preview that choice with `\-\-dry\-run
 \fBOptions:\fR
 .PP
 .TP
-\fB\-\-from\-git\fR \fI<GIT_URL|OWNER/REPO>\fR
-Install a Git repository as persistent global configuration on each target
+\fB\-\-adopt\fR \fI<GIT_URL|OWNER/REPO>\fR
+Adopt global configuration or shared dotfile history on each target
 .TP
 \fB\-\-github\-relay\-read\-only\fR
 Borrow read\-only GitHub access for this invocation

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -468,7 +468,11 @@ repeated or comma-separated parts and cannot be combined.
     flag --from help="Clone a git repository and bootstrap from its configuration" {
         arg <GIT_URL>
     }
-    flag --from-git help="Clone a git repository into the global mise config directory and bootstrap" conflicts=--from {
+    flag --adopt help="Adopt global configuration or shared dotfile history from a Git repository, then bootstrap" conflicts=--from {
+        arg "<GIT_URL|OWNER/REPO>"
+    }
+    flag --from-git help="Deprecated alias for --adopt" hide=#true {
+        conflicts "--from" "--adopt"
         arg <GIT_URL>
     }
     flag --from-dir help="Directory used for the repository cloned by --from" requires=--from {
@@ -1515,11 +1519,15 @@ Install these plugins before applying packages they manage. Installing a plugin 
 Bootstrap one or more machines over OpenSSH
 
 Select inventory hosts by name, tag, or `--all`, or supply ad-hoc `--host` targets.
-The source is staged on each target and bootstrap runs there. `--from-git` instead
+The source is staged on each target and bootstrap runs there. `--adopt` instead
 installs persistent global configuration; preview that choice with `--dry-run`.
 """#
-        flag --from-git help="Install a Git repository as persistent global configuration on each target" {
+        flag --adopt help="Adopt global configuration or shared dotfile history on each target" {
             conflicts "--source" "--copy-link" "--copy-links" "--exclude"
+            arg "<GIT_URL|OWNER/REPO>"
+        }
+        flag --from-git help="Deprecated alias for --adopt" hide=#true {
+            conflicts "--adopt" "--source" "--copy-link" "--copy-links" "--exclude"
             arg "<GIT_URL|OWNER/REPO>"
         }
         flag --github-relay-read-only help="Borrow read-only GitHub access for this invocation"
@@ -1801,7 +1809,7 @@ shell affects future sessions, not the shell running this command.
     example #"""
 mise bootstrap                    # packages + repos + dotfiles + tools + bootstrap task
 mise -E work bootstrap --from git@github.com:example/dotfiles.git --yes
-mise bootstrap --from-git git@github.com:example/mise-config.git --yes
+mise bootstrap --adopt git@github.com:example/mise-config.git --yes
 mise bootstrap --force-dotfiles   # replace conflicting dotfile targets
 mise bootstrap --skip tools,task  # skip tool installation and the bootstrap task
 mise bootstrap --only tools       # run just tool installation

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -64,7 +64,7 @@ use crate::ui::table::MiseTable;
     verbatim_doc_comment,
     example(r###"mise bootstrap                    # packages + repos + dotfiles + tools + bootstrap task
 mise -E work bootstrap --from git@github.com:example/dotfiles.git --yes
-mise bootstrap --from-git git@github.com:example/mise-config.git --yes
+mise bootstrap --adopt git@github.com:example/mise-config.git --yes
 mise bootstrap --force-dotfiles   # replace conflicting dotfile targets
 mise bootstrap --skip tools,task  # skip tool installation and the bootstrap task
 mise bootstrap --only tools       # run just tool installation
@@ -87,8 +87,13 @@ pub(crate) struct Bootstrap {
     #[usage(long, value_name = "GIT_URL")]
     from: Option<String>,
 
-    /// Clone a git repository into the global mise config directory and bootstrap
-    #[usage(long, value_name = "GIT_URL", conflicts = "from")]
+    /// Adopt global configuration or shared dotfile history from a Git repository, then bootstrap
+    #[usage(long, value_name = "GIT_URL|OWNER/REPO", conflicts = "from")]
+    adopt: Option<String>,
+
+    // Kept separately from `adopt` so only the legacy spelling emits a warning.
+    /// Deprecated alias for --adopt
+    #[usage(long, hide = true, value_name = "GIT_URL", conflicts = ["from", "adopt"])]
     from_git: Option<String>,
 
     /// Directory used for the repository cloned by --from
@@ -644,13 +649,16 @@ struct BootstrapComposeStatus {
 /// Bootstrap one or more machines over OpenSSH
 ///
 /// Select inventory hosts by name, tag, or `--all`, or supply ad-hoc `--host` targets.
-/// The source is staged on each target and bootstrap runs there. `--from-git` instead
+/// The source is staged on each target and bootstrap runs there. `--adopt` instead
 /// installs persistent global configuration; preview that choice with `--dry-run`.
 #[derive(Debug, usage_rs::Args)]
 #[usage(verbatim_doc_comment)]
 struct BootstrapRemote {
-    /// Install a Git repository as persistent global configuration on each target
+    /// Adopt global configuration or shared dotfile history on each target
     #[usage(long, value_name = "GIT_URL|OWNER/REPO", conflicts = ["source", "copy_link", "copy_links", "exclude"])]
+    adopt: Option<String>,
+    /// Deprecated alias for --adopt
+    #[usage(long, hide = true, value_name = "GIT_URL|OWNER/REPO", conflicts = ["adopt", "source", "copy_link", "copy_links", "exclude"])]
     from_git: Option<String>,
     /// Borrow read-only GitHub access for this invocation
     #[usage(long)]
@@ -1297,10 +1305,11 @@ impl Bootstrap {
     }
 
     pub(crate) async fn run(mut self) -> Result<()> {
-        if self.from.is_some() || self.from_git.is_some() {
+        normalize_adopt_alias(&mut self.adopt, self.from_git.take());
+        if self.from.is_some() || self.adopt.is_some() {
             if self.command.is_some() {
-                let flag = if self.from_git.is_some() {
-                    "--from-git"
+                let flag = if self.adopt.is_some() {
+                    "--adopt"
                 } else {
                     "--from"
                 };
@@ -1854,7 +1863,7 @@ impl Bootstrap {
 
     async fn run_from(&self) -> Result<()> {
         let expanded = self
-            .from_git
+            .adopt
             .as_deref()
             .map(crate::github_relay::expand_repository)
             .transpose()?;
@@ -1957,7 +1966,7 @@ impl Bootstrap {
     }
 
     /// Runs the bootstrap itself as a child process from `checkout` (the
-    /// global configuration directory for `--from-git`), trusted for it.
+    /// global configuration directory for `--adopt`), trusted for it.
     async fn run_child_bootstrap(&self, checkout: PathBuf) -> Result<()> {
         let checkout = dunce::canonicalize(&checkout)?;
         let mut command = Command::new(std::env::current_exe()?);
@@ -1965,7 +1974,7 @@ impl Bootstrap {
             &checkout,
             &crate::env::ARGS.read().unwrap(),
         ));
-        if self.from_git.is_some() {
+        if self.adopt.is_some() {
             if self.dry_run {
                 command.env("MISE_CONFIG_DIR", &checkout);
                 let name = crate::env::MISE_GLOBAL_CONFIG_FILE
@@ -2084,6 +2093,19 @@ impl Bootstrap {
     }
 }
 
+fn normalize_adopt_alias(adopt: &mut Option<String>, from_git: Option<String>) {
+    if let Some(repository) = from_git {
+        // One-month transition approved for this newly introduced spelling.
+        deprecated_at!(
+            "2026.9.0",
+            "2026.10.0",
+            "bootstrap.from-git",
+            "`--from-git` is deprecated. Use `--adopt` instead."
+        );
+        *adopt = Some(repository);
+    }
+}
+
 /// Re-run the original bootstrap invocation from the checkout, preserving
 /// global controls such as `--no-hooks`. Remove only arguments that describe
 /// the parent checkout operation and replace any original working directory.
@@ -2092,10 +2114,11 @@ fn bootstrap_from_child_args(checkout: &Path, args: &[String]) -> Vec<OsString> 
     let mut args = args.iter().skip(1);
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--from" | "--from-git" | "--from-dir" | "--cd" | "-C" => {
+            "--from" | "--adopt" | "--from-git" | "--from-dir" | "--cd" | "-C" => {
                 args.next();
             }
             _ if arg.starts_with("--from=")
+                || arg.starts_with("--adopt=")
                 || arg.starts_with("--from-git=")
                 || arg.starts_with("--from-dir=")
                 || arg.starts_with("--cd=")
@@ -3001,7 +3024,8 @@ impl BootstrapSecrets {
 }
 
 impl BootstrapRemote {
-    async fn run(self) -> Result<()> {
+    async fn run(mut self) -> Result<()> {
+        normalize_adopt_alias(&mut self.adopt, self.from_git.take());
         crate::ui::ctrlc::exit_on_ctrl_c(false);
         let relay = crate::github_relay::Scope::from_flags(
             self.github_relay_read_only,
@@ -3046,7 +3070,7 @@ impl BootstrapRemote {
         }
 
         let overrides = system::remote::RemoteOverrides {
-            from_git: self.from_git.is_some(),
+            from_git: self.adopt.is_some(),
             source: self.source,
             mise_env: self.remote_env,
             copy_links: self.copy_links,
@@ -3088,7 +3112,7 @@ impl BootstrapRemote {
         }
         let mut failures = vec![];
         let repository = self
-            .from_git
+            .adopt
             .as_deref()
             .map(crate::github_relay::expand_repository)
             .transpose()?;
@@ -5044,45 +5068,102 @@ mod tests {
     use crate::system::remote;
 
     #[test]
-    fn remote_from_git_parses_and_conflicts_with_source() {
-        let argv = [
-            "mise",
-            "bootstrap",
-            "remote",
-            "--host",
-            "devbox",
-            "--from-git",
-            "jdx/dotfiles",
-            "--github-relay-read-only",
-            "--github-relay-repo",
-            "jdx/dotfiles",
-        ]
-        .map(OsStr::new);
-        assert!(Cli::parse_from_argv(&argv).is_ok());
-        let conflict = [
-            "mise",
-            "bootstrap",
-            "remote",
-            "--host",
-            "devbox",
-            "--from-git",
-            "jdx/dotfiles",
-            "--source",
-            ".",
-        ]
-        .map(OsStr::new);
-        assert!(Cli::parse_from_argv(&conflict).is_err());
-        for archive_flag in ["--copy-link=link", "--copy-links", "--exclude=pattern"] {
+    fn remote_adopt_parses_and_conflicts_with_source() {
+        for flag in ["--adopt", "--from-git"] {
             let argv = [
                 "mise",
                 "bootstrap",
                 "remote",
-                "--host=devbox",
-                "--from-git=jdx/dotfiles",
-                archive_flag,
+                "--host",
+                "devbox",
+                flag,
+                "jdx/dotfiles",
+                "--github-relay-read-only",
+                "--github-relay-repo",
+                "jdx/dotfiles",
             ]
             .map(OsStr::new);
-            assert!(Cli::parse_from_argv(&argv).is_err(), "{archive_flag}");
+            assert!(Cli::parse_from_argv(&argv).is_ok());
+            let conflict = [
+                "mise",
+                "bootstrap",
+                "remote",
+                "--host",
+                "devbox",
+                flag,
+                "jdx/dotfiles",
+                "--source",
+                ".",
+            ]
+            .map(OsStr::new);
+            assert!(Cli::parse_from_argv(&conflict).is_err());
+            for archive_flag in ["--copy-link=link", "--copy-links", "--exclude=pattern"] {
+                let repository_flag = format!("{flag}=jdx/dotfiles");
+                let argv = [
+                    "mise",
+                    "bootstrap",
+                    "remote",
+                    "--host=devbox",
+                    &repository_flag,
+                    archive_flag,
+                ]
+                .map(OsStr::new);
+                assert!(Cli::parse_from_argv(&argv).is_err(), "{archive_flag}");
+            }
+        }
+    }
+
+    #[test]
+    fn adopt_accepts_both_spellings_locally_and_remotely() {
+        for remote in [false, true] {
+            for flag in ["--adopt", "--from-git"] {
+                for equals in [false, true] {
+                    let mut args = vec!["mise".to_string(), "bootstrap".to_string()];
+                    if remote {
+                        args.extend(["remote", "--host", "devbox"].map(String::from));
+                    }
+                    if equals {
+                        args.push(format!("{flag}=jdx/dotfiles"));
+                    } else {
+                        args.extend([flag, "jdx/dotfiles"].map(String::from));
+                    }
+                    let argv = args.iter().map(OsStr::new).collect::<Vec<_>>();
+                    let cli = Cli::parse_from_argv(&argv).unwrap();
+                    let Some(Commands::Bootstrap(parsed)) = cli.command else {
+                        panic!("expected bootstrap");
+                    };
+                    let (mut adopt, legacy) = if remote {
+                        let Some(super::Commands::Remote(parsed)) = parsed.command else {
+                            panic!("expected remote bootstrap");
+                        };
+                        (parsed.adopt, parsed.from_git)
+                    } else {
+                        (parsed.adopt, parsed.from_git)
+                    };
+                    assert_eq!(legacy.is_some(), flag == "--from-git");
+                    super::normalize_adopt_alias(&mut adopt, legacy);
+                    assert_eq!(adopt.as_deref(), Some("jdx/dotfiles"));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn bootstrap_reexec_removes_both_adoption_spellings() {
+        for flag in ["--adopt", "--from-git"] {
+            for equals in [false, true] {
+                let mut args = vec!["mise".to_string(), "bootstrap".to_string()];
+                if equals {
+                    args.push(format!("{flag}=jdx/dotfiles"));
+                } else {
+                    args.extend([flag, "jdx/dotfiles"].map(String::from));
+                }
+                args.push("--yes".to_string());
+                assert_eq!(
+                    bootstrap_from_child_args(Path::new("/checkout"), &args),
+                    ["--cd", "/checkout", "bootstrap", "--yes"].map(OsString::from)
+                );
+            }
         }
     }
 
@@ -5155,29 +5236,31 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_from_git_conflicts_with_project_checkout_options() {
-        for args in [
-            [
-                "mise",
-                "bootstrap",
-                "--from",
-                "project.git",
-                "--from-git",
-                "global.git",
-            ]
-            .as_slice(),
-            [
-                "mise",
-                "bootstrap",
-                "--from-git",
-                "global.git",
-                "--from-dir",
-                "checkout",
-            ]
-            .as_slice(),
-        ] {
-            let argv = args.iter().map(OsStr::new).collect::<Vec<_>>();
-            assert!(Cli::parse_from_argv(&argv).is_err(), "{args:?}");
+    fn bootstrap_adopt_conflicts_with_project_checkout_options() {
+        for flag in ["--adopt", "--from-git"] {
+            for args in [
+                [
+                    "mise",
+                    "bootstrap",
+                    "--from",
+                    "project.git",
+                    flag,
+                    "global.git",
+                ]
+                .as_slice(),
+                [
+                    "mise",
+                    "bootstrap",
+                    flag,
+                    "global.git",
+                    "--from-dir",
+                    "checkout",
+                ]
+                .as_slice(),
+            ] {
+                let argv = args.iter().map(OsStr::new).collect::<Vec<_>>();
+                assert!(Cli::parse_from_argv(&argv).is_err(), "{args:?}");
+            }
         }
     }
 

--- a/src/system/history/checkpoint.rs
+++ b/src/system/history/checkpoint.rs
@@ -216,7 +216,7 @@ impl Store {
                 .is_none()
         {
             // A service may watch policy before the first enrollment. Do not
-            // manufacture an unrelated empty root before --from-git adoption.
+            // manufacture an unrelated empty root before --adopt adoption.
             return Ok(Outcome::Unchanged);
         }
         let mut index = store::load_index_in(&self.state_dir)?;

--- a/src/system/history/scope.rs
+++ b/src/system/history/scope.rs
@@ -621,7 +621,7 @@ impl Writer {
 }
 
 /// Bootstrap without enrollment still needs private write recovery, but must
-/// not create an unrelated Git root before a later `--from-git` setup.
+/// not create an unrelated Git root before a later `--adopt` setup.
 /// Explicit command captures can request labeled empty boundaries; existing
 /// Git history also keeps its boundaries after all paths are untracked.
 fn records_file_history(

--- a/src/system/history/sync/format.rs
+++ b/src/system/history/sync/format.rs
@@ -1,6 +1,6 @@
 //! The explicit versioned marker of a history-enabled setup repository:
 //! `.mise-history/format.toml` with `format = 1`. A repository without it is
-//! an ordinary repository and keeps its old `--from`/`--from-git`
+//! an ordinary repository and keeps its old `--from`/`--adopt`
 //! behaviour; a newer format stops with an upgrade message.
 
 use eyre::{Result, bail};

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -1,14 +1,14 @@
 //! Setting a machine up from a history-managed setup repository:
-//! `mise bootstrap --from-git <url>` on a repository that carries the
+//! `mise bootstrap --adopt <url>` on a repository that carries the
 //! `.mise-history/format.toml` marker, locally or on a remote host through
-//! the bundle `mise bootstrap remote --from-git` transfers. The branch is
+//! the bundle `mise bootstrap remote --adopt` transfers. The branch is
 //! fetched into mise's own bare store, never cloned into the configuration
 //! directory; the shared configuration, the sources it references, and this
 //! machine's tracked streams are written by the same recoverable pull as any
 //! other incoming change (a file that differs is held for a decision, never
 //! overwritten); the connection is declared machine-locally and recorded
 //! for the watcher. An ordinary repository (no marker) is left to the
-//! ordinary `--from-git`.
+//! ordinary `--adopt`.
 
 use std::process::Stdio;
 
@@ -133,12 +133,12 @@ fn preview_config_path(
     )
 }
 
-/// `mise bootstrap --from-git <url>`: `Some` when the repository is
+/// `mise bootstrap --adopt <url>`: `Some` when the repository is
 /// history-managed and this machine was set up from it (or would be, on a
 /// dry run); `None` leaves the ordinary clone to the caller.
 pub(crate) async fn from_git(url: &str, yes: bool, dry_run: bool) -> Result<Option<Outcome>> {
     // Detect marked repositories without creating persistent tracking state
-    // for users of the released, ordinary --from-git workflow.
+    // for users of the released, ordinary --adopt workflow.
     let probe_dir = tempfile::tempdir()?;
     let store = Store::open_in(probe_dir.path())?;
     if let Some(reason) = store.unavailable() {

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -110,7 +110,7 @@ async fn set_inner(
         }
         RepoState::Unmarked => {
             miseprintln!(
-                "The repository already has content without mise enrollment metadata. Connecting does not import its files or replace unrelated history. Synchronization requires compatible Git ancestry; use an empty origin or reconcile the histories explicitly. Ordinary non-tracking `--from`/`--from-git` workflows remain available."
+                "The repository already has content without mise enrollment metadata. Connecting does not import its files or replace unrelated history. Synchronization requires compatible Git ancestry; use an empty origin or reconcile the histories explicitly. Ordinary non-tracking `--from`/`--adopt` workflows remain available."
             );
         }
     }

--- a/src/system/history/tracked.rs
+++ b/src/system/history/tracked.rs
@@ -699,7 +699,7 @@ pub(crate) fn hard_exclusions() -> Vec<PathBuf> {
     dirs
 }
 
-/// The global config directory (where `--from-git` checks out).
+/// The global config directory (where `--adopt` checks out).
 pub(crate) fn global_config_dir() -> PathBuf {
     crate::env::MISE_GLOBAL_CONFIG_FILE
         .as_deref()

--- a/tasks.toml
+++ b/tasks.toml
@@ -95,7 +95,12 @@ mise completion powershell > completions/mise.ps1
 description = 'Generate man pages'
 depends = ["render:usage"]
 env = { NO_COLOR = "1" }
-run = "mise x usage -- usage generate manpage --file mise.usage.kdl > man/man1/mise.1"
+run = [
+  "mise x usage -- usage generate manpage --file mise.usage.kdl > man/man1/mise.1",
+  # usage's manpage renderer currently includes hidden flags. Omit this temporary
+  # compatibility entry until it is removed alongside the alias in 2026.10.0.
+  '''perl -0pi -e 's/\.TP\n\\fB\\-\\-from\\-git\\fR[^\n]*\nDeprecated alias for \\-\\-adopt\n//g' man/man1/mise.1''',
+]
 
 ["render:help"]
 description = 'Render help documentation'


### PR DESCRIPTION
Make the two repository workflows explicit: `mise bootstrap --from` runs a bootstrap project, while `mise bootstrap --adopt` adopts global configuration or shared dotfile history. The same adoption spelling works with remote bootstrap.

The previous adoption spelling remains a hidden compatibility alias, warns on use, and is scheduled for removal in mise 2026.10.0. The one-month transition is explicitly requested for this newly introduced option. Help, completions, guides, and the manual teach only `--adopt`. The manpage generation task removes the temporary compatibility entry because the upstream renderer currently prints hidden flags.

The dotfiles and related bootstrap guides mixed introductory workflows with terminology, edge cases, and implementation details. This rewrite puts usable examples first, defines terms as they appear, and moves advanced behavior into reference and troubleshooting sections. The introductory workflow draws on [Dotfiles That Save Themselves](https://jdx.dev/posts/2026-09-07-dotfiles-that-save-themselves/).

- Dotfiles: track a file, enable autosave, restore an edit, and optionally share it; introduce managing files from sources separately.
- History: organize saving, inspection, rollback, and synchronization before storage, recovery, and watcher scheduling details.
- Machine setup: demonstrate automatic two-way syncing with an explicit manual alternative, and use a template example that preserves the reader's existing Git configuration.
- Bootstrap: explain which repository workflow to choose with a comparison table and separate examples.
- Services: give the watcher its own setup example and move platform-specific restart and executable-path details later.
- Navigation: place Dotfiles History beside Dotfiles and label the services page to cover both user and system services; regenerate the documentation index to match.

Existing heading anchors are preserved. The documentation also corrects variant precedence and clarifies what `history show` displays. Apart from the renamed option and compatibility warning, adoption and synchronization behavior stay unchanged.

Companion introduction-post update: https://github.com/jdx/blog/pull/105 (publish after the CLI change is released).

Addresses the dotfiles readability feedback in https://github.com/jdx/mise/discussions/12952.

Validation:
- `mise run docs:build`
- `mise run render` (clean working tree afterward)
- `mise x -- cargo test --all-features --bin mise cli::bootstrap::tests` (8 tests)
- `mise x -- cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run test:e2e e2e/cli/test_bootstrap_from e2e/cli/test_dotfiles_bootstrap_from_git e2e/cli/test_bootstrap_remote_git e2e/cli/test_bootstrap_remote_setup_repository`
- Scoped hk fixes and checks
- Parsed 33 TOML examples across five guides; verified 70 original heading anchors and 92 local documentation links

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming a documented bootstrap flag can break scripts until authors switch to `--adopt`, though the hidden alias limits immediate breakage; the large doc rewrite does not change runtime behavior but may diverge briefly from older mental models.
> 
> **Overview**
> Introduces **`mise bootstrap --adopt`** and **`mise bootstrap remote --adopt`** as the documented way to adopt global mise configuration or a shared dotfile-history setup repository, then bootstrap. **`--from-git`** remains as a hidden alias that warns and is slated for removal in **mise 2026.10.0**; help, completions, usage specs, man pages, and e2e tests assert the new spelling and reject mixing both flags.
> 
> **Bootstrap docs** split “starting from a repository” into a comparison table: **`--from`** for bootstrap projects vs **`--adopt`** for global config or setup repos, with remote bootstrap updated to match. **Services** documentation is reframed around user services (including the history watcher) with clearer bootstrap-phase wording for cross-platform user services and `requires_tools`.
> 
> **Dotfiles**, **history**, **setup**, and related guides are reorganized for tutorial-first flow (track → autosave → restore → share), updated terminology and examples (e.g. default **`--sync sync`**, `services apply` for the watcher), sidebar labels (**Services**, **Dotfiles History**), and **`llms.txt`** index blurbs. Generated CLI/man content reflects **`--adopt`** only in user-facing help.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f49f4f8910b8d8bd7a7461c32d5e6c7ad7f83afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer guidance for dotfile tracking, history, restoration, synchronization, encryption, conflict handling, and recovery.
  - Expanded documentation for bootstrap workflows, services across platforms, automatic saving, sharing, and troubleshooting.
  - Added a dedicated “Dotfiles History” navigation entry.

- **Updates**
  - Renamed the bootstrap repository option from `--from-git` to `--adopt`.
  - `--adopt` now supports Git URLs and `OWNER/REPO` references for adopting global configuration or shared dotfile history.
  - The former `--from-git` spelling remains available temporarily with a deprecation warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->