### PR TITLE
feat(ls): add -a short flag for --all-sources

### DIFF
--- a/docs/cli/ls.md
+++ b/docs/cli/ls.md
@@ -25,7 +25,7 @@ by a config file (active) whether or not they are installed.
 - **`-J --json`** — Output in JSON format
 - **`-l --local`** — Only show tool versions currently specified in the local mise.toml
 - **`-m --missing`** — Display missing tool versions
-- **`--all-sources`** — Display all tracked config sources for tools
+- **`-a --all-sources`** — Display all tracked config sources for tools
 - **`--monorepo`** — List tools from every [monorepo].config_roots config root
 
   Uses the active MISE_ENV and requires monorepo_root = true plus explicit

--- a/e2e/cli/test_ls_all_sources
+++ b/e2e/cli/test_ls_all_sources
@@ -10,7 +10,10 @@ assert_succeed "cd project-b && mise ls dummy"
 
 assert_contains "mise ls dummy --all-sources" "dummy  1.1.0 (missing)  ~/workdir/project-a/mise.toml  1"
 assert_contains "mise ls dummy --all-sources" "~/workdir/project-b/mise.toml  1"
+assert_contains "mise ls dummy -a" "~/workdir/project-a/mise.toml  1"
+assert_contains "mise ls dummy -a" "~/workdir/project-b/mise.toml  1"
 
 assert "mise ls dummy --all-sources --json | jq -r '.[0].sources | length'" "2"
 assert_contains "mise ls dummy --all-sources --json" "project-a/mise.toml"
 assert_contains "mise ls dummy --all-sources --json" "project-b/mise.toml"
+assert "mise ls dummy -a --json | jq -r '.[0].sources | length'" "2"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -4779,7 +4779,7 @@ Don't fetch information such as outdated versions
 .TP
 \fB\-p, \-\-plugin\fR \fI<PLUGIN>\fR
 .TP
-\fB\-\-all\-sources\fR
+\fB\-a, \-\-all\-sources\fR
 Display all tracked config sources for tools
 .TP
 \fB\-\-monorepo\fR

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3309,7 +3309,7 @@ by a config file (active) whether or not they are installed.
     flag "-p --plugin" hide=#true {
         arg <PLUGIN>
     }
-    flag --all-sources help="Display all tracked config sources for tools" {
+    flag "-a --all-sources" help="Display all tracked config sources for tools" {
         conflicts "--current" "--global" "--local" "--prunable"
     }
     flag --monorepo help="List tools from every [monorepo].config_roots config root" env=MISE_MONOREPO {

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -92,7 +92,7 @@ pub(crate) struct Ls {
     tool_flag: Option<BackendArg>,
 
     /// Display all tracked config sources for tools
-    #[usage(long, conflicts = &["current", "global", "local", "prunable"])]
+    #[usage(long, short, conflicts = &["current", "global", "local", "prunable"])]
     all_sources: bool,
 
     /// List tools from every [monorepo].config_roots config root


### PR DESCRIPTION
## Summary
- Add `-a` as the short flag for `mise ls --all-sources`, using the same `#[usage(long, short)]` pattern as `-l`/`--local` and `-g`/`--global`.
- `mise ls -a` is equivalent to `mise ls --all-sources` and keeps the existing conflicts (`--current`, `--global`, `--local`, `--prunable`).
- Update CLI help (`mise.usage.kdl`, `docs/cli/ls.md`) and cover `-a` in `e2e/cli/test_ls_all_sources`.

## Test plan
- [x] `mise ls -h` shows `-a, --all-sources`
- [x] `mise run test:e2e e2e/cli/test_ls_all_sources` (includes `mise ls dummy -a` and `-a --json`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `-a` short form for the `mise ls --all-sources` option.
  * The short form produces the same text and JSON output as the long form.

* **Documentation**
  * Updated CLI documentation and the manual to include the new `-a` alias.

* **Tests**
  * Added end-to-end coverage confirming equivalent text and JSON results for both option forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->