### PR TITLE
fix: release target repo is missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -673,6 +673,7 @@ jobs:
       - name: Publish the CLI specification and completions
         env:
           GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: gh release upload "$GITHUB_REF_NAME" mise.usage.kdl mise.bash mise.zsh mise.fish mise.powershell --clobber
       # `out: .` keeps the bundle beside mise.usage.kdl. The action defaults to
       # writing it under packslip/, and an artifact holding files at two
@@ -793,6 +794,7 @@ jobs:
       - name: Download draft release assets
         env:
           GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.finish-draft-resolve.outputs.tag }}
         run: |
           mkdir -p release-assets
@@ -844,6 +846,7 @@ jobs:
       - name: Publish the CLI specification and completions
         env:
           GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.finish-draft-resolve.outputs.tag }}
         run: gh release upload "$TAG" mise.usage.kdl mise.bash mise.zsh mise.fish mise.powershell --clobber
       - uses: jdx/packslip@a0d434ad57571c62dbd0ab5095b4eff607a71fd3 # v1.1.1


### PR DESCRIPTION
Due to 7dbd245e5 / #12812, which introduced a `gh release upload` command without `actions/checkout` in the release workflow, the most recent run [failed](https://github.com/jdx/mise/actions/runs/34196500043/job/101991447184#step:4:12).

By using `GH_REPO`, `gh` can identify the target of a release without `actions/checkout`.

Ref:
- https://github.com/jdx/mise/pull/12934#issuecomment-5582165595
- https://github.com/jdx/mise-action/issues/616
- https://github.com/jdx/mise-action/issues/617
- https://github.com/jdx/mise/discussions/12975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release automation consistency when publishing CLI specifications, completions, and draft release assets.
  - Release workflows now reliably target the repository associated with the current release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->