### PR TITLE
fix(bootstrap): sign hard-linked Mach-O aliases after relocation

### DIFF
--- a/src/system/packages/brew/relocate.rs
+++ b/src/system/packages/brew/relocate.rs
@@ -15,6 +15,8 @@
 //! string ended exactly at its slot boundary, which we detect and report as an
 //! error rather than corrupt the binary.
 
+use std::collections::HashSet;
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 use eyre::bail;
@@ -214,12 +216,21 @@ fn relocate_keg_with_replacements(
     // breaks it (extend/os/linux/keg_relocate.rb)
     let patch_elf = formula_name != "glibc" && !formula_name.starts_with("glibc@");
     let mut report = RelocationReport::default();
+    let mut changed_macho_inodes = HashSet::new();
     for entry in walkdir::WalkDir::new(keg).follow_links(false) {
         let entry = entry?;
         if !entry.file_type().is_file() {
             continue;
         }
         let path = entry.path();
+        let metadata = path.metadata()?;
+        let inode = (metadata.dev(), metadata.ino());
+        // codesign can replace an inode, so every alias needs its own signature
+        if changed_macho_inodes.contains(&inode) {
+            report.changed_machos.push(path.to_path_buf());
+            report.changed_files.push(path.to_path_buf());
+            continue;
+        }
         let content = crate::file::read(path)?;
         if !contains_any_placeholder(&content, replacements) {
             continue;
@@ -230,7 +241,7 @@ fn relocate_keg_with_replacements(
         if skip_linkage && (macho || elf || (content.contains(&0) && shebang_end.is_none())) {
             continue;
         }
-        let perms = path.metadata()?.permissions();
+        let perms = metadata.permissions();
         // bottle files are often read-only; lift that while we patch
         let mut writable = perms.clone();
         std::os::unix::fs::PermissionsExt::set_mode(
@@ -251,6 +262,7 @@ fn relocate_keg_with_replacements(
             if changed {
                 crate::file::write(path, &content)?;
                 if macho {
+                    changed_macho_inodes.insert(inode);
                     report.changed_machos.push(path.to_path_buf());
                 }
                 report.changed_files.push(path.to_path_buf());
@@ -367,6 +379,51 @@ pub(super) mod tests {
         assert_eq!(binary.metadata()?.permissions().mode() & 0o777, 0o444);
         assert_eq!(report.changed_files, vec![text]);
         assert!(report.changed_machos.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_relocate_macho_hard_links() -> Result<()> {
+        for skip_linkage in [false, true] {
+            let tmp = tempfile::tempdir()?;
+            let paths =
+                ["fish", "fish_indent", "fish_key_reader"].map(|name| tmp.path().join(name));
+            let mut content = vec![0; 32];
+            content[..4].copy_from_slice(&0xfeedfacf_u32.to_le_bytes());
+            content.extend_from_slice(b"@@HOMEBREW_PREFIX@@/lib/libpcre2.dylib\0");
+            crate::file::write(&paths[0], &content)?;
+            for path in &paths[1..] {
+                std::fs::hard_link(&paths[0], path)?;
+            }
+            std::fs::set_permissions(&paths[0], std::fs::Permissions::from_mode(0o555))?;
+            std::os::unix::fs::symlink(&paths[0], tmp.path().join("symlink"))?;
+            let untouched = tmp.path().join("untouched");
+            crate::file::write(&untouched, &content[..32])?;
+
+            let mut report = relocate_keg_with_replacements(
+                tmp.path(),
+                "fish",
+                skip_linkage,
+                &test_replacements(),
+            )?;
+
+            let expected = if skip_linkage { vec![] } else { paths.to_vec() };
+            report.changed_files.sort();
+            report.changed_machos.sort();
+            assert_eq!(report.changed_files, expected);
+            assert_eq!(report.changed_machos, expected);
+            for path in &paths {
+                let relocated = crate::file::read(path)?;
+                if skip_linkage {
+                    assert_eq!(relocated, content);
+                } else {
+                    assert!(!contains_any_placeholder(&relocated, &test_replacements()));
+                    assert!(memmem(&relocated, b"/opt/homebrew/lib/libpcre2.dylib").is_some());
+                }
+                assert_eq!(path.metadata()?.permissions().mode() & 0o777, 0o555);
+            }
+            assert_eq!(crate::file::read(&untouched)?, content[..32]);
+        }
         Ok(())
     }
 


### PR DESCRIPTION
When a Homebrew bottle contains hard-linked Mach-O executables, relocating one path changes the shared inode. The other paths then have no placeholders left and are omitted from the signing list. On macOS, `codesign` can replace the signed path's inode, leaving its aliases with relocated contents and an invalid signature.

This reproduces with fish 4.9.3: `fish_indent` passes signature verification while `fish` is killed with SIGKILL after a successful bootstrap install. The original bottle's `fish` signature is valid.

Track modified Mach-O files by device and inode during relocation, and include every encountered hard-link alias in both the signing list and the changed-files receipt. This keeps signing limited to modified binaries rather than re-signing the entire keg. Add regression coverage for three aliases, unchanged files, symlinks, permissions, and skipped linkage relocation.

Related: https://github.com/jdx/mise/discussions/12765 (reports fish 4.9.0; reproduction and verification here used 4.9.3).

Validation:
- Contributor ran `mise run test:unit -- system::packages::brew::relocate::tests` successfully and built with `mise run build`.
- Contributor installed fish 4.9.3 with the patched debug binary into a fresh temporary prefix using `MISE_SYSTEM_BREW_PREFIX`. Strict signature verification passed for `fish`, `fish_indent`, and `fish_key_reader`; `fish --no-config -c 'echo fish-started'` ran successfully.
- Scoped hk Cargo formatting check/fix and `git diff --check` passed.
- Build completed with an oversized `__eh_frame` linker warning and a future-incompatibility notice for `proc-macro-error2 v2.0.1`. Full-suite tests and Clippy were not run locally.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed relocation and code signing for hard-linked Mach-O files, ensuring every alias is correctly recognized and signed.
  - Prevented redundant patching of the same underlying file while preserving correct results for each linked path.
  - Preserved file permissions and existing behavior for symlinks and unaffected files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->