### PR TITLE
docs: drop the "you need Git installed" prerequisite

### DIFF
--- a/docs/bootstrap/setup.md
+++ b/docs/bootstrap/setup.md
@@ -10,7 +10,7 @@ Start with one file; add more once you have tried restoring a change.
 
 ## Install mise
 
-You need Git installed. If mise is already installed, skip the first two commands.
+If mise is already installed, skip the first two commands.
 
 ```sh
 curl https://mise.run | sh

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -19,8 +19,8 @@ For an introduction to this workflow, read
 
 ## Tracking files in place
 
-With Git installed, start saving the history of a file you already have.
-For example, if you use zsh:
+Start saving the history of a file you already have. For example, if you
+use zsh:
 
 ```sh
 mise bootstrap dotfiles track ~/.zshrc


### PR DESCRIPTION
Two dotfiles guides opened by telling the reader they need Git installed:

- `docs/dotfiles.md` — "With Git installed, start saving the history of a file you already have."
- `docs/bootstrap/setup.md` — "You need Git installed. If mise is already installed, skip the first two commands."

Anyone reaching these pages already has Git, so the prerequisite is noise in
the first line of each guide. Removed it and reflowed the surrounding text.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5[1m]; version: 2.1.263.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy edits with no runtime or configuration behavior changes.
> 
> **Overview**
> Removes opening **“you need Git installed”** wording from the bootstrap setup and dotfiles tracking intros so readers aren’t told to install Git before the first actionable step.
> 
> In `docs/bootstrap/setup.md`, the **Install mise** section now starts with the skip-if-already-installed note only. In `docs/dotfiles.md`, **Tracking files in place** begins directly with “Start saving the history…” with a light line wrap. **Install Git first** remains in **Set up another machine**, where it still applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35c9dfa54b76e4f6abf5fa85ddad202d9ce1c6b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the setup guide to clarify that users with mise already installed can skip the initial setup commands.
  - Simplified the dotfiles tracking instructions by removing the Git installation prerequisite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->