### PR TITLE
feat(bootstrap): support current-host macOS defaults

### DIFF
--- a/docs/bootstrap/macos-defaults.md
+++ b/docs/bootstrap/macos-defaults.md
@@ -158,21 +158,27 @@ sudo. `sudo defaults` system domains are not supported.
 
 ## Current-host preferences
 
-Use `defaults_current_host` for preferences normally written with
-`defaults -currentHost`:
+Use an explicit entry for preferences normally written with `defaults -currentHost`:
 
 ```toml
-[bootstrap.macos.defaults_current_host.NSGlobalDomain]
-"com.apple.mouse.tapBehavior" = 1
+[[bootstrap.macos.defaults_entries]]
+domain = "NSGlobalDomain"
+key = "com.apple.mouse.tapBehavior"
+host = "current"
+value = 1
 ```
 
-This accepts the same typed values as `defaults`, including arrays and tables.
-Reads, writes, and synchronization use the current host. The two sections can
-manage the same domain and key independently: entries in `defaults` retain their
-any-host scope. Each scope merges global → local by domain and key.
+Entries accept the same typed values as `defaults`, including arrays and tables.
+The optional `host` is `"any"` by default; `"current"` scopes reads, writes, and
+synchronization to the current host. The same domain and key can be managed
+independently in each scope.
+
+Preferences merge global → local by domain, key, and host. Explicit entries
+override shorthand defaults in the same file. The global-domain aliases `-g`
+and `-globalDomain` share the identity of `NSGlobalDomain`.
 
 Status labels current-host domains with `(current host)` and JSON entries include
-`current_host`. Scalar dry-runs include `-currentHost`.
+`host`. Scalar dry-runs include `-currentHost`.
 
 ## Commands
 

--- a/docs/bootstrap/macos-defaults.md
+++ b/docs/bootstrap/macos-defaults.md
@@ -154,8 +154,25 @@ type and is also not supported.
   typed value.
 
 User defaults are per-user, so unlike system packages they never involve
-sudo. Host-scoped preferences (`defaults -currentHost`) and `sudo
-defaults` system domains are not supported.
+sudo. `sudo defaults` system domains are not supported.
+
+## Current-host preferences
+
+Use `defaults_current_host` for preferences normally written with
+`defaults -currentHost`:
+
+```toml
+[bootstrap.macos.defaults_current_host.NSGlobalDomain]
+"com.apple.mouse.tapBehavior" = 1
+```
+
+This accepts the same typed values as `defaults`, including arrays and tables.
+Reads, writes, and synchronization use the current host. The two sections can
+manage the same domain and key independently: entries in `defaults` retain their
+any-host scope. Each scope merges global → local by domain and key.
+
+Status labels current-host domains with `(current host)` and JSON entries include
+`current_host`. Scalar dry-runs include `-currentHost`.
 
 ## Commands
 

--- a/e2e/cli/test_system_defaults_current_host
+++ b/e2e/cli/test_system_defaults_current_host
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+require_cmd jq
+domain="com.mise.defaults-current-host-test.$$"
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF_CONFIG
+[bootstrap.macos.defaults_current_host."$domain"]
+ScopeValue = 1
+GlobalOnly = true
+EOF_CONFIG
+cat >mise.toml <<EOF_CONFIG
+[bootstrap.macos.defaults."$domain"]
+ScopeValue = false
+[bootstrap.macos.defaults_current_host."$domain"]
+ScopeValue = 2
+EOF_CONFIG
+assert_contains 'mise bootstrap macos defaults status' '(current host)'
+if [[ $(uname) != Darwin ]]; then
+  assert_contains 'mise bootstrap macos defaults status' skipped
+  assert_succeed 'mise bootstrap macos defaults apply --yes'
+else
+  trap 'defaults delete "$domain" >/dev/null 2>&1 || true; defaults -currentHost delete "$domain" >/dev/null 2>&1 || true' EXIT
+  assert_contains 'mise bootstrap macos defaults apply --dry-run' "defaults -currentHost write $domain ScopeValue -int 2"
+  assert 'mise bootstrap macos defaults status --json | jq ".macos_defaults.entries | length"' 3
+  assert_succeed 'mise bootstrap macos defaults apply --yes'
+  assert "defaults read '$domain' ScopeValue" 0
+  assert "defaults -currentHost read '$domain' ScopeValue" 2
+  assert "defaults -currentHost read '$domain' GlobalOnly" 1
+  assert_succeed 'mise bootstrap macos defaults status --missing'
+  assert 'mise bootstrap macos defaults status --json | jq "[.macos_defaults.entries[] | select(.current_host)] | length"' 2
+  assert_contains 'mise bootstrap macos defaults apply --yes 2>&1' '3 value(s) already set'
+fi

--- a/e2e/cli/test_system_defaults_current_host
+++ b/e2e/cli/test_system_defaults_current_host
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-require_cmd jq
 domain="com.mise.defaults-current-host-test.$$"
 cat >"$MISE_CONFIG_DIR/config.toml" <<EOF_CONFIG
 [bootstrap.macos.defaults_current_host."$domain"]
@@ -17,6 +16,9 @@ if [[ $(uname) != Darwin ]]; then
   assert_contains 'mise bootstrap macos defaults status' skipped
   assert_succeed 'mise bootstrap macos defaults apply --yes'
 else
+  require_cmd jq
+  # Core Foundation writes outside the harness HOME, to the user's preference store.
+  # Remove only this test's preference domain.
   trap 'defaults delete "$domain" >/dev/null 2>&1 || true; defaults -currentHost delete "$domain" >/dev/null 2>&1 || true' EXIT
   assert_contains 'mise bootstrap macos defaults apply --dry-run' "defaults -currentHost write $domain ScopeValue -int 2"
   assert 'mise bootstrap macos defaults status --json | jq ".macos_defaults.entries | length"' 3

--- a/e2e/cli/test_system_defaults_current_host
+++ b/e2e/cli/test_system_defaults_current_host
@@ -23,6 +23,11 @@ value = 2
 EOF_CONFIG
 assert_contains 'mise bootstrap macos defaults status' '(current host)'
 if [[ $(uname) != Darwin ]]; then
