### PR TITLE
ci: treat mise-en-dev as a trusted actor

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ permissions: {}
 
 jobs:
   trusted:
-    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
+    if: ${{ (github.actor == 'jdx' || github.actor == 'mise-en-dev') && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && (github.event.pull_request.user.login == 'jdx' || github.event.pull_request.user.login == 'mise-en-dev'))) }}
     permissions:
       contents: read
     uses: ./.github/workflows/docs-impl.yml
@@ -38,7 +38,7 @@ jobs:
       MISE_GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
 
   untrusted:
-    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
+    if: ${{ (github.actor != 'jdx' && github.actor != 'mise-en-dev') || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || (github.event.pull_request.user.login != 'jdx' && github.event.pull_request.user.login != 'mise-en-dev'))) }}
     permissions:
       contents: read
     uses: ./.github/workflows/docs-impl.yml

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   trusted:
-    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
+    if: ${{ (github.actor == 'jdx' || github.actor == 'mise-en-dev') && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && (github.event.pull_request.user.login == 'jdx' || github.event.pull_request.user.login == 'mise-en-dev'))) }}
     permissions:
       contents: read
     uses: ./.github/workflows/registry-impl.yml
@@ -22,7 +22,7 @@ jobs:
       MISE_VERSIONS_API_SECRET: ${{ secrets.MISE_VERSIONS_API_SECRET }}
 
   untrusted:
-    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
+    if: ${{ (github.actor != 'jdx' && github.actor != 'mise-en-dev') || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || (github.event.pull_request.user.login != 'jdx' && github.event.pull_request.user.login != 'mise-en-dev'))) }}
     permissions:
       contents: read
     uses: ./.github/workflows/registry-impl.yml

--- a/.github/workflows/test-vfox.yml
+++ b/.github/workflows/test-vfox.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   trusted:
-    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
+    if: ${{ (github.actor == 'jdx' || github.actor == 'mise-en-dev') && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && (github.event.pull_request.user.login == 'jdx' || github.event.pull_request.user.login == 'mise-en-dev'))) }}
     permissions:
       contents: read
     uses: ./.github/workflows/test-vfox-impl.yml
@@ -23,7 +23,7 @@ jobs:
       MISE_GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
 
   untrusted:
-    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
+    if: ${{ (github.actor != 'jdx' && github.actor != 'mise-en-dev') || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || (github.event.pull_request.user.login != 'jdx' && github.event.pull_request.user.login != 'mise-en-dev'))) }}
     permissions:
       contents: read
     uses: ./.github/workflows/test-vfox-impl.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ permissions: {}
 
 jobs:
   trusted:
-    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
+    if: ${{ (github.actor == 'jdx' || github.actor == 'mise-en-dev') && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && (github.event.pull_request.user.login == 'jdx' || github.event.pull_request.user.login == 'mise-en-dev'))) }}
     permissions:
       contents: read
     uses: ./.github/workflows/test-impl.yml
@@ -32,7 +32,7 @@ jobs:
       MISE_VERSIONS_API_SECRET: ${{ secrets.MISE_VERSIONS_API_SECRET }}
 
   untrusted:
-    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
+    if: ${{ (github.actor != 'jdx' && github.actor != 'mise-en-dev') || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || (github.event.pull_request.user.login != 'jdx' && github.event.pull_request.user.login != 'mise-en-dev'))) }}
     permissions:
       contents: read
     uses: ./.github/workflows/test-impl.yml


### PR DESCRIPTION
## Problem

[Run 34192721809](https://github.com/jdx/mise/actions/runs/34192721809) (push to `release`, `chore: release 2026.9.3`) failed all 8 `test-tool` tranches. The tools were fine — the job had no usable GitHub token.

`registry.yml` gates on `github.actor == 'jdx'`. That push was made by **`mise-en-dev`**, so it took the `untrusted` path, which deliberately passes no secrets. `registry-impl.yml:199` then gets an empty `MISE_VERSIONS_API_SECRET`:

```
API_SECRET:
No API secret provided, skipping token fetch
```

`Set pooled token` is skipped, mise falls back to the shared installation token, and everything 403s:

```
"message": "API rate limit exceeded for installation. ... request ID A7C0:C54BD:C1E60A:26DEFAD:6A9FA8EC"
```

72 `403 Forbidden` lines in tranche 0 alone. `allurectl`, `doppler`, `foundry` and `micromamba` were reported as hard failures only because they happened to be under test; `aube` failed identically but was waived, since the grace period keys on upstream release age rather than on the cause.

## Change

Adds `mise-en-dev` alongside `jdx` in the trusted/untrusted gates of `registry.yml`, `test.yml`, `docs.yml` and `test-vfox.yml`.

This matches what the repo already does elsewhere — `release.yml:88,156` and `vendored-file-warning.yml:13` treat the bot as jdx-equivalent, including for access to the private Namespace runners. These four gates were the inconsistent ones.

## Trust boundary

Unchanged. Being `github.actor == 'mise-en-dev'` requires write access to this repo: `release` is a protected branch, and creating a same-repo PR branch needs write access. The `head.repo.full_name == github.repository` guard still excludes forks.

The two conditions are exact De Morgan negations and have to move together, or both jobs run. Verified over all 36 combinations of actor x event x same-repo x PR author:

- exactly one of `trusted`/`untrusted` matches in every case
- no fork PR is ever trusted, for any actor
- a bot push to `release` is now trusted

## Note

The `mise-en-dev` token becoming a trusted-path credential means a leak of it could exfiltrate `MISE_GH_TOKEN` / `MISE_VERSIONS_API_SECRET` via a workflow edit on a same-repo PR. That is already true of the `jdx` account, and a leaked write-capable bot token is a repo compromise regardless — but it is the one real delta, so calling it out.

Separately, and not addressed here: a 403 `rate limit exceeded` currently surfaces as "these 4 tools are broken" rather than "CI was rate limited." Worth a follow-up.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5[1m]; version: 2.1.263.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Trusted-path workflows now pass repository secrets when `mise-en-dev` triggers them; the trust model is unchanged in principle (write access required) but expands which automation account can receive CI secrets.
> 
> **Overview**
> **Extends CI trusted/untrusted job gates** so the `mise-en-dev` bot is treated like `jdx` for secret-bearing workflows, fixing release pushes that previously ran the untrusted path without `MISE_GH_TOKEN` / `MISE_VERSIONS_API_SECRET`.
> 
> The `trusted` and `untrusted` `if` conditions in `docs.yml`, `registry.yml`, `test.yml`, and `test-vfox.yml` now allow `github.actor` or same-repo PR author to be either `jdx` or `mise-en-dev`. Fork PRs still never take the trusted path. This aligns these four entry workflows with patterns already used in `release.yml` and similar files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f001326757d803b4203b9523d39c62f04593ba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated documentation, registry, testing, and vfox testing workflows to recognize an additional trusted contributor.
  - Matching changes ensure trusted runs are used for eligible activity from the approved contributor, while other activity continues through untrusted checks.
  - This improves consistency across automated validation and publishing workflows without changing application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->