### PR TITLE
feat(task): add task-scoped quiet setting

### DIFF
--- a/docs/tasks/running-tasks.md
+++ b/docs/tasks/running-tasks.md
@@ -30,7 +30,15 @@ The output _style_ (`prefix`, `interleave`, `keep-order`, …) is independent of
 (`--quiet`/`--silent`, the `quiet`/`silent` settings, or the per-task `quiet`/`silent` fields).
 They combine: e.g. `MISE_TASK_OUTPUT=prefix` with `--quiet` keeps the task-name prefixes while
 suppressing mise's own messages. `--quiet` no longer forces un-prefixed output — use
-`--output quiet` (or `-o interleave`) if you want the old un-prefixed behavior.
+`--output interleave --quiet` if you want the old un-prefixed behavior. To make every task quiet
+without affecting other mise commands, set both `task.output = "interleave"` and
+`task.quiet = true` under `[settings]`.
+
+::: warning Deprecated
+The `quiet` output value is deprecated. Warnings begin in mise `2027.3.0`, and support will be
+removed in `2028.3.0`. Combine `interleave` with the task-scoped or command-line quiet option
+instead.
+:::
 
 Stdin is not connected by default. Set `interactive = true` for a task that needs
 the terminal; it has exclusive terminal access for the duration of the task.

--- a/docs/tasks/running-tasks.md
+++ b/docs/tasks/running-tasks.md
@@ -35,8 +35,8 @@ without affecting other mise commands, set both `task.output = "interleave"` and
 `task.quiet = true` under `[settings]`.
 
 ::: warning Deprecated
-The `quiet` output value is deprecated. Warnings begin in mise `2027.3.0`, and support will be
-removed in `2028.3.0`. Combine `interleave` with the task-scoped or command-line quiet option
+The `quiet` output value is deprecated. Warnings begin in mise `2026.9.3`, and support will be
+removed in `2027.9.3`. Combine `interleave` with the task-scoped or command-line quiet option
 instead.
 :::
 

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -860,6 +860,12 @@ Output _style_ for this task: `prefix`, `interleave`, `keep-order`, `replacing`,
 (e.g. `output = "prefix"` + `quiet = true`). The `quiet`/`silent` _values_ are kept for backwards
 compatibility and bundle a style with that verbosity.
 
+::: warning Deprecated
+The `quiet` output value is deprecated. Warnings begin in mise `2027.3.0`, and support will be
+removed in `2028.3.0`. Use `output = "interleave"` with `quiet = true` instead. For a global task
+default, use `task.output = "interleave"` with `task.quiet = true` under `[settings]`.
+:::
+
 ### `usage`
 
 - **Type**: `string`

--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -861,8 +861,8 @@ Output _style_ for this task: `prefix`, `interleave`, `keep-order`, `replacing`,
 compatibility and bundle a style with that verbosity.
 
 ::: warning Deprecated
-The `quiet` output value is deprecated. Warnings begin in mise `2027.3.0`, and support will be
-removed in `2028.3.0`. Use `output = "interleave"` with `quiet = true` instead. For a global task
+The `quiet` output value is deprecated. Warnings begin in mise `2026.9.3`, and support will be
+removed in `2027.9.3`. Use `output = "interleave"` with `quiet = true` instead. For a global task
 default, use `task.output = "interleave"` with `task.quiet = true` under `[settings]`.
 :::
 

--- a/e2e/tasks/test_task_output_style_decoupling
+++ b/e2e/tasks/test_task_output_style_decoupling
@@ -15,10 +15,11 @@ assert_contains "mise run hello 2>&1" "[hello] hello world"
 # the command-echo header (`[hello] \$ echo ...`) must be suppressed by quiet
 assert_not_contains "mise run hello 2>&1" '$ echo'
 
-# (b) legacy task.output="quiet" value stays un-prefixed (maps to interleave).
+# (b) task.quiet suppresses mise's task messages without changing output style.
 cat <<EOF >mise.toml
 [settings]
-task.output = "quiet"
+task.output = "interleave"
+task.quiet = true
 [tasks.a]
 run = 'echo running a'
 [tasks.d]
@@ -26,6 +27,16 @@ run = 'echo running d'
 EOF
 assert_not_contains "mise run a ::: d 2>&1" "[a] running a"
 assert_contains "mise run a ::: d 2>&1" "running a"