+  require_cmd jq
+  assert 'mise bootstrap macos defaults status --json | jq ".macos_defaults.entries | length"' 3
+  assert 'mise bootstrap macos defaults status --json | jq -r ".macos_defaults.entries[0].host"' current
+  mise bootstrap status --json | jq -c .macos_defaults >aggregate.json
+  assert 'mise bootstrap macos defaults status --json | jq -c .macos_defaults' "$(cat aggregate.json)"
   assert_contains 'mise bootstrap macos defaults status' skipped
   assert_succeed 'mise bootstrap macos defaults apply --yes'
 else

--- a/e2e/cli/test_system_defaults_current_host
+++ b/e2e/cli/test_system_defaults_current_host
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 domain="com.mise.defaults-current-host-test.$$"
 cat >"$MISE_CONFIG_DIR/config.toml" <<EOF_CONFIG
-[bootstrap.macos.defaults_current_host."$domain"]
-ScopeValue = 1
-GlobalOnly = true
+[[bootstrap.macos.defaults_entries]]
+domain = "$domain"
+key = "ScopeValue"
+host = "current"
+value = 1
+[[bootstrap.macos.defaults_entries]]
+domain = "$domain"
+key = "GlobalOnly"
+host = "current"
+value = true
 EOF_CONFIG
 cat >mise.toml <<EOF_CONFIG
 [bootstrap.macos.defaults."$domain"]
 ScopeValue = false
-[bootstrap.macos.defaults_current_host."$domain"]
-ScopeValue = 2
+[[bootstrap.macos.defaults_entries]]
+domain = "$domain"
+key = "ScopeValue"
+host = "current"
+value = 2
 EOF_CONFIG
 assert_contains 'mise bootstrap macos defaults status' '(current host)'
 if [[ $(uname) != Darwin ]]; then
@@ -27,6 +37,61 @@ else
   assert "defaults -currentHost read '$domain' ScopeValue" 2
   assert "defaults -currentHost read '$domain' GlobalOnly" 1
   assert_succeed 'mise bootstrap macos defaults status --missing'
-  assert 'mise bootstrap macos defaults status --json | jq "[.macos_defaults.entries[] | select(.current_host)] | length"' 2
+  assert 'mise bootstrap macos defaults status --json | jq "[.macos_defaults.entries[] | select(.host == \"current\")] | length"' 2
   assert_contains 'mise bootstrap macos defaults apply --yes 2>&1' '3 value(s) already set'
 fi
+
+# Explicit any-host entries override shorthand without wrapping dictionary values.
+cat >mise.toml <<EOF_CONFIG
+[bootstrap.macos.defaults."$domain"]
+Dictionary = { host = "current", value = 1 }
+ScopeValue = false
+[[bootstrap.macos.defaults_entries]]
+domain = "$domain"
+key = "ScopeValue"
+value = 7
+EOF_CONFIG
+assert_contains 'mise bootstrap macos defaults status' 'ScopeValue'
+if [[ $(uname) == Darwin ]]; then
+  assert_contains 'mise bootstrap macos defaults apply --dry-run' "defaults write $domain ScopeValue -int 7"
+  assert 'mise bootstrap macos defaults status --json | jq -r ".macos_defaults.entries[] | select(.key == \"Dictionary\") | .value.host"' current
+fi
+
+cat >mise.toml <<EOF_CONFIG
+[[bootstrap.macos.defaults_entries]]
+domain = "$domain"
+key = "ScopeValue"
+host = "other"
+value = 1
+EOF_CONFIG
+assert_fail 'mise bootstrap macos defaults status' 'unknown variant'
+
+# Global-domain aliases merge across shorthand and explicit entries in both directions.
+for alias in -g -globalDomain; do
+  cat >"$MISE_CONFIG_DIR/config.toml" <<EOF_CONFIG
+[bootstrap.macos.defaults."$alias"]
+"_mise_host_alias_test_$$" = 1
+EOF_CONFIG
+  cat >mise.toml <<EOF_CONFIG
+[[bootstrap.macos.defaults_entries]]
+domain = "NSGlobalDomain"
+key = "_mise_host_alias_test_$$"
+value = 2
+EOF_CONFIG
+  if [[ $(uname) == Darwin ]]; then
+    assert 'mise bootstrap macos defaults status --json | jq -c "[.macos_defaults.entries[].value]"' '[2]'
+  fi
+  cat >"$MISE_CONFIG_DIR/config.toml" <<EOF_CONFIG
+[[bootstrap.macos.defaults_entries]]
+domain = "NSGlobalDomain"
+key = "_mise_host_alias_test_$$"
+value = 1
+EOF_CONFIG
+  cat >mise.toml <<EOF_CONFIG
+[bootstrap.macos.defaults."$alias"]
+"_mise_host_alias_test_$$" = 2
+EOF_CONFIG
+  if [[ $(uname) == Darwin ]]; then
+    assert 'mise bootstrap macos defaults status --json | jq -c "[.macos_defaults.entries[].value]"' '[2]'
+  fi
+done

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4695,6 +4695,37 @@
                 }
               }
             },
+            "defaults_current_host": {
+              "type": "object",
+              "description": "Current-host macOS user defaults, keyed by preferences domain; equivalent to defaults -currentHost",
+              "additionalProperties": {
+                "type": "object",
+                "description": "defaults keys and their desired values for this domain",
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "object"
+                    }
+                  ],
+                  "description": "Desired typed property-list value"
+                }
+              }
+            },
             "launchd": {
               "type": "object",
               "description": "macOS launchd bootstrap config",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4695,34 +4695,44 @@
                 }
               }
             },
