### PR TITLE
fix(release): publish CDN after GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -520,6 +520,26 @@ jobs:
       - run: echo "$HOME/mise/bin" >> "$GITHUB_PATH"
       - run: which mise && mise -v && mise i
       - run: mise x -- scripts/release.sh
+      # Keep the mutable CDN files available until the GitHub release is
+      # public. Publishing it here would advance VERSION while the release is
+      # still a draft, so mise-action could resolve a version whose GitHub
+      # assets return 404.
+      - name: Stage latest CDN files
+        if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cdn-latest
+          path: |
+            releases/mise-latest-*
+            !releases/mise-latest-*.tar.gz
+            !releases/mise-latest-*.tar.xz
+            !releases/mise-latest-*.tar.zst
+            !releases/mise-latest-*.zip
+            releases/SHASUMS*
+            releases/install.sh*
+            artifacts/mise.run
+          if-no-files-found: error
+          retention-days: 1
       - name: Stage release assets for attestation
         if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -587,13 +607,6 @@ jobs:
           EXISTING_DRAFT: ${{ steps.check-release.outputs.draft }}
           EXISTING_RELEASE_ID: ${{ steps.check-release.outputs.release-id }}
           GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
-      - name: Publish Release Assets to CDN
-        if: startsWith(github.ref, 'refs/tags/v') && steps.check-release.outputs.exists != 'true'
-        run: mise x -- scripts/publish-release.sh
-        env:
-          CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
-          CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
 
   # !cancelled() replaces the implicit success() gate. Tag publishes skip
   # e2e-linux; release still runs via !cancelled(), but without a status
@@ -744,6 +757,49 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.MISE_GH_TOKEN }}
           RELEASE_ID: ${{ needs.release.outputs.release-id }}
+
+  publish-cdn:
+    needs:
+      - release
+      - publish-release
+    if: ${{ !cancelled() && needs.release.outputs.created == 'true' && needs.publish-release.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Download versioned release files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-assets
+          path: releases/${{ github.ref_name }}
+      - name: Download latest CDN files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: cdn-latest
+          path: .
+      - name: Download RPM repository
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: rpm
+          path: artifacts/rpm
+      - name: Download Debian repository
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: deb
+          path: artifacts/deb
+      - name: Use the mise binary from this release
+        run: |
+          mkdir -p "$HOME/mise"
+          tar -xzf "releases/$GITHUB_REF_NAME/mise-$GITHUB_REF_NAME-linux-x64.tar.gz" -C "$HOME/mise" --strip-components=1
+          echo "$HOME/mise/bin" >> "$GITHUB_PATH"
+      - name: Publish release assets to CDN
+        run: mise x -- scripts/publish-release.sh
+        env:
+          CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+          CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
 
   # Finish a draft that already has build assets (no tarball rebuild). Used
   # when attest/packslip/publish were skipped — e.g. v2026.9.2 after tag e2e

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# This script runs after the GitHub release is successfully created
-# It updates the VERSION file and publishes to R2
+# This script runs only after the GitHub release is public. It updates the
+# mutable latest files, including VERSION, while publishing the release to R2.
 
 BASE_DIR="$(pwd)"
 MISE_VERSION=$(./scripts/get-version.sh)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -86,4 +86,4 @@ curl -L -o "$TMP_FILE" "https://github.com/jdx/mise/archive/refs/tags/$MISE_VERS
 gpg --detach-sign -u 8B81C9D17413A06D <"$TMP_FILE" >"$RELEASE_DIR/$MISE_VERSION/$MISE_VERSION.tar.gz.sig"
 rm "$TMP_FILE"
 
-# Publishing is now done after GitHub release is created
+# CDN publishing is done after the GitHub release is public.


### PR DESCRIPTION
## Summary
- stage mutable CDN files while the GitHub release is still a draft
- publish the complete CDN payload only after release assets are verified and the GitHub release is public
- run the CDN publication with the mise binary built for that release

This prevents `https://mise.jdx.dev/VERSION` from advancing to a version whose GitHub release assets still return 404, as reported in jdx/mise-action#616. If attestation, packslip generation, or publication fails, the CDN continues serving the previous working release.

## Testing
- `hk` safe check (schema, formatting, Cargo check, ShellCheck, Actionlint, and repository linters)

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reorders the production release pipeline and CDN upload timing; a miswired job dependency could leave CDN stale or skip publish, but the change reduces the prior race where clients saw a new VERSION with 404 assets.
> 
> **Overview**
> **Delays R2/CDN publication** until after attestation, packslip, asset verification, and flipping the GitHub release out of draft—so `VERSION` and other `mise-latest-*` pointers on the CDN no longer move ahead of downloadable GitHub assets.
> 
> The `release` job **stops calling** `scripts/publish-release.sh` inline and instead **uploads a `cdn-latest` artifact** (latest symlinks/metadata, checksums, `install.sh`, `mise.run`; not the large archive blobs). A new **`publish-cdn` job** runs only when `publish-release` succeeds, rehydrates `release-assets`, `cdn-latest`, rpm/deb artifacts, installs the **linux-x64 binary from that tag**, then runs `publish-release.sh`. Comments in `release.sh` and `publish-release.sh` document the new ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b4a3ba2fad8dab967e1bea5c389dee07a538b61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to stage the latest CDN files and publish them in a follow-up step after the release is public.
  * Excluded archive files from the staged latest-file artifact.
  * Clarified release-script documentation for publishing mutable latest files, including the version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->