+assert_not_contains "mise run a ::: d 2>&1" '$ echo'
+
+# The legacy task.output="quiet" value remains compatible during deprecation.
+cat <<EOF >mise.toml
+[settings]
+task.output = "quiet"
+[tasks.a]
+run = 'echo running a'
+EOF
+assert "mise run a 2>&1" "running a"
 
 # (c) silent (per-task output value) -> nothing at all.
 cat <<EOF >mise.toml

--- a/e2e/tasks/test_task_output_style_decoupling
+++ b/e2e/tasks/test_task_output_style_decoupling
@@ -36,7 +36,10 @@ task.output = "quiet"
 [tasks.a]
 run = 'echo running a'
 EOF
-assert "mise run a 2>&1" "running a"
+assert_contains "mise run a 2>&1" "running a"
+assert_not_contains "mise run a 2>&1" "[a] running a"
+assert_not_contains "mise run a 2>&1" '$ echo'
+assert_contains "mise run a 2>&1" "deprecated [task-output-quiet]"
 
 # (c) silent (per-task output value) -> nothing at all.
 cat <<EOF >mise.toml

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2129,6 +2129,11 @@
                 "silent"
               ]
             },
+            "quiet": {
+              "default": false,
+              "description": "Suppress mise's own output while executing tasks.",
+              "type": "boolean"
+            },
             "remote_no_cache": {
               "description": "Mise will always fetch the latest tasks from the remote, by default the cache is used.",
               "type": "boolean"

--- a/settings.toml
+++ b/settings.toml
@@ -3466,11 +3466,19 @@ docs = """
 Change output style when executing tasks. This controls the output of `mise run`.
 
 This is the output *style* axis. Verbosity is a separate axis controlled by
-`quiet`/`silent` (as settings, `--quiet`/`--silent` flags, or per-task fields),
-so a style can be combined with quietness — e.g. `output = "prefix"` together
-with `quiet = true` keeps the task-name prefixes while suppressing mise's own
-messages. The `quiet` and `silent` *values* below are kept for backwards
-compatibility and bundle a style with that verbosity.
+`task.quiet`/`silent` (as settings, `--quiet`/`--silent` flags, or per-task
+fields), so a style can be combined with quietness — e.g. `output = "prefix"`
+together with `task.quiet = true` keeps the task-name prefixes while suppressing
+mise's own task messages. The `quiet` and `silent` *values* below are kept for
+backwards compatibility and bundle a style with that verbosity.
+
+::: warning Deprecated
+The `quiet` output value is deprecated. Warnings begin in mise `2027.3.0`, and
+support will be removed in `2028.3.0`. For a global task default, use
+`task.output = "interleave"` with `task.quiet = true`. For an individual task,
+use `output = "interleave"` with `quiet = true`. On the command line, use
+`--output interleave --quiet`.
+:::
 """
 enum = [
   { value = "prefix", description = "(default if jobs > 1) print by line with the prefix of the task name" },
@@ -3478,13 +3486,25 @@ enum = [
   { value = "keep-order", description = "stream one task's output live while buffering others, printing in definition order as tasks complete" },
   { value = "replacing", description = "replace stdout each time a line is printed-this uses similar logic as `mise install`" },
   { value = "timed", description = "only show stdout lines that take longer than 1s to complete" },
-  { value = "quiet", description = "legacy: interleave task output and suppress mise's own messages (equivalent to `interleave` + `quiet = true`). Prefer `--quiet`/`quiet = true` to keep your chosen style." },
+  { value = "quiet", description = "deprecated: interleave task output and suppress mise's own messages. Use `interleave` with the appropriate quiet setting or flag." },
   { value = "silent", description = "print nothing from tasks or mise (nulls stdout and stderr)" },
 ]
 env = "MISE_TASK_OUTPUT"
 optional = true
 rust_type = "crate::task::TaskOutput"
 type = "String"
+
+[task.quiet]
+default = false
+description = "Suppress mise's own output while executing tasks."
+docs = """
+Suppress mise's own output while executing tasks without affecting other mise
+commands. Task stdout and stderr remain visible. This setting is independent of
+the `task.output` style, so it can be combined with `prefix`, `interleave`, or
+another output style.
+"""
+env = "MISE_TASK_QUIET"
+type = "Bool"
 
 [task.remote_no_cache]
 description = "Mise will always fetch the latest tasks from the remote, by default the cache is used."

--- a/settings.toml
+++ b/settings.toml
@@ -3473,8 +3473,8 @@ mise's own task messages. The `quiet` and `silent` *values* below are kept for
 backwards compatibility and bundle a style with that verbosity.
 
 ::: warning Deprecated
-The `quiet` output value is deprecated. Warnings begin in mise `2027.3.0`, and
-support will be removed in `2028.3.0`. For a global task default, use
+The `quiet` output value is deprecated. Warnings begin in mise `2026.9.3`, and
+support will be removed in `2027.9.3`. For a global task default, use
 `task.output = "interleave"` with `task.quiet = true`. For an individual task,
 use `output = "interleave"` with `quiet = true`. On the command line, use
 `--output interleave --quiet`.

--- a/src/task/task_output.rs
+++ b/src/task/task_output.rs
@@ -36,7 +36,15 @@ impl TaskOutput {
     /// `OutputHandler::output`), so it passes through unchanged.
     pub(crate) fn style_only(self) -> TaskOutput {
         match self {
-            TaskOutput::Quiet => TaskOutput::Interleave,
+            TaskOutput::Quiet => {
+                deprecated_at!(
+                    "2027.3.0",
+                    "2028.3.0",
+                    "task-output-quiet",
+                    "The quiet task output mode is deprecated. Use output=\"interleave\" with task.quiet=true or a per-task quiet=true, or use --output interleave --quiet."
+                );
+                TaskOutput::Interleave
+            }
             other => other,
         }
     }

--- a/src/task/task_output.rs
+++ b/src/task/task_output.rs
@@ -38,8 +38,8 @@ impl TaskOutput {
         match self {
             TaskOutput::Quiet => {
                 deprecated_at!(
-                    "2027.3.0",
-                    "2028.3.0",
+                    "2026.9.3",
+                    "2027.9.3",
                     "task-output-quiet",
                     "The quiet task output mode is deprecated. Use output=\"interleave\" with task.quiet=true or a per-task quiet=true, or use --output interleave --quiet."
                 );

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -677,6 +677,7 @@ impl OutputHandler {
     pub(crate) fn quiet(&self, task: Option<&Task>) -> bool {
         self.quiet
             || Settings::get().quiet
+            || Settings::get().task.quiet
             || self.output.is_some_and(|o| o.is_quiet())
             || Settings::get().task.output.is_some_and(|o| o.is_quiet())
             || task.is_some_and(|t| t.quiet)

--- a/src/task/task_output_handler.rs
+++ b/src/task/task_output_handler.rs
@@ -674,6 +674,7 @@ impl OutputHandler {
             || task.is_some_and(|t| t.output.is_some_and(|o| o.is_silent()))
     }
 
+    /// Return whether mise-generated output should be suppressed for this task.
     pub(crate) fn quiet(&self, task: Option<&Task>) -> bool {
         self.quiet
             || Settings::get().quiet


### PR DESCRIPTION
## Summary

- add `task.quiet` and `MISE_TASK_QUIET` for suppressing mise task messages without affecting other commands
- deprecate the bundled `output = "quiet"` mode in favor of explicit output style and verbosity settings
- document the migration and regenerate the configuration schema

## Deprecation

The documentation and runtime warning deprecate the output mode immediately in `2026.9.3`. Removal is scheduled for `2027.9.3`, twelve months after warnings begin.

Addresses https://github.com/jdx/mise/discussions/12976

## Testing

- `mise run render`
- `mise run test:e2e e2e/tasks/test_task_output_style_decoupling e2e/tasks/test_task_run_output`
- `mise run lint-fix`
- `mise run render:schema`
- `taplo check settings.toml`
- `markdownlint docs/tasks/running-tasks.md docs/tasks/task-configuration.md`
- `cargo fmt --all -- --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `task.quiet` setting to suppress mise-generated task messages while preserving task output.
  - Added support for configuring quiet interleaved output globally or per task.

- **Documentation**
  - Updated task configuration and task-running guidance with the recommended `interleave` plus `quiet` configuration.
  - Documented deprecation warnings beginning in 2026.9.3 and removal of the `quiet` output value in 2027.9.3.

- **Bug Fixes**
  - Quiet mode now consistently suppresses task prefixes and command-echo headers without hiding task output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->