-            "defaults_current_host": {
-              "type": "object",
-              "description": "Current-host macOS user defaults, keyed by preferences domain; equivalent to defaults -currentHost",
-              "additionalProperties": {
+            "defaults_entries": {
+              "type": "array",
+              "description": "Explicit macOS preferences with a selectable host scope",
+              "items": {
                 "type": "object",
-                "description": "defaults keys and their desired values for this domain",
-                "additionalProperties": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "array"
-                    },
-                    {
-                      "type": "object"
-                    }
-                  ],
-                  "description": "Desired typed property-list value"
+                "additionalProperties": false,
+                "required": ["domain", "key", "value"],
+                "properties": {
+                  "domain": {
+                    "type": "string"
+                  },
+                  "key": {
+                    "type": "string"
+                  },
+                  "host": {
+                    "type": "string",
+                    "enum": ["any", "current"],
+                    "default": "any"
+                  },
+                  "value": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array"
+                      },
+                      {
+                        "type": "object"
+                      }
+                    ]
+                  }
                 }
               }
             },

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -3842,7 +3842,7 @@ impl BootstrapStatus {
                     "entries": defaults.iter().map(|req| {
                         json!({
                             "domain": req.domain,
-                            "current_host": req.current_host,
+                            "host": req.host,
                             "key": req.key,
                             "value": req.value.to_json(),
                             "state": "skipped",
@@ -3869,7 +3869,7 @@ impl BootstrapStatus {
             );
             json_entries.push(json!({
                 "domain": s.request.domain,
-                "current_host": s.request.current_host,
+                "host": s.request.host,
                 "key": s.request.key,
                 "value": s.request.value.to_json(),
                 "current": current,
@@ -4811,7 +4811,7 @@ impl BootstrapMacosDefaultsStatus {
                     if self.json {
                         json_entries.push(json!({
                             "domain": s.request.domain,
-                            "current_host": s.request.current_host,
+                            "host": s.request.host,
                             "key": s.request.key,
                             "value": s.request.value.to_json(),
                             "current": current,

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -3828,7 +3828,7 @@ impl BootstrapStatus {
             for req in &defaults {
                 report.row(
                     "defaults",
-                    format!("{} {}", req.domain, req.key),
+                    format!("{} {}", req.display_domain(), req.key),
                     "",
                     format!("skipped ({reason})"),
                     false,
@@ -3842,6 +3842,7 @@ impl BootstrapStatus {
                     "entries": defaults.iter().map(|req| {
                         json!({
                             "domain": req.domain,
+                            "current_host": req.current_host,
                             "key": req.key,
                             "value": req.value.to_json(),
                             "state": "skipped",
@@ -3861,13 +3862,14 @@ impl BootstrapStatus {
             };
             report.row(
                 "defaults",
-                format!("{} {}", s.request.domain, s.request.key),
+                format!("{} {}", s.request.display_domain(), s.request.key),
                 current.clone(),
                 state,
                 missing,
             );
             json_entries.push(json!({
                 "domain": s.request.domain,
+                "current_host": s.request.current_host,
                 "key": s.request.key,
                 "value": s.request.value.to_json(),
                 "current": current,
@@ -4783,7 +4785,7 @@ impl BootstrapMacosDefaultsStatus {
                 } else {
                     for req in &defaults {
                         rows.push(vec![
-                            req.domain.clone(),
+                            req.display_domain(),
                             req.key.clone(),
                             req.value.to_string(),
                             "".to_string(),
@@ -4809,6 +4811,7 @@ impl BootstrapMacosDefaultsStatus {
                     if self.json {
                         json_entries.push(json!({
                             "domain": s.request.domain,
+                            "current_host": s.request.current_host,
                             "key": s.request.key,
                             "value": s.request.value.to_json(),
                             "current": current,
@@ -4816,7 +4819,7 @@ impl BootstrapMacosDefaultsStatus {
                         }));
                     } else {
                         rows.push(vec![
-                            s.request.domain.clone(),
+                            s.request.display_domain(),
                             s.request.key.clone(),
                             s.request.value.to_string(),
                             current,

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -3836,19 +3836,7 @@ impl BootstrapStatus {
             }
             report.json.insert(
                 "macos_defaults".to_string(),
-                json!({
-                    "available": false,
-                    "reason": reason,
-                    "entries": defaults.iter().map(|req| {
-                        json!({
-                            "domain": req.domain,
-                            "host": req.host,
-                            "key": req.key,
-                            "value": req.value.to_json(),
-                            "state": "skipped",
-                        })
-                    }).collect::<Vec<_>>(),
-                }),
+                unavailable_defaults_json(&defaults, &reason),
             );
             return Ok(());
         }
@@ -4767,6 +4755,25 @@ impl BootstrapMacosDefaultsApply {
     }
 }
 
+fn unavailable_defaults_json(
+    defaults: &[system::defaults::DefaultsRequest],
+    reason: &str,
+) -> serde_json::Value {
+    json!({
+        "available": false,
+        "reason": reason,
+        "entries": defaults.iter().map(|req| {
+            json!({
+                "domain": req.domain,
+                "host": req.host,
+                "key": req.key,
+                "value": req.value.to_json(),
+                "state": "skipped",
+            })
+        }).collect::<Vec<_>>(),
+    })
+}
+
 impl BootstrapMacosDefaultsStatus {
     async fn run(self) -> Result<()> {
         let config = Config::get().await?;
@@ -4780,7 +4787,7 @@ impl BootstrapMacosDefaultsStatus {
                 if self.json {
                     json_out.insert(
                         "macos_defaults".to_string(),
-                        json!({ "available": false, "reason": reason }),
+                        unavailable_defaults_json(&defaults, &reason),
                     );
                 } else {
                     for req in &defaults {
@@ -5072,6 +5079,32 @@ mod tests {
     use super::{bootstrap_from_child_args, select_remote_inventory};
     use crate::cli::{Cli, Commands};
     use crate::system::remote;
+
+    #[test]
+    fn unavailable_defaults_json_retains_configured_entries() {
+        use crate::system::defaults::{DefaultsRequest, DefaultsValue, HostScope};
+        let request = DefaultsRequest {
+            domain: "com.mise.test".into(),
+            key: "Settings".into(),
+            host: HostScope::Current,
+            value: DefaultsValue::Bool(false),
+        };
+        let output = super::unavailable_defaults_json(&[request], "macOS only");
+        assert_eq!(
+            output,
+            serde_json::json!({
+                "available": false,
+                "reason": "macOS only",
+                "entries": [{
+                    "domain": "com.mise.test",
+                    "key": "Settings",
+                    "host": "current",
+                    "value": false,
+                    "state": "skipped",
+                }],
+            })
+        );
+    }
 
     #[test]
     fn remote_adopt_parses_and_conflicts_with_source() {

--- a/src/system/defaults.rs
+++ b/src/system/defaults.rs
@@ -555,7 +555,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn test_host_scopes_are_independent() {
-        let domain = format!("com.mise.defaults-test.{}", uuid::Uuid::new_v4());
+        let domain = format!("com.mise.defaults-test.{}", uuid::Uuid::now_v7());
         let any = DefaultsRequest {
             domain: domain.clone(),
             key: "ScopeValue".into(),

--- a/src/system/defaults.rs
+++ b/src/system/defaults.rs
@@ -15,12 +15,24 @@ pub(crate) struct DefaultsRequest {
     /// preferences domain, e.g. "com.apple.dock" or "NSGlobalDomain"
     pub domain: String,
     pub key: String,
+    /// Use the current host instead of the any-host preference scope.
+    pub current_host: bool,
     pub value: DefaultsValue,
+}
+
+impl DefaultsRequest {
+    pub(crate) fn display_domain(&self) -> String {
+        if self.current_host {
+            format!("{} (current host)", self.domain)
+        } else {
+            self.domain.clone()
+        }
+    }
 }
 
 impl std::fmt::Display for DefaultsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {} = {}", self.domain, self.key, self.value)
+        write!(f, "{} {} = {}", self.display_domain(), self.key, self.value)
     }
 }
 
@@ -177,7 +189,7 @@ pub(crate) async fn status(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsS
 fn status_sync(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsStatus>> {
     let mut out = vec![];
     for req in requests {
-        let state = match read(&req.domain, &req.key)? {
+        let state = match read(&req.domain, &req.key, req.current_host)? {
             Some(current) => {
                 if req.value.matches(&current) {
                     DefaultsState::Set
@@ -202,7 +214,11 @@ pub(crate) async fn apply(requests: &[DefaultsRequest], dry_run: bool) -> Result
     for req in requests {
         if dry_run {
             if let Some(write_args) = req.value.write_args() {
-                let mut args = vec!["write".to_string(), req.domain.clone(), req.key.clone()];
+                let mut args = vec![];
+                if req.current_host {
+                    args.push("-currentHost".to_string());
+                }
+                args.extend(["write".to_string(), req.domain.clone(), req.key.clone()]);
                 args.extend(write_args);
                 miseprintln!("defaults {}", shell_words::join(&args));
             } else {
@@ -266,12 +282,12 @@ fn plist_to_json(value: &plist::Value) -> Option<serde_json::Value> {
 }
 
 #[cfg(target_os = "macos")]
-fn read(domain: &str, key: &str) -> Result<Option<plist::Value>> {
-    macos::read(domain, key)
+fn read(domain: &str, key: &str, current_host: bool) -> Result<Option<plist::Value>> {
+    macos::read(domain, key, current_host)
 }
 
 #[cfg(not(target_os = "macos"))]
-fn read(_domain: &str, _key: &str) -> Result<Option<plist::Value>> {
+fn read(_domain: &str, _key: &str, _current_host: bool) -> Result<Option<plist::Value>> {
     Ok(None)
 }
 
@@ -293,7 +309,8 @@ mod macos {
     use core_foundation::string::CFString;
     use core_foundation_sys::preferences::{
         CFPreferencesCopyValue, CFPreferencesSetValue, CFPreferencesSynchronize,
-        kCFPreferencesAnyApplication, kCFPreferencesAnyHost, kCFPreferencesCurrentUser,
+        kCFPreferencesAnyApplication, kCFPreferencesAnyHost, kCFPreferencesCurrentHost,
+        kCFPreferencesCurrentUser,
     };
     use core_foundation_sys::propertylist::{
         kCFPropertyListImmutable, kCFPropertyListXMLFormat_v1_0,
@@ -301,6 +318,16 @@ mod macos {
     use indexmap::IndexSet;
 
     use super::*;
+
+    fn host_id(current_host: bool) -> core_foundation_sys::string::CFStringRef {
+        unsafe {
+            if current_host {
+                kCFPreferencesCurrentHost
+            } else {
+                kCFPreferencesAnyHost
+            }
+        }
+    }
 
     fn application_id(
         domain: &str,
@@ -314,7 +341,11 @@ mod macos {
         }
     }
 
-    pub(super) fn read(domain: &str, key: &str) -> Result<Option<plist::Value>> {
+    pub(super) fn read(
+        domain: &str,
+        key: &str,
+        current_host: bool,
+    ) -> Result<Option<plist::Value>> {
         let key = CFString::new(key);
         let (_application, application_id) = application_id(domain);
         let value = unsafe {
@@ -322,7 +353,7 @@ mod macos {
                 key.as_concrete_TypeRef(),
                 application_id,
                 kCFPreferencesCurrentUser,
-                kCFPreferencesAnyHost,
+                host_id(current_host),
             )
         };
         if value.is_null() {
@@ -334,7 +365,7 @@ mod macos {
         Ok(Some(plist::Value::from_reader_xml(data.bytes())?))
     }
 
-    fn set(domain: &str, key: &str, value: &DefaultsValue) -> Result<()> {
+    fn set(domain: &str, key: &str, value: &DefaultsValue, current_host: bool) -> Result<()> {
         let mut xml = Vec::new();
         plist::to_writer_xml(&mut xml, &value.to_plist())?;
         let data = CFData::from_buffer(&xml);
@@ -349,19 +380,19 @@ mod macos {
                 value.as_CFTypeRef(),
                 application_id,
                 kCFPreferencesCurrentUser,
-                kCFPreferencesAnyHost,
+                host_id(current_host),
             );
         }
         Ok(())
     }
 
-    fn synchronize(domain: &str) -> Result<()> {
+    fn synchronize(domain: &str, current_host: bool) -> Result<()> {
         let (_application, application_id) = application_id(domain);
         unsafe {
             if CFPreferencesSynchronize(
                 application_id,
                 kCFPreferencesCurrentUser,
-                kCFPreferencesAnyHost,
+                host_id(current_host),
             ) == 0
             {
                 eyre::bail!("failed to synchronize macOS preference domain {domain}");
@@ -373,17 +404,22 @@ mod macos {
     pub(super) fn write_all(requests: &[DefaultsRequest]) -> Result<()> {
         let mut domains = IndexSet::new();
         for request in requests {
-            set(&request.domain, &request.key, &request.value)?;
-            domains.insert(request.domain.as_str());
+            set(
+                &request.domain,
+                &request.key,
+                &request.value,
+                request.current_host,
+            )?;
+            domains.insert((request.domain.as_str(), request.current_host));
         }
-        for domain in domains {
-            synchronize(domain)?;
+        for (domain, current_host) in domains {
+            synchronize(domain, current_host)?;
         }
         Ok(())
     }
 
     #[cfg(test)]
-    pub(super) fn remove(domain: &str, key: &str) -> Result<()> {
+    pub(super) fn remove(domain: &str, key: &str, current_host: bool) -> Result<()> {
         let key = CFString::new(key);
         let (_application, application_id) = application_id(domain);
         unsafe {
@@ -392,12 +428,12 @@ mod macos {
                 std::ptr::null(),
                 application_id,
                 kCFPreferencesCurrentUser,
-                kCFPreferencesAnyHost,
+                host_id(current_host),
             );
             if CFPreferencesSynchronize(
                 application_id,
                 kCFPreferencesCurrentUser,
-                kCFPreferencesAnyHost,
+                host_id(current_host),
             ) == 0
             {
                 eyre::bail!("failed to synchronize macOS preference domain {domain}");
@@ -516,6 +552,40 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_host_scopes_are_independent() {
+        let domain = format!("com.mise.defaults-test.{}", uuid::Uuid::new_v4());
+        let any = DefaultsRequest {
+            domain: domain.clone(),
+            key: "ScopeValue".into(),
+            current_host: false,
+            value: DefaultsValue::Bool(true),
+        };
+        let host = DefaultsRequest {
+            current_host: true,
+            value: DefaultsValue::from_toml(&val("{ nested = [1, false] }")).unwrap(),
+            ..any.clone()
+        };
+        write_all(std::slice::from_ref(&any)).unwrap();
+        let missing = status_sync(std::slice::from_ref(&host));
+        let write = write_all(&[any.clone(), host.clone()]);
+        let any_value = read(&domain, &any.key, false);
+        let host_value = read(&domain, &host.key, true);
+        let statuses = status_sync(&[any.clone(), host.clone()]);
+        let cleanup_any = macos::remove(&domain, &any.key, false);
+        let cleanup_host = macos::remove(&domain, &host.key, true);
+        assert_eq!(missing.unwrap()[0].state, DefaultsState::Unset);
+        write.unwrap();
+        assert_eq!(any_value.unwrap(), Some(any.value.to_plist()));
+        assert_eq!(host_value.unwrap(), Some(host.value.to_plist()));
+        for status in statuses.unwrap() {
+            assert_eq!(status.state, DefaultsState::Set);
+        }
+        cleanup_any.unwrap();
+        cleanup_host.unwrap();
+    }
+
     /// `status()` must not fail when keys don't exist yet — this is the
     /// expected path on a fresh macOS install.
     #[cfg(target_os = "macos")]
@@ -524,12 +594,14 @@ mod tests {
         let reqs = vec![
             // key doesn't exist in a real domain
             DefaultsRequest {
+                current_host: false,
                 domain: "NSGlobalDomain".into(),
                 key: "_mise_test_nonexistent_key_42".into(),
                 value: DefaultsValue::Bool(true),
             },
             // domain doesn't exist at all
             DefaultsRequest {
+                current_host: false,
                 domain: "com.mise.nonexistent".into(),
                 key: "TestKey".into(),
                 value: DefaultsValue::Bool(true),
@@ -559,13 +631,14 @@ mod tests {
         .unwrap();
 
         write_all(&[DefaultsRequest {
+            current_host: false,
             domain: domain.into(),
             key: key.into(),
             value: value.clone(),
         }])
         .unwrap();
-        let current = read(domain, key);
-        let cleanup = macos::remove(domain, key);
+        let current = read(domain, key, false);
+        let cleanup = macos::remove(domain, key, false);
 
         assert_eq!(current.unwrap(), Some(value.to_plist()));
         cleanup.unwrap();

--- a/src/system/defaults.rs
+++ b/src/system/defaults.rs
@@ -9,20 +9,38 @@ use indexmap::IndexMap;
 
 use crate::result::Result;
 
-/// A single `[bootstrap.macos.defaults.<domain>]` entry: `key = value`
+/// The host scope is part of a preference's identity.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum HostScope {
+    #[default]
+    Any,
+    Current,
+}
+
+pub(super) fn canonical_domain(domain: &str) -> &str {
+    match domain {
+        "-g" | "-globalDomain" => "NSGlobalDomain",
+        domain => domain,
+    }
+}
+
+/// A typed preference and its host scope.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct DefaultsRequest {
     /// preferences domain, e.g. "com.apple.dock" or "NSGlobalDomain"
     pub domain: String,
     pub key: String,
     /// Use the current host instead of the any-host preference scope.
-    pub current_host: bool,
+    pub host: HostScope,
     pub value: DefaultsValue,
 }
 
 impl DefaultsRequest {
     pub(crate) fn display_domain(&self) -> String {
-        if self.current_host {
+        if self.host == HostScope::Current {
             format!("{} (current host)", self.domain)
         } else {
             self.domain.clone()
@@ -189,7 +207,7 @@ pub(crate) async fn status(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsS
 fn status_sync(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsStatus>> {
     let mut out = vec![];
     for req in requests {
-        let state = match read(&req.domain, &req.key, req.current_host)? {
+        let state = match read(&req.domain, &req.key, req.host)? {
             Some(current) => {
                 if req.value.matches(&current) {
                     DefaultsState::Set
@@ -215,7 +233,7 @@ pub(crate) async fn apply(requests: &[DefaultsRequest], dry_run: bool) -> Result
         if dry_run {
             if let Some(write_args) = req.value.write_args() {
                 let mut args = vec![];
-                if req.current_host {
+                if req.host == HostScope::Current {
                     args.push("-currentHost".to_string());
                 }
                 args.extend(["write".to_string(), req.domain.clone(), req.key.clone()]);
@@ -282,12 +300,12 @@ fn plist_to_json(value: &plist::Value) -> Option<serde_json::Value> {
 }
 
 #[cfg(target_os = "macos")]
-fn read(domain: &str, key: &str, current_host: bool) -> Result<Option<plist::Value>> {
-    macos::read(domain, key, current_host)
+fn read(domain: &str, key: &str, host: HostScope) -> Result<Option<plist::Value>> {
+    macos::read(domain, key, host)
 }
 
 #[cfg(not(target_os = "macos"))]
-fn read(_domain: &str, _key: &str, _current_host: bool) -> Result<Option<plist::Value>> {
+fn read(_domain: &str, _key: &str, _host: HostScope) -> Result<Option<plist::Value>> {
     Ok(None)
 }
 
@@ -319,12 +337,11 @@ mod macos {
 
     use super::*;
 
-    fn host_id(current_host: bool) -> core_foundation_sys::string::CFStringRef {
+    fn host_id(host: HostScope) -> core_foundation_sys::string::CFStringRef {
         unsafe {
-            if current_host {
-                kCFPreferencesCurrentHost
-            } else {
-                kCFPreferencesAnyHost
+            match host {
+                HostScope::Any => kCFPreferencesAnyHost,
+                HostScope::Current => kCFPreferencesCurrentHost,
             }
         }
     }
@@ -332,7 +349,7 @@ mod macos {
     fn application_id(
         domain: &str,
     ) -> (Option<CFString>, core_foundation_sys::string::CFStringRef) {
-        if matches!(domain, "NSGlobalDomain" | "-g" | "-globalDomain") {
+        if canonical_domain(domain) == "NSGlobalDomain" {
             (None, unsafe { kCFPreferencesAnyApplication })
         } else {
             let domain = CFString::new(domain);
@@ -341,11 +358,7 @@ mod macos {
         }
     }
 
-    pub(super) fn read(
-        domain: &str,
-        key: &str,
-        current_host: bool,
-    ) -> Result<Option<plist::Value>> {
+    pub(super) fn read(domain: &str, key: &str, host: HostScope) -> Result<Option<plist::Value>> {
         let key = CFString::new(key);
         let (_application, application_id) = application_id(domain);
         let value = unsafe {
@@ -353,7 +366,7 @@ mod macos {
                 key.as_concrete_TypeRef(),
                 application_id,
                 kCFPreferencesCurrentUser,
-                host_id(current_host),
+                host_id(host),
             )
         };
         if value.is_null() {
@@ -365,7 +378,7 @@ mod macos {
         Ok(Some(plist::Value::from_reader_xml(data.bytes())?))
     }
 
-    fn set(domain: &str, key: &str, value: &DefaultsValue, current_host: bool) -> Result<()> {
+    fn set(domain: &str, key: &str, value: &DefaultsValue, host: HostScope) -> Result<()> {
         let mut xml = Vec::new();
         plist::to_writer_xml(&mut xml, &value.to_plist())?;
         let data = CFData::from_buffer(&xml);
@@ -380,20 +393,17 @@ mod macos {
                 value.as_CFTypeRef(),
                 application_id,
                 kCFPreferencesCurrentUser,
-                host_id(current_host),
+                host_id(host),
             );
         }
         Ok(())
     }
 
-    fn synchronize(domain: &str, current_host: bool) -> Result<()> {
+    fn synchronize(domain: &str, host: HostScope) -> Result<()> {
         let (_application, application_id) = application_id(domain);
         unsafe {
-            if CFPreferencesSynchronize(
-                application_id,
-                kCFPreferencesCurrentUser,
-                host_id(current_host),
-            ) == 0
+            if CFPreferencesSynchronize(application_id, kCFPreferencesCurrentUser, host_id(host))
+                == 0
             {
                 eyre::bail!("failed to synchronize macOS preference domain {domain}");
             }
@@ -404,22 +414,17 @@ mod macos {
     pub(super) fn write_all(requests: &[DefaultsRequest]) -> Result<()> {
         let mut domains = IndexSet::new();
         for request in requests {
-            set(
-                &request.domain,
-                &request.key,
-                &request.value,
-                request.current_host,
-            )?;
-            domains.insert((request.domain.as_str(), request.current_host));
+            set(&request.domain, &request.key, &request.value, request.host)?;
+            domains.insert((request.domain.as_str(), request.host));
         }
-        for (domain, current_host) in domains {
-            synchronize(domain, current_host)?;
+        for (domain, host) in domains {
+            synchronize(domain, host)?;
         }
         Ok(())
     }
 
     #[cfg(test)]
-    pub(super) fn remove(domain: &str, key: &str, current_host: bool) -> Result<()> {
+    pub(super) fn remove(domain: &str, key: &str, host: HostScope) -> Result<()> {
         let key = CFString::new(key);
         let (_application, application_id) = application_id(domain);
         unsafe {
@@ -428,13 +433,10 @@ mod macos {
                 std::ptr::null(),
                 application_id,
                 kCFPreferencesCurrentUser,
-                host_id(current_host),
+                host_id(host),
             );
-            if CFPreferencesSynchronize(
-                application_id,
-                kCFPreferencesCurrentUser,
-                host_id(current_host),
-            ) == 0
+            if CFPreferencesSynchronize(application_id, kCFPreferencesCurrentUser, host_id(host))
+                == 0
             {
                 eyre::bail!("failed to synchronize macOS preference domain {domain}");
             }
@@ -559,22 +561,22 @@ mod tests {
         let any = DefaultsRequest {
             domain: domain.clone(),
             key: "ScopeValue".into(),
-            current_host: false,
+            host: HostScope::Any,
             value: DefaultsValue::Bool(true),
         };
         let host = DefaultsRequest {
-            current_host: true,
+            host: HostScope::Current,
             value: DefaultsValue::from_toml(&val("{ nested = [1, false] }")).unwrap(),
             ..any.clone()
         };
         write_all(std::slice::from_ref(&any)).unwrap();
         let missing = status_sync(std::slice::from_ref(&host));
         let write = write_all(&[any.clone(), host.clone()]);
-        let any_value = read(&domain, &any.key, false);
-        let host_value = read(&domain, &host.key, true);
+        let any_value = read(&domain, &any.key, HostScope::Any);
+        let host_value = read(&domain, &host.key, HostScope::Current);
         let statuses = status_sync(&[any.clone(), host.clone()]);
-        let cleanup_any = macos::remove(&domain, &any.key, false);
-        let cleanup_host = macos::remove(&domain, &host.key, true);
+        let cleanup_any = macos::remove(&domain, &any.key, HostScope::Any);
+        let cleanup_host = macos::remove(&domain, &host.key, HostScope::Current);
         assert_eq!(missing.unwrap()[0].state, DefaultsState::Unset);
         write.unwrap();
         assert_eq!(any_value.unwrap(), Some(any.value.to_plist()));
@@ -594,14 +596,14 @@ mod tests {
         let reqs = vec![
             // key doesn't exist in a real domain
             DefaultsRequest {
-                current_host: false,
+                host: HostScope::Any,
                 domain: "NSGlobalDomain".into(),
                 key: "_mise_test_nonexistent_key_42".into(),
                 value: DefaultsValue::Bool(true),
             },
             // domain doesn't exist at all
             DefaultsRequest {
-                current_host: false,
+                host: HostScope::Any,
                 domain: "com.mise.nonexistent".into(),
                 key: "TestKey".into(),
                 value: DefaultsValue::Bool(true),
@@ -631,14 +633,14 @@ mod tests {
         .unwrap();
 
         write_all(&[DefaultsRequest {
-            current_host: false,
+            host: HostScope::Any,
             domain: domain.into(),
             key: key.into(),
             value: value.clone(),
         }])
         .unwrap();
-        let current = read(domain, key, false);
-        let cleanup = macos::remove(domain, key, false);
+        let current = read(domain, key, HostScope::Any);
+        let cleanup = macos::remove(domain, key, HostScope::Any);
 
         assert_eq!(current.unwrap(), Some(value.to_plist()));
         cleanup.unwrap();

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -307,6 +307,9 @@ pub(crate) struct BootstrapMacosTomlConfig {
     /// instead of failing the whole config.
     #[serde(default)]
     pub defaults: IndexMap<String, toml::Value>,
+    /// The same domain/key/value map, scoped to the current host.
+    #[serde(default)]
+    pub defaults_current_host: IndexMap<String, toml::Value>,
     /// `[bootstrap.macos.launchd.agents.<name>]`: declarative macOS user
     /// LaunchAgents rendered to ~/Library/LaunchAgents.
     #[serde(default)]
@@ -751,13 +754,13 @@ fn merge_package_configs<'a>(
     merged
 }
 
-/// Aggregate `[bootstrap.macos.defaults]` across all loaded config files.
+/// Aggregate macOS defaults across all loaded config files.
 ///
-/// (domain, key) pairs union global -> local; a more local config overrides
-/// the value a global config declared. Unsupported value shapes warn
+/// Within each host scope, (domain, key) pairs union global -> local; a more
+/// local config overrides the value a global config declared. Unsupported value shapes warn
 /// (forward compatibility) and are skipped.
 pub(crate) fn defaults_from_config(config: &Config) -> Vec<DefaultsRequest> {
-    let mut merged: IndexMap<(String, String), toml::Value> = IndexMap::new();
+    let mut merged: IndexMap<(String, String, bool), toml::Value> = IndexMap::new();
     // config_files is ordered local -> global; reverse for global -> local
     for cf in config.config_files.values().rev() {
         if let Some(sys) = cf.bootstrap_config() {
@@ -777,18 +780,42 @@ pub(crate) fn defaults_from_config(config: &Config) -> Vec<DefaultsRequest> {
                 }
             }
             for (key, value) in merge_raw_over_friendly_macos_defaults(friendly, raw) {
-                merged.insert(key, value);
+                merged.insert((key.0, key.1, false), value);
+            }
+            for (domain, entries) in sys.macos.defaults_current_host {
+                match entries {
+                    toml::Value::Table(entries) => {
+                        for (key, value) in entries {
+                            merged.insert((domain.clone(), key, true), value);
+                        }
+                    }
+                    _ => warn!(
+                        "[bootstrap.macos.defaults_current_host]: expected a table of key/value pairs for domain '{domain}'"
+                    ),
+                }
             }
         }
     }
     let mut out = vec![];
-    for ((domain, key), value) in merged {
+    for ((domain, key, current_host), value) in merged {
         match DefaultsValue::from_toml(&value) {
-            Some(value) => out.push(DefaultsRequest { domain, key, value }),
-            None => warn!(
-                "[bootstrap.macos.defaults]: unsupported value type for {domain} {key} \
-                 (expected bool, integer, float, string, array, or table)"
-            ),
+            Some(value) => out.push(DefaultsRequest {
+                domain,
+                key,
+                current_host,
+                value,
+            }),
+            None => {
+                let section = if current_host {
+                    "defaults_current_host"
+                } else {
+                    "defaults"
+                };
+                warn!(
+                    "[bootstrap.macos.{section}]: unsupported value type for {domain} {key} \
+                     (expected bool, integer, float, string, array, or table)"
+                );
+            }
         }
     }
     out
@@ -859,7 +886,12 @@ pub(crate) fn macos_defaults_entry_count(macos: &BootstrapMacosTomlConfig) -> us
             _ => malformed_domains += 1,
         }
     }
-    merge_raw_over_friendly_macos_defaults(friendly, raw).len() + malformed_domains
+    let current_host = macos
+        .defaults_current_host
+        .values()
+        .map(|entries| entries.as_table().map_or(1, |entries| entries.len()))
+        .sum::<usize>();
+    merge_raw_over_friendly_macos_defaults(friendly, raw).len() + malformed_domains + current_host
 }
 
 fn merge_raw_over_friendly_macos_defaults(
@@ -2349,5 +2381,12 @@ mod tests {
         macos.defaults.insert("malformed".into(), tv("true"));
 
         assert_eq!(macos_defaults_entry_count(&macos), 5);
+        macos
+            .defaults_current_host
+            .insert("NSGlobalDomain".into(), tv("{ KeyRepeat = 3 }"));
+        macos
+            .defaults_current_host
+            .insert("malformed".into(), tv("true"));
+        assert_eq!(macos_defaults_entry_count(&macos), 7);
     }
 }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -29,7 +29,7 @@ use indexmap::IndexMap;
 use serde::Deserialize;
 
 use crate::config::{Config, ConfigMap};
-use crate::system::defaults::{DefaultsRequest, DefaultsValue};
+use crate::system::defaults::{DefaultsRequest, DefaultsValue, HostScope, canonical_domain};
 use crate::system::launchd::{LaunchdRequest, LaunchdTomlConfig};
 use crate::system::packages::{PackageRequest, SystemPackageManager};
 use crate::system::repos::{RepoRequest, RepoTomlConfig};
@@ -307,13 +307,23 @@ pub(crate) struct BootstrapMacosTomlConfig {
     /// instead of failing the whole config.
     #[serde(default)]
     pub defaults: IndexMap<String, toml::Value>,
-    /// The same domain/key/value map, scoped to the current host.
+    /// Explicit preferences with a selectable host scope.
     #[serde(default)]
-    pub defaults_current_host: IndexMap<String, toml::Value>,
+    pub defaults_entries: Vec<BootstrapMacosDefaultsEntry>,
     /// `[bootstrap.macos.launchd.agents.<name>]`: declarative macOS user
     /// LaunchAgents rendered to ~/Library/LaunchAgents.
     #[serde(default)]
     pub launchd: BootstrapMacosLaunchdTomlConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct BootstrapMacosDefaultsEntry {
+    pub domain: String,
+    pub key: String,
+    #[serde(default)]
+    pub host: HostScope,
+    pub value: toml::Value,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -760,7 +770,7 @@ fn merge_package_configs<'a>(
 /// local config overrides the value a global config declared. Unsupported value shapes warn
 /// (forward compatibility) and are skipped.
 pub(crate) fn defaults_from_config(config: &Config) -> Vec<DefaultsRequest> {
-    let mut merged: IndexMap<(String, String, bool), toml::Value> = IndexMap::new();
+    let mut merged: IndexMap<(String, String, HostScope), toml::Value> = IndexMap::new();
     // config_files is ordered local -> global; reverse for global -> local
     for cf in config.config_files.values().rev() {
         if let Some(sys) = cf.bootstrap_config() {
@@ -780,39 +790,35 @@ pub(crate) fn defaults_from_config(config: &Config) -> Vec<DefaultsRequest> {
                 }
             }
             for (key, value) in merge_raw_over_friendly_macos_defaults(friendly, raw) {
-                merged.insert((key.0, key.1, false), value);
+                merged.insert(
+                    (canonical_domain(&key.0).into(), key.1, HostScope::Any),
+                    value,
+                );
             }
-            for (domain, entries) in sys.macos.defaults_current_host {
-                match entries {
-                    toml::Value::Table(entries) => {
-                        for (key, value) in entries {
-                            merged.insert((domain.clone(), key, true), value);
-                        }
-                    }
-                    _ => warn!(
-                        "[bootstrap.macos.defaults_current_host]: expected a table of key/value pairs for domain '{domain}'"
+            for entry in sys.macos.defaults_entries {
+                merged.insert(
+                    (
+                        canonical_domain(&entry.domain).into(),
+                        entry.key,
+                        entry.host,
                     ),
-                }
+                    entry.value,
+                );
             }
         }
     }
     let mut out = vec![];
-    for ((domain, key, current_host), value) in merged {
+    for ((domain, key, host), value) in merged {
         match DefaultsValue::from_toml(&value) {
             Some(value) => out.push(DefaultsRequest {
                 domain,
                 key,
-                current_host,
+                host,
                 value,
             }),
             None => {
-                let section = if current_host {
-                    "defaults_current_host"
-                } else {
-                    "defaults"
-                };
                 warn!(
-                    "[bootstrap.macos.{section}]: unsupported value type for {domain} {key} \
+                    "[bootstrap.macos.defaults]: unsupported value type for {domain} {key} \
                      (expected bool, integer, float, string, array, or table)"
                 );
             }
@@ -886,12 +892,26 @@ pub(crate) fn macos_defaults_entry_count(macos: &BootstrapMacosTomlConfig) -> us
             _ => malformed_domains += 1,
         }
     }
-    let current_host = macos
-        .defaults_current_host
-        .values()
-        .map(|entries| entries.as_table().map_or(1, |entries| entries.len()))
-        .sum::<usize>();
-    merge_raw_over_friendly_macos_defaults(friendly, raw).len() + malformed_domains + current_host
+    let mut merged: IndexMap<_, _> = merge_raw_over_friendly_macos_defaults(friendly, raw)
+        .into_iter()
+        .map(|((domain, key), value)| {
+            (
+                (canonical_domain(&domain).to_owned(), key, HostScope::Any),
+                value,
+            )
+        })
+        .collect();
+    for entry in &macos.defaults_entries {
+        merged.insert(
+            (
+                canonical_domain(&entry.domain).to_owned(),
+                entry.key.clone(),
+                entry.host,
+            ),
+            entry.value.clone(),
+        );
+    }
+    merged.len() + malformed_domains
 }
 
 fn merge_raw_over_friendly_macos_defaults(
@@ -2381,12 +2401,12 @@ mod tests {
         macos.defaults.insert("malformed".into(), tv("true"));
 
         assert_eq!(macos_defaults_entry_count(&macos), 5);
-        macos
-            .defaults_current_host
-            .insert("NSGlobalDomain".into(), tv("{ KeyRepeat = 3 }"));
-        macos
-            .defaults_current_host
-            .insert("malformed".into(), tv("true"));
-        assert_eq!(macos_defaults_entry_count(&macos), 7);
+        macos.defaults_entries.push(BootstrapMacosDefaultsEntry {
+            domain: "NSGlobalDomain".into(),
+            key: "KeyRepeat".into(),
+            host: HostScope::Current,
+            value: tv("3"),
+        });
+        assert_eq!(macos_defaults_entry_count(&macos), 6);
     }
 }


### PR DESCRIPTION
Add `[[bootstrap.macos.defaults_entries]]` for explicit macOS preferences with `domain`, `key`, `value`, and an optional `host` (`any` by default, or `current`). This supports preferences normally written with `defaults -currentHost` while preserving the existing `[bootstrap.macos.defaults]` shorthand and dictionary-valued preferences.

Host scope is part of preference identity throughout configuration merging, native reads and writes, synchronization, and JSON status. Entries merge global → local by domain, key, and host; explicit entries override shorthand in the same file. Global-domain aliases are normalized before merging. Status labels current-host entries, and scalar dry runs include `-currentHost`.

Both status commands include configured entries with their scope when defaults are unavailable, marking each entry as skipped.

The entry form also provides the foundation for optional dictionary paths in #12984.

Related: #12981.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring macOS current-host preferences through `bootstrap.macos.defaults_entries`.
  * Supports typed values, including strings, numbers, booleans, arrays, and tables.
  * Status, JSON output, dry-runs, synchronization, and apply operations now identify current-host preferences.
  * Global-domain aliases are handled consistently when merging preferences.

* **Documentation**
  * Documented current-host preference configuration and clarified that system-domain preferences using `sudo defaults` remain unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
