### PR TITLE
fix(http): retry when a response body drops mid-stream

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -52,6 +52,16 @@ static UNAVAILABLE_HTTP_HOSTS: Lazy<Mutex<HashMap<String, String>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 type RetryStateHandle = Arc<Mutex<RetryState>>;
 
+/// The parts of a request that stay fixed across retry attempts.
+struct RetryableRequest<'a> {
+    method: Method,
+    url: Url,
+    headers: &'a HeaderMap,
+    verb_label: &'a str,
+    retries: i64,
+    error_for_status: bool,
+}
+
 #[derive(Debug)]
 struct UnavailableHttpHost {
     origin: String,
@@ -600,9 +610,21 @@ impl Client {
     }
 
     pub(crate) async fn get_bytes<U: IntoUrl>(&self, url: U) -> Result<impl AsRef<[u8]>> {
+        ensure!(!Settings::get().offline(), "offline mode is enabled");
         let url = url.into_url()?;
-        let resp = self.get_async(url.clone()).await?;
-        Ok(resp.bytes().await?)
+        let headers = host_auth_headers(&url)?;
+        self.send_with_retries(
+            RetryableRequest {
+                method: Method::GET,
+                url,
+                headers: &headers,
+                verb_label: "GET",
+                retries: Settings::get().http_retries(),
+                error_for_status: true,
+            },
+            |resp| async move { Ok(resp.bytes().await?) },
+        )
+        .await
     }
 
     pub(crate) async fn get_async<U: IntoUrl>(&self, url: U) -> Result<Response> {
@@ -730,10 +752,8 @@ impl Client {
         T: serde::de::DeserializeOwned,
     {
         let url = url.into_url()?;
-        let resp = self.get_async(url).await?;
-        let headers = resp.headers().clone();
-        let json = resp.json().await?;
-        Ok((json, headers))
+        let headers = host_auth_headers(&url)?;
+        self.json_headers_with_headers(url, &headers).await
     }
 
     pub(crate) async fn json_headers_with_headers<T, U: IntoUrl>(
@@ -744,11 +764,23 @@ impl Client {
     where
         T: serde::de::DeserializeOwned,
     {
+        ensure!(!Settings::get().offline(), "offline mode is enabled");
         let url = url.into_url()?;
-        let resp = self.get_async_with_headers(url, headers).await?;
-        let headers = resp.headers().clone();
-        let json = resp.json().await?;
-        Ok((json, headers))
+        self.send_with_retries(
+            RetryableRequest {
+                method: Method::GET,
+                url,
+                headers,
+                verb_label: "GET",
+                retries: Settings::get().http_retries(),
+                error_for_status: true,
+            },
+            |resp| async move {
+                let headers = resp.headers().clone();
+                Ok((resp.json().await?, headers))
+            },
+        )
+        .await
     }
 
     pub(crate) async fn json<T, U: IntoUrl>(&self, url: U) -> Result<T>
@@ -1157,13 +1189,16 @@ impl Client {
         headers: &HeaderMap,
         verb_label: &str,
     ) -> Result<Response> {
-        self.send_with_https_fallback_with_retries(
-            method,
-            url,
-            headers,
-            verb_label,
-            Settings::get().http_retries(),
-            true,
+        self.send_with_retries(
+            RetryableRequest {
+                method,
+                url,
+                headers,
+                verb_label,
+                retries: Settings::get().http_retries(),
+                error_for_status: true,
+            },
+            |resp| async move { Ok(resp) },
         )
         .await
     }
@@ -1175,30 +1210,45 @@ impl Client {
         headers: &HeaderMap,
         verb_label: &str,
     ) -> Result<Response> {
-        self.send_with_https_fallback_with_retries(
-            method,
-            url,
-            headers,
-            verb_label,
-            Settings::get().http_retries(),
-            false,
+        self.send_with_retries(
+            RetryableRequest {
+                method,
+                url,
+                headers,
+                verb_label,
+                retries: Settings::get().http_retries(),
+                error_for_status: false,
+            },
+            |resp| async move { Ok(resp) },
         )
         .await
     }
 
-    async fn send_with_https_fallback_with_retries(
-        &self,
-        method: Method,
-        url: Url,
-        headers: &HeaderMap,
-        verb_label: &str,
-        retries: i64,
-        error_for_status: bool,
-    ) -> Result<Response> {
+    /// Send with retries, turning the response into `T` inside the retried unit.
+    ///
+    /// reqwest resolves a request as soon as the response headers arrive, so a
+    /// retry that stops there leaves body streaming unprotected: a connection
+    /// dropped mid-body surfaces as `error decoding response body` and fails
+    /// outright, even though [`is_transient`] already classifies
+    /// `reqwest::Error::is_body()` as retryable.
+    async fn send_with_retries<T, F, Fut>(&self, req: RetryableRequest<'_>, read: F) -> Result<T>
+    where
+        F: Fn(Response) -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        let RetryableRequest {
+            method,
+            url,
+            headers,
+            verb_label,
+            retries,
+            error_for_status,
+        } = req;
         let retry_state = Arc::new(Mutex::new(RetryState {
             headers: headers.clone(),
             use_netrc: true,
         }));
+        let read = &read;
         retry_async_with_retries(verb_label, &url, retries, || async {
             let (headers, use_netrc) = {
                 let state = retry_state.lock().unwrap();
@@ -1210,14 +1260,16 @@ impl Client {
             } else {
                 options.allow_error_status()
             };
-            self.send_once_with_https_fallback_with_retry_headers(
-                method.clone(),
-                url.clone(),
-                &headers,
-                verb_label,
-                options,
-            )
-            .await
+            let resp = self
+                .send_once_with_https_fallback_with_retry_headers(
+                    method.clone(),
+                    url.clone(),
+                    &headers,
+                    verb_label,
+                    options,
+                )
+                .await?;
+            read(resp).await
         })
         .await
     }
@@ -1538,18 +1590,20 @@ impl TextRequest<'_> {
         // Merge GitHub headers with any extra headers provided
         let mut headers = host_auth_headers(&url)?;
         headers.extend(self.extra_headers.clone());
-        let resp = self
+        let text = self
             .client
-            .send_with_https_fallback_with_retries(
-                Method::GET,
-                url.clone(),
-                &headers,
-                "GET",
-                self.retries,
-                true,
+            .send_with_retries(
+                RetryableRequest {
+                    method: Method::GET,
+                    url: url.clone(),
+                    headers: &headers,
+                    verb_label: "GET",
+                    retries: self.retries,
+                    error_for_status: true,
+                },
+                |resp| async move { Ok(resp.text().await?) },
             )
             .await?;
-        let text = resp.text().await?;
         if text.starts_with("<!DOCTYPE html>") {
             if url.scheme() == "http" {
                 // try with https since http may be blocked
@@ -2688,6 +2742,29 @@ mod tests {
     fn ok_response() -> &'static str {
         "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
     }
+    // Declares 21 bytes of JSON and sends 13 before closing. reqwest surfaces
+    // that as `error decoding response body`, the exact shape GitHub's
+    // `/releases?page=2` produces for repos with thousands of releases.
+    fn truncated_json_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Type: application/json\r\n",
+            "Content-Length: 21\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "[{\"tag_name\":"
+        )
+    }
+    fn json_array_response() -> &'static str {
+        concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Type: application/json\r\n",
+            "Content-Length: 21\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "[{\"tag_name\":\"v1.0\"}]"
+        )
+    }
     fn truncated_download_response() -> &'static str {
         concat!(
             "HTTP/1.1 200 OK\r\n",
@@ -3353,6 +3430,24 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         assert!(resp.status().is_success());
         // Should have served 3 connections: two 502s + one 200.
         assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_json_retries_when_body_drops_mid_stream() {
+        // reqwest resolves a request as soon as the headers land, so a retry that
+        // stops there never covers body streaming. `is_transient` already calls
+        // `reqwest::Error::is_body()` retryable; this asserts the retry boundary
+        // actually reaches it.
+        let _guard = set_test_http_retries(1);
+        let (port, count) =
+            spawn_canned_server(vec![truncated_json_response(), json_array_response()]).await;
+        let url: Url = format!("http://127.0.0.1:{port}/").parse().unwrap();
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+        let (releases, _headers): (Vec<serde_json::Value>, _) =
+            client.json_headers(url).await.unwrap();
+        assert_eq!(releases.len(), 1);
+        // Two connections: the truncated body, then the complete one.
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 2);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -4146,6 +4241,20 @@ refresh_expires_at = "2099-01-01T00:00:00Z"
         assert!(format!("{err:?}").contains("502"));
         // Should stop after the initial request plus the single overridden retry.
         assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_json_headers_respects_offline_mode() {
+        let _guard = set_test_offline();
+        let (port, count) = spawn_canned_server(vec![json_array_response()]).await;
+        let url: Url = format!("http://127.0.0.1:{port}/").parse().unwrap();
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+        let err = client
+            .json_headers::<Vec<serde_json::Value>, _>(url)
+            .await
+            .unwrap_err();
+        assert_eq!(err.to_string(), "offline mode is enabled");
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 0);
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Problem

`is_transient` classifies `reqwest::Error::is_body()` as retryable — the comment there literally says "mid-stream body drop" — but the retry boundary stopped one step short of reaching it. reqwest resolves a request as soon as the response headers arrive, so the retry loop behind `send_with_https_fallback` returned a `Response`, and every caller then read the body outside the loop:

```rust
let resp = self.get_async_with_headers(url, headers).await?; // retried
let json = resp.json().await?;                               // not retried
```

A response that dies partway through streaming therefore failed on the first attempt regardless of `http_retries`. The same gap existed in `TextRequest::send` (which backs `get_text`, ~30 call sites) and `get_bytes`.

## Change

Generalize the existing retry loop over how the response is consumed rather than adding a second loop beside it. `send_with_retries` takes a `read` closure and runs it inside the retried unit:

- callers that buffer a whole body pass a reader that consumes it, so the read is covered
- callers that need the raw `Response` — HEAD, streamed downloads, bounded error-body inspection — pass an identity reader and behave exactly as before

Rewired: `json_headers`, `json_headers_with_headers`, `TextRequest::send`, `get_bytes`. Each keeps its own decoding (`json()` / `text()` / `bytes()`), so charset handling and deserialization are unchanged.

`get_html` is deliberately untouched: it rejects non-HTML by inspecting `Content-Type` before touching the body, and moving the read inside the retry would make it download bodies it currently discards.

## How this was found

`jdx/mise-versions` has been unable to refresh the `codex` entry since 2026-09-01; `data/codex.toml` is frozen at `0.153.0-alpha.2` while upstream is at `0.153.4`, so `mise latest codex` resolves to `0.152.0`. Its 30-minute job fails on page 2 of `openai/codex`'s releases:

```
GET https://api.github.com/repos/openai/codex/releases?per_page=100              200 OK
GET https://api.github.com/repositories/965415649/releases?per_page=100&page=2   200 OK
mise WARN  Remote versions cannot be fetched for openai/codex: error decoding
           response body for url (...page=2): request or response body error
mise ERROR unable to fetch versions for codex
```

**This patch alone will not fix that case**, and I would rather say so up front than imply otherwise. The payload is the real problem there. Measured on page 1 of that endpoint:

| | bytes | share |
| --- | ---: | ---: |
| whole page (100 releases) | 27,488,411 | 100% |
| `assets[]` | 27,158,425 | 98.8% |
| └ `uploader` sub-objects | 17,636,408 | 64.2% |
| `body` (changelogs) | 118,189 | 0.4% |
| fields `GithubRelease`/`GithubAsset` keep | ~792,747 | ~2.9% |

That page carries 16,004 assets (~160 per release), and the `uploader` object — which mise never deserializes — is repeated once per asset. With `MISE_LIST_ALL_VERSIONS=1`, which `mise-versions` sets, that is 11 pages and roughly 300 MB per refresh to produce a ~40 KB TOML. GitHub itself returns 504 on this endpoint often enough that `gh api` hit one while I was measuring.

So retrying a 27 MB request that dropped mid-stream will often just drop again. Shrinking the request is a separate change with its own trade-offs — GraphQL field selection, or backing `per_page` off after a body-drop retry — and I did not want to fold it into a bug fix.

What this patch does fix is the general case it exposed: a transient body drop is already classified as retryable, and now the retry actually covers it.

## Tests

`test_json_retries_when_body_drops_mid_stream`: a canned server declares `Content-Length: 21`, sends 13 bytes, and closes; the second attempt serves the full body. Reverting the production change makes it fail with the same error seen in CI above:

```
error decoding response body for url (http://127.0.0.1:.../)
Caused by:
   0: request or response body error
   1: error reading a body from connection
   2: end of file before message length reached
```

`test_json_headers_respects_offline_mode`: `json_headers` used to inherit the offline guard from `get_async_with_headers`, which this change routes around; the test pins the behavior. Reverting the guard makes it fail.

Verification:

```
MBX_DISABLE=1 cargo test http::                    103 passed, 0 failed
MBX_DISABLE=1 cargo fmt --check                    clean
MBX_DISABLE=1 cargo clippy --workspace --all-features --all-targets -- -D warnings
                                                   clean, no allow attributes
```

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5[1m]; version: 2.1.263.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of HTTP requests by retrying failures that occur while reading response bodies.
  - Added consistent retry handling for JSON, text, byte, and standard GET responses.
  - JSON requests now correctly reject when offline mode is enabled.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->