### PR TITLE
fix(version): use = syntax in auto_update hint

### DIFF
--- a/docs/installing-mise.md
+++ b/docs/installing-mise.md
@@ -33,7 +33,7 @@ which updates managed tools.
 For installations that support `mise self-update`, automatic updates can be enabled globally:
 
 ```sh
-mise settings set auto_update true
+mise settings auto_update=true
 ```
 
 mise then periodically checks before eligible interactive commands, installs a newer release without

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -275,7 +275,7 @@ pub(crate) fn show_auto_update_hint() {
         hint!(
             "auto_update",
             "keep mise updated automatically with",
-            "mise settings set auto_update true"
+            "mise settings auto_update=true"
         );
     }
 }


### PR DESCRIPTION
The auto-update hint shown by `mise version` suggested:

```
mise settings set auto_update true
```

`mise settings <KEY>=<VALUE>` is the form used in the `mise settings` help
examples, so use it here too:

```
mise settings auto_update=true
```

Also updates the matching example in `docs/installing-mise.md`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5[1m]; version: 2.1.263.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to docs and a user-facing hint string; no behavior or settings parsing changes.
> 
> **Overview**
> Updates the **auto-update** setup example from `mise settings set auto_update true` to **`mise settings auto_update=true`** so it matches the `KEY=VALUE` style shown in `mise settings` help.
> 
> The same string is changed in the installing guide and in the hint printed by **`mise version`** when self-update is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c2f57c685ded65f578f51a8e0c613d0816d74d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the command for enabling automatic updates to use the current syntax.

* **Bug Fixes**
  * Updated the automatic-update hint to recommend the correct command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->