### PR TITLE
feat(bootstrap): patch nested macOS preference values

### DIFF
--- a/docs/bootstrap/macos-defaults.md
+++ b/docs/bootstrap/macos-defaults.md
@@ -192,6 +192,39 @@ and `-globalDomain` share the identity of `NSGlobalDomain`.
 Status labels current-host domains with `(current host)` and JSON entries include
 `host`. Scalar dry-runs include `-currentHost`.
 
+## Targeted dictionary updates
+
+Add `path` to a defaults entry to manage a nested value in a shared dictionary without
+replacing its siblings. For example, disable one symbolic shortcut while retaining
+its parameters and the other shortcuts:
+
+```toml
+[[bootstrap.macos.defaults_entries]]
+domain = "com.apple.symbolichotkeys"
+key = "AppleSymbolicHotKeys"
+path = ["64", "enabled"]
+value = false
+```
+
+Each `path` component is a literal dictionary key, so dots in a component are not
+separators. The path must contain at least one component. `value` accepts the same
+types as `defaults` and replaces the selected value in full, including when that
+value is an array or dictionary. Array indices are not supported.
+
+Paths work with both `host = "any"` (the default) and `host = "current"`.
+Mise reads the existing plist in the selected host scope,
+applies the patches, and writes the updated value.
+Unselected values retain their types, including data and dates. Missing parent
+dictionaries are created; an existing scalar or array along the path is an error.
+Status compares only the selected value, and dry-run output shows its path.
+
+Declarations with the same domain, key, host, and path merge global → local, with the
+last value winning. Ancestor/descendant patches, or a patch and a whole-value
+declaration for the same preference and host, are rejected before writing.
+All patched values are prepared before the first preference write. As with other
+preferences, applications may change a value concurrently; this is not an atomic
+transaction with those applications.
+
 ## Commands
 
 ```sh

--- a/e2e/cli/test_system_defaults_patch_aliases
+++ b/e2e/cli/test_system_defaults_patch_aliases
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Equivalent global-domain names must not turn local overrides into overlaps.
+if [[ $(uname) != Darwin ]]; then
+  exit 0
+fi
+require_cmd jq
+
+write_patch() {
+  cat >"$1" <<EOF_CONFIG
+[[bootstrap.macos.defaults_entries]]
+domain = "$2"
+key = "_mise_patch_alias_test_$$"
+path = ["nested", "enabled"]
+value = $3
+EOF_CONFIG
+}
+
+for alias in -g -globalDomain; do
+  write_patch "$MISE_CONFIG_DIR/config.toml" "$alias" true
+  write_patch mise.toml NSGlobalDomain false
+  assert 'mise bootstrap macos defaults status --json | jq -c "[.macos_defaults.entries[].value]"' '[false]'
+  write_patch "$MISE_CONFIG_DIR/config.toml" NSGlobalDomain true
+  write_patch mise.toml "$alias" false
+  assert 'mise bootstrap macos defaults status --json | jq -c "[.macos_defaults.entries[].value]"' '[false]'
+done
+
+# Aliases still share ownership: an ancestor patch conflicts with a descendant.
+write_patch "$MISE_CONFIG_DIR/config.toml" -g true
+cat >mise.toml <<EOF_CONFIG
+[[bootstrap.macos.defaults_entries]]
+domain = "NSGlobalDomain"
+key = "_mise_patch_alias_test_$$"
+path = ["nested"]
+value = { enabled = false }
+EOF_CONFIG
+assert_fail 'mise bootstrap macos defaults status' 'overlapping macOS defaults declarations'

--- a/e2e/cli/test_system_defaults_patches
+++ b/e2e/cli/test_system_defaults_patches
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+domain="com.mise.defaults-patch-test.$$"
+cat >"$MISE_CONFIG_DIR/config.toml" <<EOF_CONFIG
+[[bootstrap.macos.defaults_entries]]
+domain = "$domain"
+key = "Shortcuts"
+path = ["64", "enabled"]
+value = true
+EOF_CONFIG
+cat >mise.toml <<EOF_CONFIG
+[[bootstrap.macos.defaults_entries]]
+domain = "$domain"
+key = "Shortcuts"
+path = ["64", "enabled"]
+value = false
+[[bootstrap.macos.defaults_entries]]
+domain = "$domain"
+key = "Shortcuts"
+path = ["literal.key", "items"]
+value = [1, true, "three"]
+EOF_CONFIG
+if [[ $(uname) != Darwin ]]; then
+  require_cmd jq
+  assert 'mise bootstrap macos defaults status --json | jq -c ".macos_defaults.entries[0] | [.host, .path, .value, .state]"' '["any",["64","enabled"],false,"skipped"]'
+  mise bootstrap status --json | jq -c .macos_defaults >aggregate.json
+  assert 'mise bootstrap macos defaults status --json | jq -c .macos_defaults' "$(cat aggregate.json)"
+  assert_contains 'mise bootstrap macos defaults status' skipped
+  assert_succeed 'mise bootstrap macos defaults apply --yes'
+else
+  require_cmd jq
+  # Core Foundation writes outside the harness HOME, to the user's preference store.
+  # Remove only this test's preference domain.
+  trap 'defaults delete "$domain" >/dev/null 2>&1 || true; defaults -currentHost delete "$domain" >/dev/null 2>&1 || true' EXIT
+  defaults write "$domain" Shortcuts '{ "64" = { enabled = 1; parameters = (32, 49, 1048576); }; "65" = { enabled = 1; }; }'
+  assert_contains 'mise bootstrap macos defaults apply --dry-run' 'Shortcuts["64"]["enabled"] = false'
+  assert_succeed 'mise bootstrap macos defaults apply --yes'
+  assert_succeed 'mise bootstrap macos defaults status --missing'
+  assert 'mise bootstrap macos defaults status --json | jq ".macos_defaults.entries | length"' 2
+  assert 'mise bootstrap macos defaults status --json | jq -c ".macos_defaults.entries[0].path"' '["64","enabled"]'
+  assert_contains "defaults read '$domain' Shortcuts" parameters
+  assert_contains "defaults read '$domain' Shortcuts" 65
+  assert_contains 'mise bootstrap macos defaults apply --yes 2>&1' '2 value(s) already set'
+  # The same path on the current host reads and preserves that scope's siblings.
+  defaults -currentHost write "$domain" Shortcuts '{ "64" = { enabled = 1; }; hostOnly = 42; }'
+  cat >>mise.toml <<EOF_CONFIG
+[[bootstrap.macos.defaults_entries]]
+domain = "$domain"
+key = "Shortcuts"
+host = "current"
+path = ["64", "enabled"]
+value = false
+EOF_CONFIG
+  assert_contains 'mise bootstrap macos defaults apply --dry-run' '(current host)'
+  assert_succeed 'mise bootstrap macos defaults apply --yes'
+  assert_succeed 'mise bootstrap macos defaults status --missing'
+  assert_contains "defaults -currentHost read '$domain' Shortcuts" hostOnly
+  assert_contains "defaults read '$domain' Shortcuts" parameters
+  assert_contains 'mise bootstrap macos defaults apply --yes 2>&1' '3 value(s) already set'
+  # Overlapping declarations fail even when one already matches the stored value.
+  cat >>mise.toml <<EOF_CONFIG
+[[bootstrap.macos.defaults_entries]]
+domain = "$domain"
+key = "Shortcuts"
+path = ["64"]
+value = { enabled = false }
+EOF_CONFIG
+  assert_fail 'mise bootstrap macos defaults apply --yes' 'overlapping macOS defaults declarations'
+  # A whole-value declaration and a patch must not compete for the same key.
+  cat >mise.toml <<EOF_CONFIG
+[bootstrap.macos.defaults."$domain"]
+Shortcuts = {}
+EOF_CONFIG
+  assert_fail 'mise bootstrap macos defaults apply --yes' 'overlapping macOS defaults declarations'
+  cat >mise.toml <<EOF_CONFIG
+[[bootstrap.macos.defaults_entries]]
+domain = "$domain"
+key = "Other"
+path = []
+value = false
+EOF_CONFIG
+  assert_fail 'mise bootstrap macos defaults status' 'defaults patch path must not be empty'
+fi

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4738,6 +4738,14 @@
                   "key": {
                     "type": "string"
                   },
+                  "path": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Dictionary keys below the preference key; omitted to replace the whole value"
+                  },
                   "host": {
                     "type": "string",
                     "enum": ["any", "current"],

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -3828,7 +3828,7 @@ impl BootstrapStatus {
             for req in &defaults {
                 report.row(
                     "defaults",
-                    format!("{} {}", req.display_domain(), req.key),
+                    format!("{} {}", req.display_domain(), req.display_key()),
                     "",
                     format!("skipped ({reason})"),
                     false,
@@ -3850,7 +3850,7 @@ impl BootstrapStatus {
             };
             report.row(
                 "defaults",
-                format!("{} {}", s.request.display_domain(), s.request.key),
+                format!("{} {}", s.request.display_domain(), s.request.display_key()),
                 current.clone(),
                 state,
                 missing,
@@ -3858,6 +3858,7 @@ impl BootstrapStatus {
             json_entries.push(json!({
                 "domain": s.request.domain,
                 "host": s.request.host,
+                "path": s.request.path,
                 "key": s.request.key,
                 "value": s.request.value.to_json(),
                 "current": current,
@@ -4766,6 +4767,7 @@ fn unavailable_defaults_json(
             json!({
                 "domain": req.domain,
                 "host": req.host,
+                "path": req.path,
                 "key": req.key,
                 "value": req.value.to_json(),
                 "state": "skipped",
@@ -4793,7 +4795,7 @@ impl BootstrapMacosDefaultsStatus {
                     for req in &defaults {
                         rows.push(vec![
                             req.display_domain(),
-                            req.key.clone(),
+                            req.display_key(),
                             req.value.to_string(),
                             "".to_string(),
                             format!("skipped ({reason})"),
@@ -4819,6 +4821,7 @@ impl BootstrapMacosDefaultsStatus {
                         json_entries.push(json!({
                             "domain": s.request.domain,
                             "host": s.request.host,
+                            "path": s.request.path,
                             "key": s.request.key,
                             "value": s.request.value.to_json(),
                             "current": current,
@@ -4827,7 +4830,7 @@ impl BootstrapMacosDefaultsStatus {
                     } else {
                         rows.push(vec![
                             s.request.display_domain(),
-                            s.request.key.clone(),
+                            s.request.display_key(),
                             s.request.value.to_string(),
                             current,
                             state.to_string(),
@@ -5087,6 +5090,7 @@ mod tests {
             domain: "com.mise.test".into(),
             key: "Settings".into(),
             host: HostScope::Current,
+            path: Some(vec!["nested".into(), "enabled".into()]),
             value: DefaultsValue::Bool(false),
         };
         let output = super::unavailable_defaults_json(&[request], "macOS only");
@@ -5099,6 +5103,7 @@ mod tests {
                     "domain": "com.mise.test",
                     "key": "Settings",
                     "host": "current",
+                    "path": ["nested", "enabled"],
                     "value": false,
                     "state": "skipped",
                 }],

--- a/src/system/defaults.rs
+++ b/src/system/defaults.rs
@@ -35,10 +35,24 @@ pub(crate) struct DefaultsRequest {
     pub key: String,
     /// Use the current host instead of the any-host preference scope.
     pub host: HostScope,
+    /// A nonempty dictionary path, or None to replace the whole preference.
+    pub path: Option<Vec<String>>,
     pub value: DefaultsValue,
 }
 
 impl DefaultsRequest {
+    pub(crate) fn display_key(&self) -> String {
+        let mut key = self.key.clone();
+        if let Some(path) = &self.path {
+            for component in path {
+                key.push('[');
+                key.push_str(&serde_json::to_string(component).expect("string serialization"));
+                key.push(']');
+            }
+        }
+        key
+    }
+
     pub(crate) fn display_domain(&self) -> String {
         if self.host == HostScope::Current {
             format!("{} (current host)", self.domain)
@@ -50,7 +64,13 @@ impl DefaultsRequest {
 
 impl std::fmt::Display for DefaultsRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {} = {}", self.display_domain(), self.key, self.value)
+        write!(
+            f,
+            "{} {} = {}",
+            self.display_domain(),
+            self.display_key(),
+            self.value
+        )
     }
 }
 
@@ -200,6 +220,7 @@ pub(crate) fn unavailable_reason() -> String {
 
 /// Query the current state of each entry. Side-effect free.
 pub(crate) async fn status(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsStatus>> {
+    validate_requests(requests)?;
     let requests = requests.to_vec();
     tokio::task::spawn_blocking(move || status_sync(&requests)).await?
 }
@@ -207,13 +228,15 @@ pub(crate) async fn status(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsS
 fn status_sync(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsStatus>> {
     let mut out = vec![];
     for req in requests {
-        let state = match read(&req.domain, &req.key, req.host)? {
+        let current = read(&req.domain, &req.key, req.host)?;
+        let current = selected_value(current.as_ref(), req)?;
+        let state = match current {
             Some(current) => {
-                if req.value.matches(&current) {
+                if req.value.matches(current) {
                     DefaultsState::Set
                 } else {
                     DefaultsState::Differs {
-                        current: display_plist(&current),
+                        current: display_plist(current),
                     }
                 }
             }
@@ -229,9 +252,10 @@ fn status_sync(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsStatus>> {
 
 /// Write the given entries (already filtered to unset/differing ones)
 pub(crate) async fn apply(requests: &[DefaultsRequest], dry_run: bool) -> Result<()> {
+    validate_requests(requests)?;
     for req in requests {
         if dry_run {
-            if let Some(write_args) = req.value.write_args() {
+            if let Some(write_args) = req.value.write_args().filter(|_| req.path.is_none()) {
                 let mut args = vec![];
                 if req.host == HostScope::Current {
                     args.push("-currentHost".to_string());
@@ -251,6 +275,108 @@ pub(crate) async fn apply(requests: &[DefaultsRequest], dry_run: bool) -> Result
     }
     let requests = requests.to_vec();
     tokio::task::spawn_blocking(move || write_all(&requests)).await?
+}
+
+/// Reject conflicting ownership before inspecting or writing preferences.
+fn validate_requests(requests: &[DefaultsRequest]) -> Result<()> {
+    for (i, request) in requests.iter().enumerate() {
+        if let Some(path) = &request.path {
+            eyre::ensure!(
+                !path.is_empty(),
+                "defaults patch path must not be empty: {request}"
+            );
+        }
+        for other in &requests[..i] {
+            if canonical_domain(&request.domain) != canonical_domain(&other.domain)
+                || request.key != other.key
+                || request.host != other.host
+            {
+                continue;
+            }
+            let overlaps = match (&request.path, &other.path) {
+                (None, None) => false, // Preserve existing whole-value declarations.
+                (Some(a), Some(b)) => a.starts_with(b) || b.starts_with(a),
+                _ => true,
+            };
+            eyre::ensure!(
+                !overlaps,
+                "overlapping macOS defaults declarations: {other}; {request}"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn selected_value<'a>(
+    mut current: Option<&'a plist::Value>,
+    request: &DefaultsRequest,
+) -> Result<Option<&'a plist::Value>> {
+    if let Some(path) = &request.path {
+        for component in path {
+            current = match current {
+                Some(plist::Value::Dictionary(dict)) => dict.get(component),
+                None => return Ok(None),
+                Some(_) => eyre::bail!("expected dictionary along defaults patch path: {request}"),
+            };
+        }
+    }
+    Ok(current)
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn patch_value(current: &mut plist::Value, path: &[String], value: plist::Value) -> Result<()> {
+    let Some((key, rest)) = path.split_first() else {
+        eyre::bail!("defaults patch path must not be empty");
+    };
+    let dict = current
+        .as_dictionary_mut()
+        .ok_or_else(|| eyre::eyre!("expected dictionary along defaults patch path"))?;
+    if rest.is_empty() {
+        dict.insert(key.clone(), value);
+    } else {
+        if !dict.contains_key(key) {
+            dict.insert(
+                key.clone(),
+                plist::Value::Dictionary(plist::Dictionary::new()),
+            );
+        }
+        patch_value(
+            dict.get_mut(key).expect("dictionary entry inserted"),
+            rest,
+            value,
+        )?;
+    }
+    Ok(())
+}
+
+/// Prepare every value before writing, including all patches of the same key.
+#[cfg(any(target_os = "macos", test))]
+fn prepare_writes(
+    requests: &[DefaultsRequest],
+    mut read: impl FnMut(&str, &str, HostScope) -> Result<Option<plist::Value>>,
+) -> Result<IndexMap<(String, String, HostScope), plist::Value>> {
+    validate_requests(requests)?;
+    let mut writes = IndexMap::new();
+    for request in requests {
+        let domain = canonical_domain(&request.domain);
+        let key = (domain.to_string(), request.key.clone(), request.host);
+        if let Some(path) = &request.path {
+            if !writes.contains_key(&key) {
+                let current = read(domain, &request.key, request.host)?
+                    .unwrap_or_else(|| plist::Value::Dictionary(plist::Dictionary::new()));
+                writes.insert(key.clone(), current);
+            }
+            patch_value(
+                writes.get_mut(&key).expect("preference inserted"),
+                path,
+                request.value.to_plist(),
+            )
+            .map_err(|err| eyre::eyre!("{request}: {err}"))?;
+        } else {
+            writes.insert(key, request.value.to_plist());
+        }
+    }
+    Ok(writes)
 }
 
 fn display_plist(value: &plist::Value) -> String {
@@ -378,9 +504,9 @@ mod macos {
         Ok(Some(plist::Value::from_reader_xml(data.bytes())?))
     }
 
-    fn set(domain: &str, key: &str, value: &DefaultsValue, host: HostScope) -> Result<()> {
+    fn set(domain: &str, key: &str, value: &plist::Value, host: HostScope) -> Result<()> {
         let mut xml = Vec::new();
-        plist::to_writer_xml(&mut xml, &value.to_plist())?;
+        plist::to_writer_xml(&mut xml, value)?;
         let data = CFData::from_buffer(&xml);
         let (value, _) = create_with_data(data, kCFPropertyListImmutable)
             .map_err(|err| eyre::eyre!("failed to parse macOS preference: {err}"))?;
@@ -413,9 +539,10 @@ mod macos {
 
     pub(super) fn write_all(requests: &[DefaultsRequest]) -> Result<()> {
         let mut domains = IndexSet::new();
-        for request in requests {
-            set(&request.domain, &request.key, &request.value, request.host)?;
-            domains.insert((request.domain.as_str(), request.host));
+        let writes = prepare_writes(requests, read)?;
+        for ((domain, key, host), value) in &writes {
+            set(domain, key, value, *host)?;
+            domains.insert((domain.as_str(), *host));
         }
         for (domain, host) in domains {
             synchronize(domain, host)?;
@@ -562,6 +689,7 @@ mod tests {
             domain: domain.clone(),
             key: "ScopeValue".into(),
             host: HostScope::Any,
+            path: None,
             value: DefaultsValue::Bool(true),
         };
         let host = DefaultsRequest {
@@ -588,6 +716,201 @@ mod tests {
         cleanup_host.unwrap();
     }
 
+    fn patch(path: &[&str], value: DefaultsValue) -> DefaultsRequest {
+        DefaultsRequest {
+            domain: "com.mise.patch-test".into(),
+            key: "Shortcuts".into(),
+            host: HostScope::Any,
+            path: Some(path.iter().map(|s| s.to_string()).collect()),
+            value,
+        }
+    }
+
+    #[test]
+    fn test_patches_preserve_siblings_and_plist_types() {
+        let mut original = DefaultsValue::from_toml(&val(
+            r#"{ "64" = { enabled = true, parameters = [32, 49, 1048576] }, "65" = { enabled = true } }"#,
+        )).unwrap().to_plist();
+        let dict = original.as_dictionary_mut().unwrap();
+        dict.insert("data".into(), plist::Value::Data(vec![0, 255]));
+        dict.insert(
+            "date".into(),
+            plist::Value::Date(std::time::UNIX_EPOCH.into()),
+        );
+        let requests = [
+            patch(&["64", "enabled"], DefaultsValue::Bool(false)),
+            patch(&["new.key", "enabled"], DefaultsValue::Bool(true)),
+        ];
+        let mut reads = 0;
+        let writes = prepare_writes(&requests, |_, _, _| {
+            reads += 1;
+            Ok(Some(original.clone()))
+        })
+        .unwrap();
+        assert_eq!(reads, 1);
+        let updated = writes.values().next().unwrap();
+        let mut expected = original.clone();
+        let dict = expected.as_dictionary_mut().unwrap();
+        dict.get_mut("64")
+            .unwrap()
+            .as_dictionary_mut()
+            .unwrap()
+            .insert("enabled".into(), plist::Value::Boolean(false));
+        dict.insert(
+            "new.key".into(),
+            DefaultsValue::from_toml(&val("{ enabled = true }"))
+                .unwrap()
+                .to_plist(),
+        );
+        assert_eq!(updated, &expected);
+        for request in &requests {
+            assert!(
+                request
+                    .value
+                    .matches(selected_value(Some(updated), request).unwrap().unwrap())
+            );
+        }
+        let again = prepare_writes(&requests, |_, _, _| Ok(Some(updated.clone()))).unwrap();
+        assert_eq!(again, writes);
+    }
+
+    #[test]
+    fn test_patches_create_missing_dictionaries_but_reject_wrong_types() {
+        let request = patch(&["64", "enabled"], DefaultsValue::Bool(false));
+        let writes = prepare_writes(std::slice::from_ref(&request), |_, _, _| Ok(None)).unwrap();
+        assert_eq!(
+            writes.values().next().unwrap(),
+            &DefaultsValue::from_toml(&val(r#"{ "64" = { enabled = false } }"#,))
+                .unwrap()
+                .to_plist()
+        );
+        assert_eq!(selected_value(None, &request).unwrap(), None);
+        for value in [
+            plist::Value::Boolean(true),
+            DefaultsValue::from_toml(&val(r#"{ "64" = [true] }"#))
+                .unwrap()
+                .to_plist(),
+        ] {
+            assert!(selected_value(Some(&value), &request).is_err());
+            assert!(
+                prepare_writes(std::slice::from_ref(&request), |_, _, _| Ok(Some(
+                    value.clone()
+                )))
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn test_patches_reject_overlapping_ownership() {
+        let request = patch(&["64", "enabled"], DefaultsValue::Bool(false));
+        for path in [
+            None,
+            Some(vec!["64".into()]),
+            request.path.clone(),
+            Some(vec!["64".into(), "enabled".into(), "child".into()]),
+        ] {
+            let other = DefaultsRequest {
+                path,
+                ..request.clone()
+            };
+            assert!(validate_requests(&[request.clone(), other]).is_err());
+        }
+        assert!(validate_requests(&[patch(&[], DefaultsValue::Bool(false))]).is_err());
+        let any = DefaultsRequest {
+            domain: "-g".into(),
+            ..request.clone()
+        };
+        let global = DefaultsRequest {
+            domain: "NSGlobalDomain".into(),
+            path: None,
+            ..request
+        };
+        assert!(validate_requests(&[any, global]).is_err());
+    }
+
+    #[test]
+    fn test_patch_host_scopes_have_independent_ownership_and_reads() {
+        let any = patch(&["enabled"], DefaultsValue::Bool(false));
+        let current = DefaultsRequest {
+            host: HostScope::Current,
+            ..any.clone()
+        };
+        let whole_current = DefaultsRequest {
+            path: None,
+            ..current.clone()
+        };
+        assert!(validate_requests(&[any.clone(), whole_current]).is_ok());
+        let mut scopes = vec![];
+        let writes = prepare_writes(&[any, current], |_, _, host| {
+            scopes.push(host);
+            Ok(Some(
+                DefaultsValue::from_toml(&val(if host == HostScope::Any {
+                    "{ sibling = 1 }"
+                } else {
+                    "{ sibling = 2 }"
+                }))
+                .unwrap()
+                .to_plist(),
+            ))
+        })
+        .unwrap();
+        assert_eq!(scopes, vec![HostScope::Any, HostScope::Current]);
+        for ((_, _, host), value) in writes {
+            let dict = value.as_dictionary().unwrap();
+            assert_eq!(dict.get("enabled"), Some(&plist::Value::Boolean(false)));
+            assert_eq!(
+                dict.get("sibling").unwrap().as_signed_integer(),
+                Some(if host == HostScope::Any { 1 } else { 2 })
+            );
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_patch_native_round_trip_and_preflight() {
+        let domain = format!("com.mise.patch-test.{}", uuid::Uuid::now_v7());
+        let original =
+            DefaultsValue::from_toml(&val(r#"{ "64" = { enabled = true }, data = [1, 2] }"#))
+                .unwrap();
+        let whole = DefaultsRequest {
+            domain: domain.clone(),
+            path: None,
+            value: original.clone(),
+            ..patch(&["64"], DefaultsValue::Bool(false))
+        };
+        let request = DefaultsRequest {
+            domain: domain.clone(),
+            ..patch(&["64", "enabled"], DefaultsValue::Bool(false))
+        };
+        write_all(&[whole]).unwrap();
+        let apply = write_all(std::slice::from_ref(&request));
+        let current = read(&domain, &request.key, HostScope::Any);
+        let status = status_sync(std::slice::from_ref(&request));
+        // A later invalid patch must prevent an earlier valid write.
+        let invalid = DefaultsRequest {
+            path: Some(vec!["data".into(), "child".into()]),
+            ..request.clone()
+        };
+        let valid = DefaultsRequest {
+            value: DefaultsValue::Bool(true),
+            ..request.clone()
+        };
+        let failed = write_all(&[valid, invalid]);
+        let after_failed = read(&domain, &request.key, HostScope::Any);
+        let cleanup = macos::remove(&domain, &request.key, HostScope::Any);
+        apply.unwrap();
+        let current = current.unwrap().unwrap();
+        assert_eq!(
+            current.as_dictionary().unwrap().get("data"),
+            original.to_plist().as_dictionary().unwrap().get("data")
+        );
+        assert_eq!(status.unwrap()[0].state, DefaultsState::Set);
+        assert!(failed.is_err());
+        assert_eq!(after_failed.unwrap(), Some(current));
+        cleanup.unwrap();
+    }
+
     /// `status()` must not fail when keys don't exist yet — this is the
     /// expected path on a fresh macOS install.
     #[cfg(target_os = "macos")]
@@ -597,6 +920,7 @@ mod tests {
             // key doesn't exist in a real domain
             DefaultsRequest {
                 host: HostScope::Any,
+                path: None,
                 domain: "NSGlobalDomain".into(),
                 key: "_mise_test_nonexistent_key_42".into(),
                 value: DefaultsValue::Bool(true),
@@ -604,6 +928,7 @@ mod tests {
             // domain doesn't exist at all
             DefaultsRequest {
                 host: HostScope::Any,
+                path: None,
                 domain: "com.mise.nonexistent".into(),
                 key: "TestKey".into(),
                 value: DefaultsValue::Bool(true),
@@ -634,6 +959,7 @@ mod tests {
 
         write_all(&[DefaultsRequest {
             host: HostScope::Any,
+            path: None,
             domain: domain.into(),
             key: key.into(),
             value: value.clone(),

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -323,6 +323,8 @@ pub(crate) struct BootstrapMacosDefaultsEntry {
     pub key: String,
     #[serde(default)]
     pub host: HostScope,
+    #[serde(default)]
+    pub path: Option<Vec<String>>,
     pub value: toml::Value,
 }
 
@@ -766,11 +768,11 @@ fn merge_package_configs<'a>(
 
 /// Aggregate macOS defaults across all loaded config files.
 ///
-/// Within each host scope, (domain, key) pairs union global -> local; a more
-/// local config overrides the value a global config declared. Unsupported value shapes warn
-/// (forward compatibility) and are skipped.
+/// Within each host scope, (domain, key, path) entries union global -> local;
+/// a more local config overrides the value a global config declared. Unsupported
+/// value shapes warn (forward compatibility) and are skipped.
 pub(crate) fn defaults_from_config(config: &Config) -> Vec<DefaultsRequest> {
-    let mut merged: IndexMap<(String, String, HostScope), toml::Value> = IndexMap::new();
+    let mut merged = IndexMap::new();
     // config_files is ordered local -> global; reverse for global -> local
     for cf in config.config_files.values().rev() {
         if let Some(sys) = cf.bootstrap_config() {
@@ -791,7 +793,7 @@ pub(crate) fn defaults_from_config(config: &Config) -> Vec<DefaultsRequest> {
             }
             for (key, value) in merge_raw_over_friendly_macos_defaults(friendly, raw) {
                 merged.insert(
-                    (canonical_domain(&key.0).into(), key.1, HostScope::Any),
+                    (canonical_domain(&key.0).into(), key.1, HostScope::Any, None),
                     value,
                 );
             }
@@ -801,6 +803,7 @@ pub(crate) fn defaults_from_config(config: &Config) -> Vec<DefaultsRequest> {
                         canonical_domain(&entry.domain).into(),
                         entry.key,
                         entry.host,
+                        entry.path,
                     ),
                     entry.value,
                 );
@@ -808,12 +811,13 @@ pub(crate) fn defaults_from_config(config: &Config) -> Vec<DefaultsRequest> {
         }
     }
     let mut out = vec![];
-    for ((domain, key, host), value) in merged {
+    for ((domain, key, host, path), value) in merged {
         match DefaultsValue::from_toml(&value) {
             Some(value) => out.push(DefaultsRequest {
                 domain,
                 key,
                 host,
+                path,
                 value,
             }),
             None => {
@@ -896,7 +900,12 @@ pub(crate) fn macos_defaults_entry_count(macos: &BootstrapMacosTomlConfig) -> us
         .into_iter()
         .map(|((domain, key), value)| {
             (
-                (canonical_domain(&domain).to_owned(), key, HostScope::Any),
+                (
+                    canonical_domain(&domain).to_owned(),
+                    key,
+                    HostScope::Any,
+                    None,
+                ),
                 value,
             )
         })
@@ -907,6 +916,7 @@ pub(crate) fn macos_defaults_entry_count(macos: &BootstrapMacosTomlConfig) -> us
                 canonical_domain(&entry.domain).to_owned(),
                 entry.key.clone(),
                 entry.host,
+                entry.path.clone(),
             ),
             entry.value.clone(),
         );
@@ -2594,6 +2604,7 @@ mod tests {
             domain: "NSGlobalDomain".into(),
             key: "KeyRepeat".into(),
             host: HostScope::Current,
+            path: None,
             value: tv("3"),
         });
         assert_eq!(macos_defaults_entry_count(&macos), 6);


### PR DESCRIPTION
Add an optional `path` to `[[bootstrap.macos.defaults_entries]]` so mise can manage a nested dictionary value without replacing its siblings. Paths work with both `host = "any"` and `host = "current"`; omitting the path retains whole-value replacement.

Updates preserve existing property-list types, create missing dictionary parents, and replace the selected leaf as a whole. Array indexing is unsupported. Exact paths merge global → local, including equivalent global-domain aliases. Overlapping paths and whole-value/path conflicts are rejected within each host scope. All values are prepared before writing, so a malformed dictionary cannot cause an earlier patch to be applied.

Both status commands include configured entries with their scope and path when defaults are unavailable, marking each entry as skipped.

Preference updates use native read-modify-write operations and are not atomic with concurrent application writes.

Builds on the explicit defaults entries and host-scope support merged in #12983. Related: #12981.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for current-host macOS preferences and targeted nested dictionary updates.
  - Added curated Dock, Finder, and Keyboard preference options.
  - Improved macOS defaults status and JSON output with host and path details.
  - Added package environment selectors and improved Nix package export handling.

- **Documentation**
  - Documented supported preferences, host scopes, nested updates, validation, and status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->