### PR TITLE
fix(dotfiles): resolve history filters through portable roots

### DIFF
--- a/e2e/cli/test_dotfiles_history_home_alias
+++ b/e2e/cli/test_dotfiles_history_home_alias
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# History filters use the same portable paths as checkpoints when HOME is a link.
+require_cmd git
+require_cmd jq
+canonical_home="$HOME"
+ln -s "$canonical_home" "$TMPDIR/home-alias"
+export HOME="$TMPDIR/home-alias"
+echo one >"$HOME/history-file"
+ln -s history-file "$HOME/history-link"
+assert_succeed "mise bootstrap dotfiles track '$HOME/history-file' '$HOME/history-link'"
+for name in history-file history-link; do
+  assert "mise bootstrap dotfiles history ls --path '$HOME/$name' --json | jq length" 1
+  assert_succeed "mise bootstrap dotfiles history show latest --path '$canonical_home/$name' --json"
+  assert_succeed "mise bootstrap dotfiles history diff --path '~/$name' --exit-code"
+done
+echo two >"$HOME/history-file"
+assert_fail "mise bootstrap dotfiles history diff --path '$HOME/history-file' --exit-code"
+assert_succeed "mise bootstrap dotfiles history diff --path '$HOME/history-link' --exit-code"

--- a/src/cli/dotfiles/history/mod.rs
+++ b/src/cli/dotfiles/history/mod.rs
@@ -84,10 +84,11 @@ pub(crate) fn resolve(spec: &str, entries: &[Entry], path: Option<&str>) -> Resu
 
 /// The display form of a path argument (`~/…` under `$HOME`).
 pub(crate) fn display_arg(path: &str) -> String {
-    // the link itself, never its destination
-    crate::file::display_path(crate::system::history::tracked::normalize_target(
-        std::path::Path::new(path),
-    ))
+    // Use the checkpoint's portable root mapping. Normalizing the target and
+    // abbreviating against the unnormalized HOME loses root aliases. The tree
+    // conversion also preserves a symlink leaf rather than following it.
+    use crate::system::history::tracked::{display_to_tree_path, tree_path_to_display};
+    tree_path_to_display(&display_to_tree_path(path))
 }
 
 pub(crate) fn local_time(rfc3339: &str) -> String {


### PR DESCRIPTION
When HOME is a symlink, history records a tracked file as `~/file` but `--path` previously compared its canonical absolute path. Lists came back empty, and `show latest` or `diff` reported that no checkpoint existed.

Resolve the filter through the same snapshot-tree mapping used by checkpoints. Aliased, canonical, and tilde paths now address the same history entry, while a tracked symlink still addresses the link itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dotfiles history path handling when the home directory is accessed through a symlink or alias.
  - History listing, viewing, and diff commands now consistently recognize paths expressed through aliased home directories, canonical paths, or `~`.
  - Symlinked history files are displayed without incorrectly resolving their final path component.

- **Tests**
  - Added end-to-end coverage for history commands in aliased home-directory environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->