### PR TITLE
fix(install): install a lazy tool's missing dependencies on first use

### DIFF
--- a/docs/dev-tools/shims.md
+++ b/docs/dev-tools/shims.md
@@ -100,9 +100,11 @@ declare their command names with `lazy_bins`:
 
 Run `mise reshim` after editing a lazy declaration directly. Commands such as
 `mise use` that update tool configuration rebuild the shim farm automatically.
-Invoking a lazy shim installs only its configured provider and then executes
-it. This is independent of `not_found_auto_install`; an explicit project tool
-selection is never bypassed by a lower-precedence lazy declaration.
+Invoking a lazy shim installs its configured provider, plus any configured tools
+that provider [depends](/dev-tools/#tool-dependencies) on that are not installed
+yet, and then executes it. Nothing else in the toolset is installed. This is
+independent of `not_found_auto_install`; an explicit project tool selection is
+never bypassed by a lower-precedence lazy declaration.
 
 A bare `mise install` skips missing lazy tools. Pass `--include-lazy` to install
 all configured tools, including lazy declarations, or name one explicitly, such

--- a/e2e/cli/test_lazy_tools_depends
+++ b/e2e/cli/test_lazy_tools_depends
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+export MISE_SHIMS_DIR="$HOME/.local/share/mise/user-shims"
+export PATH="$MISE_SHIMS_DIR:$PATH"
+
+# A lazy tool's dependency is commonly lazy itself, so `mise install` never
+# materializes it. First-use dispatch must install the whole missing dependency
+# closure: the needs-dummy install script fails unless dummy is already on disk.
+mkdir -p "$MISE_CONFIG_DIR"
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[tools.dummy]
+lazy = true
+lazy_bins = ["dummy"]
+version = "2.0.0"
+
+[tools.needs-dummy]
+depends = ["dummy"]
+lazy = true
+lazy_bins = ["needs-dummy"]
+version = "1.0.0"
+EOF
+
+mise reshim
+mise install
+assert_fail "test -d '$MISE_DATA_DIR/installs/needs-dummy/1.0.0'"
+assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/2.0.0'"
+
+assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 needs-dummy --version" "needs-dummy v1.0.0"
+assert_directory_exists "$MISE_DATA_DIR/installs/dummy/2.0.0"
+assert_directory_exists "$MISE_DATA_DIR/installs/needs-dummy/1.0.0"
+
+# `mise x` dispatches through the same lazy provider path.
+mise uninstall --all needs-dummy
+mise uninstall --all dummy
+assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 mise x -- needs-dummy --version" "needs-dummy v1.0.0"
+assert_directory_exists "$MISE_DATA_DIR/installs/dummy/2.0.0"
+
+# An already-installed dependency is not reinstalled or duplicated.
+mise uninstall --all needs-dummy
+assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 needs-dummy --version" "needs-dummy v1.0.0"
+assert_directory_exists "$MISE_DATA_DIR/installs/dummy/2.0.0"

--- a/e2e/cli/test_lazy_tools_depends
+++ b/e2e/cli/test_lazy_tools_depends
@@ -39,3 +39,21 @@ assert_directory_exists "$MISE_DATA_DIR/installs/dummy/2.0.0"
 mise uninstall --all needs-dummy
 assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 needs-dummy --version" "needs-dummy v1.0.0"
 assert_directory_exists "$MISE_DATA_DIR/installs/dummy/2.0.0"
+
+# The dependency preflight requires every configured version of a dependency, so
+# all of them have to be installed, not just the first one that matches.
+mise uninstall --all needs-dummy
+mise uninstall --all dummy
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[tools]
+dummy = [
+  { version = "1.0.0", lazy = true, lazy_bins = ["dummy"] },
+  { version = "2.0.0", lazy = true, lazy_bins = ["dummy"] },
+]
+needs-dummy = { version = "1.0.0", depends = ["dummy"], lazy = true, lazy_bins = ["needs-dummy"] }
+EOF
+
+mise reshim
+assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 needs-dummy --version" "needs-dummy v1.0.0"
+assert_directory_exists "$MISE_DATA_DIR/installs/dummy/1.0.0"
+assert_directory_exists "$MISE_DATA_DIR/installs/dummy/2.0.0"

--- a/e2e/cli/test_lazy_tools_system
+++ b/e2e/cli/test_lazy_tools_system
@@ -26,6 +26,28 @@ assert_contains "dummy --version" "This is Dummy 1.0.0"
 assert_directory_exists "$MISE_SYSTEM_INSTALLS_DIR/dummy/1.0.0"
 assert_fail "test -d '$MISE_DATA_DIR/installs/dummy/1.0.0'"
 
+# A lazy provider installs its missing dependencies too, and each tool is stored
+# in the scope of the config that declares it. A system provider must not drag a
+# user-scoped dependency into the system installs directory.
+cat >"$MISE_SYSTEM_CONFIG_FILE" <<'EOF'
+[tools]
+dummy = { version = "2.0.0", depends = ["pitchfork"], lazy = true, lazy_bins = ["dummy"] }
+EOF
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+[tools]
+pitchfork = { version = "0.1.5", lazy = true, lazy_bins = ["pitchfork"] }
+EOF
+mise reshim
+mise reshim --system
+assert_contains "MISE_NOT_FOUND_AUTO_INSTALL=0 dummy --version" "This is Dummy 2.0.0"
+assert_directory_exists "$MISE_SYSTEM_INSTALLS_DIR/dummy/2.0.0"
+assert_directory_exists "$MISE_DATA_DIR/installs/pitchfork/0.1.5"
+assert_fail "test -d '$MISE_SYSTEM_INSTALLS_DIR/pitchfork'"
+cat >"$MISE_CONFIG_DIR/config.toml" <<'EOF'
+EOF
+mise uninstall --all pitchfork
+mise uninstall dummy@2.0.0
+
 # Upgrades preserve an existing system install's storage scope.
 cat >"$MISE_SYSTEM_CONFIG_FILE" <<'EOF'
 [tools]

--- a/src/toolset/install_options.rs
+++ b/src/toolset/install_options.rs
@@ -24,6 +24,10 @@ pub(crate) struct InstallOptions {
     pub locked: bool,
     /// Override the install directory (e.g. for --system or --shared)
     pub install_dir: Option<PathBuf>,
+    /// Derive each tool's install directory from the scope of the config file that
+    /// declares it. Lazy first-use dispatch installs a provider together with its
+    /// dependencies, and those can come from different scopes.
+    pub scoped_install_dirs: bool,
     /// skip confirmation prompts (e.g. installing missing plugin system deps).
     /// Defaults to the global `yes` setting; `mise bootstrap --yes` also sets it.
     pub yes: bool,
@@ -45,6 +49,7 @@ impl Default for InstallOptions {
             global_hooks_only: false,
             locked: Settings::get().locked,
             install_dir: None,
+            scoped_install_dirs: false,
             yes: Settings::get().yes,
         }
     }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -98,9 +98,9 @@ impl Toolset {
             let declarations = install_dependency_declarations(&requests[next]);
             next += 1;
             for candidate in &missing {
-                if declarations.matches(candidate.ba())
-                    && !requests.iter().any(|tr| tr.ba().as_ref() == candidate.ba())
-                {
+                // Keyed on the request, not the backend: the preflight requires every
+                // configured version of a dependency, not just the first one.
+                if declarations.matches(candidate.ba()) && !requests.contains(&candidate.request) {
                     requests.push(candidate.request.clone());
                 }
             }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -13,7 +13,7 @@ use crate::config::Config;
 use crate::config::settings::Settings;
 use crate::errors::Error;
 use crate::hooks::{Hooks, InstalledToolInfo};
-use crate::install_context::InstallContext;
+use crate::install_context::{InstallContext, install_dependency_declarations};
 use crate::plugins::PluginType;
 use crate::registry::REGISTRY;
 use crate::toolset::Toolset;
@@ -84,6 +84,30 @@ impl Toolset {
             .is_some())
     }
 
+    /// A lazy tool's dependencies are commonly lazy themselves, so nothing else
+    /// installs them and the provider alone fails its dependency preflight.
+    async fn lazy_install_requests(
+        &self,
+        config: &Arc<Config>,
+        tv: &ToolVersion,
+    ) -> Vec<ToolRequest> {
+        let missing = self.list_missing_versions_for_install(config).await;
+        let mut requests = vec![tv.request.clone()];
+        let mut next = 0;
+        while next < requests.len() {
+            let declarations = install_dependency_declarations(&requests[next]);
+            next += 1;
+            for candidate in &missing {
+                if declarations.matches(candidate.ba())
+                    && !requests.iter().any(|tr| tr.ba().as_ref() == candidate.ba())
+                {
+                    requests.push(candidate.request.clone());
+                }
+            }
+        }
+        requests
+    }
+
     pub(crate) async fn install_missing_lazy_bin(
         &mut self,
         config: &mut Arc<Config>,
@@ -102,8 +126,9 @@ impl Toolset {
             install_dir: install_dir.filter(|dir| dir != *crate::dirs::INSTALLS),
             ..Default::default()
         };
+        let requests = self.lazy_install_requests(config, &tv).await;
         let installed = self
-            .install_all_versions(config, vec![tv.request.clone()], &install_options)
+            .install_all_versions(config, requests, &install_options)
             .await
             .wrap_err_with(|| {
                 install_options.install_dir.as_ref().map_or_else(

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use eyre::Result;
@@ -116,14 +117,13 @@ impl Toolset {
         let Some(tv) = self.missing_lazy_bin_provider(config, bin_name).await? else {
             return Ok(None);
         };
-        let install_dir = tv.request.source().path().and_then(|path| {
-            (crate::config::provenance::ConfigProvenance::from_path(path).scope()
-                == crate::config::provenance::ConfigFileScope::System)
-                .then(|| Settings::get().system_installs_dir().to_path_buf())
-        });
+        // The batch can span scopes, so each tool resolves its own destination rather
+        // than inheriting the provider's. The provider's own directory is still needed
+        // to explain a failure that is caused by writing outside the user's install dir.
+        let provider_install_dir = scope_installs_dir(&tv.request);
         let install_options = InstallOptions {
             reason: "lazy shim".into(),
-            install_dir: install_dir.filter(|dir| dir != *crate::dirs::INSTALLS),
+            scoped_install_dirs: true,
             ..Default::default()
         };
         let requests = self.lazy_install_requests(config, &tv).await;
@@ -131,7 +131,7 @@ impl Toolset {
             .install_all_versions(config, requests, &install_options)
             .await
             .wrap_err_with(|| {
-                install_options.install_dir.as_ref().map_or_else(
+                provider_install_dir.as_ref().map_or_else(
                     || format!("failed to install lazy tool {}", tv.style()),
                     |dir| {
                         format!(
@@ -751,7 +751,12 @@ impl Toolset {
         .await?;
         let backend = tv.backend()?;
         backend::ensure_backend_enabled(&backend.get_type())?;
-        if let Some(dir) = &opts.install_dir {
+        let install_dir = opts.install_dir.clone().or_else(|| {
+            opts.scoped_install_dirs
+                .then(|| scope_installs_dir(tr))
+                .flatten()
+        });
+        if let Some(dir) = &install_dir {
             let tool_dir_name = tv.ba().tool_dir_name();
             tv.install_path = Some(dir.join(tool_dir_name).join(tv.tv_pathname()));
             tv.install_path_is_explicit = true;
@@ -918,6 +923,19 @@ impl Toolset {
     fn parse_plugin_key(key: &str) -> (PluginType, &str) {
         PluginType::from_plugin_config(key)
     }
+}
+
+/// The install directory a tool belongs in based on the scope of the config file that
+/// declares it. Only system configuration relocates; everything else uses the default.
+fn scope_installs_dir(tr: &ToolRequest) -> Option<PathBuf> {
+    tr.source()
+        .path()
+        .and_then(|path| {
+            (crate::config::provenance::ConfigProvenance::from_path(path).scope()
+                == crate::config::provenance::ConfigFileScope::System)
+                .then(|| Settings::get().system_installs_dir().to_path_buf())
+        })
+        .filter(|dir| dir != *crate::dirs::INSTALLS)
 }
 
 fn lazy_bin_names_eq(configured: &str, requested: &str) -> bool {


### PR DESCRIPTION
### Issue

A lazy tool's `depends` target is commonly lazy itself, and in that case nothing ever installs it. `mise install` skips lazy tools by design, and first-use dispatch installs only the provider, so the dependency preflight fails. The hint it prints suggests `mise install`, which skips lazy tools, so there is no way out except to stop marking the dependency lazy.

> We hit this with [hk](https://hk.jdx.dev). Both `python` and `ruff` were marked lazy, and hk invokes `ruff` itself during a check run, so it failed mid-workflow while `mise install` kept reporting that everything was already installed.

### Fix

With this change, upon the first-use dispatch through a shim, `mise x`, or a task, mise now installs the provider together with its still-missing configured dependencies.

### Reproduction

```toml
# mise.toml
[tools.python]
lazy = true
lazy_bins = ["python", "python3"]
version = "3"

[tools.ruff]
depends = ["python"]
lazy = true
version = "latest"
```

```sh
$ mise install
#> mise all tools are installed          # lazy tools are skipped by design

$ ruff --version
#> mise ERROR failed to install lazy tool ruff@0.16.6
#> mise ERROR Failed to install aqua:astral-sh/ruff@latest: tool 'ruff@latest' requires
#>   configured install dependency 'python@3', but its selected version is not installed
#> hint: Run `mise install python@3` before installing 'ruff@latest'. Remove the
#> dependency from configuration to allow the install hook to rely on system PATH instead.
```

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5[1m]; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lazy tool execution now installs configured tools along with missing direct and transitive dependencies.
  - Dependency installation works consistently during direct execution and through `mise x`.
  - Already-installed dependencies are reused without duplicate installation.
  - Each dependency is installed in the scope associated with its configuration, including support for multiple configured versions.

- **Documentation**
  - Updated developer documentation to reflect lazy tool dependency installation.

- **Tests**
  - Added end-to-end coverage for dependency installation, reuse, multiple versions, and configuration scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->