### PR TITLE
ci(release): publish version after release

### DIFF
--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -1,0 +1,59 @@
+name: publish-version
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Published release tag to expose (e.g., v2026.9.3)"
+        required: true
+        type: string
+
+concurrency:
+  group: publish-version-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}
+
+jobs:
+  publish-version:
+    if: |
+      (github.event_name == 'release' &&
+       startsWith(github.event.release.tag_name, 'v') &&
+       !github.event.release.prerelease) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Resolve published release
+        id: release
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          TAG="${EVENT_TAG:-$INPUT_VERSION}"
+          if ! [[ "$TAG" =~ ^v[0-9][0-9A-Za-z._+-]*$ ]]; then
+            echo "::error::Invalid release tag: $TAG" >&2
+            exit 1
+          fi
+          RELEASE="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG")"
+          if ! jq -e '.draft == false and .prerelease == false' <<< "$RELEASE" >/dev/null; then
+            echo "::error::$TAG is not a published stable release" >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Install mise
+        run: |
+          curl -fsSL https://mise.run | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Publish VERSION and purge release caches
+        env:
+          CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+          CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+        run: mise x aws-cli@2.22.35 -- ./scripts/publish-version.sh "${{ steps.release.outputs.tag }}"

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -20,7 +20,7 @@ jobs:
        startsWith(github.event.release.tag_name, 'v') &&
        !github.event.release.prerelease) ||
       github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -44,16 +44,16 @@ jobs:
             echo "::error::$TAG is not a published stable release" >&2
             exit 1
           fi
+          LATEST_TAG="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')"
+          if [[ "$TAG" != "$LATEST_TAG" ]]; then
+            echo "::error::$TAG is not the latest stable release ($LATEST_TAG)" >&2
+            exit 1
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Install mise
-        run: |
-          curl -fsSL https://mise.run | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Publish VERSION and purge release caches
         env:
           CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
           CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
-        run: mise x aws-cli@2.22.35 -- ./scripts/publish-version.sh "${{ steps.release.outputs.tag }}"
+        run: ./scripts/publish-version.sh "${{ steps.release.outputs.tag }}"

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -26,6 +26,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Release events normally check out the tag. Use the trusted default
+          # branch so recovery also works for tags created before this script.
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Resolve published release
         id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -592,7 +592,6 @@ jobs:
         run: mise x -- scripts/publish-release.sh
         env:
           CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
           CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
 
   # !cancelled() replaces the implicit success() gate. Tag publishes skip

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,18 +1,14 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# This script runs after the GitHub release is successfully created
-# It updates the VERSION file and publishes to R2
+# This script stages release assets in R2 while the GitHub release is still a
+# draft. The VERSION pointer is published separately after the release becomes
+# public.
 
 BASE_DIR="$(pwd)"
 MISE_VERSION=$(./scripts/get-version.sh)
 RELEASE_DIR=releases
 export BASE_DIR MISE_VERSION RELEASE_DIR
-
-echo "::group::Create VERSION file"
-pushd "$RELEASE_DIR"
-echo "$MISE_VERSION" | tr -d 'v' >VERSION
-popd
 
 if [[ ${DRY_RUN:-0} != 1 ]]; then
 	echo "::group::Publish r2"

--- a/scripts/publish-s3.sh
+++ b/scripts/publish-s3.sh
@@ -23,7 +23,6 @@ aws s3 cp "$RELEASE_DIR" "s3://$AWS_S3_BUCKET/" --cache-control "$cache_day" --n
 aws s3 cp "$RELEASE_DIR" "s3://$AWS_S3_BUCKET/" --cache-control "$cache_day" --no-progress --content-type "text/plain" --recursive --exclude "*" --include "SHASUMS*"
 
 # Upload individual files sequentially to avoid rate limiting
-aws s3 cp "$RELEASE_DIR/VERSION" "s3://$AWS_S3_BUCKET/" --cache-control "$cache_day" --no-progress --content-type "text/plain"
 aws s3 cp "$RELEASE_DIR/install.sh" "s3://$AWS_S3_BUCKET/" --cache-control "$cache_day" --no-progress --content-type "text/plain"
 aws s3 cp "$RELEASE_DIR/install.sh.sig" "s3://$AWS_S3_BUCKET/" --cache-control "$cache_day" --no-progress
 aws s3 cp "$RELEASE_DIR/install.sh.minisig" "s3://$AWS_S3_BUCKET/" --cache-control "$cache_day" --no-progress
@@ -66,23 +65,5 @@ aws s3 cp artifacts/deb/dists/ "s3://$AWS_S3_BUCKET/deb/dists/" --cache-control 
 # since=`date --date '-3 years' +%F 2>/dev/null`
 # aws s3api list-objects-v2 --bucket "$AWS_S3_BUCKET" --query 'Contents[?LastModified < `'"$since"'`]' | jq -r '.[].Key' | grep "^(deb|rpm)\/"
 
-export CLOUDFLARE_ACCOUNT_ID=6e243906ff257b965bcae8025c2fc344
-
-# Purge every CDN zone that fronts the release artifacts. install.sh and
-# install.sh.minisig are uploaded with `immutable` cache-control, so without
-# an explicit purge per zone the CDN keeps serving the previous release's
-# bytes while a sibling zone serves the new ones — which is how mise.en.dev
-# ended up serving v(N-1)/install.sh next to a v(N) install.sh.minisig.
-ZONES=(
-	"jdx.dev:90dfd7997bdcfa8579c52d8ee8dd4cd1"
-	"en.dev:531d003297f1f4ae2415b41f7f5da8fa"
-	"mise.run:782fc08181b7bbd26c529a00df52a277"
-)
-for entry in "${ZONES[@]}"; do
-	IFS=":" read -r HOST ZONE_ID <<<"$entry"
-	echo "Purging CDN cache for $HOST (zone=$ZONE_ID)"
-	curl --fail-with-body -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/purge_cache" \
-		-H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-		-H "Content-Type: application/json" \
-		--data '{ "purge_everything": true }'
-done
+# Cache invalidation happens with VERSION after the GitHub release is public,
+# making the new latest artifacts and their discovery pointer visible together.

--- a/scripts/publish-version.sh
+++ b/scripts/publish-version.sh
@@ -19,6 +19,33 @@ export AWS_SECRET_ACCESS_KEY=$CLOUDFLARE_SECRET_ACCESS_KEY
 export AWS_RETRY_MODE=adaptive
 export AWS_MAX_ATTEMPTS=10
 
+# A recovery run can publish a draft without rerunning the original CDN staging
+# step. Do not expose it as latest unless every archive used by installers is
+# already present in R2.
+unix_platforms=(
+	linux-x64
+	linux-x64-musl
+	linux-arm64
+	linux-arm64-musl
+	linux-armv7
+	linux-armv7-musl
+	macos-x64
+	macos-arm64
+)
+for platform in "${unix_platforms[@]}"; do
+	for extension in tar.gz tar.xz tar.zst; do
+		aws s3api head-object \
+			--bucket mise \
+			--key "$TAG/mise-$TAG-$platform.$extension" >/dev/null
+	done
+done
+for platform in windows-arm64 windows-x64; do
+	aws s3api head-object \
+		--bucket mise \
+		--key "$TAG/mise-$TAG-$platform.zip" >/dev/null
+done
+aws s3api head-object --bucket mise --key "$TAG/SHASUMS256.txt" >/dev/null
+
 aws s3 cp "$version_file" s3://mise/VERSION \
 	--cache-control "max-age=86400,s-maxage=86400,public,immutable" \
 	--no-progress \

--- a/scripts/publish-version.sh
+++ b/scripts/publish-version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TAG=${1:?usage: publish-version.sh <release-tag>}
+if ! [[ $TAG =~ ^v[0-9][0-9A-Za-z._+-]*$ ]]; then
+	echo "Invalid release tag: $TAG" >&2
+	exit 1
+fi
+
+version_file=$(mktemp)
+trap 'rm -f "$version_file"' EXIT
+printf '%s\n' "${TAG#v}" >"$version_file"
+
+export AWS_REGION=auto
+export AWS_DEFAULT_OUTPUT=json
+export AWS_ENDPOINT_URL=https://6e243906ff257b965bcae8025c2fc344.r2.cloudflarestorage.com
+export AWS_ACCESS_KEY_ID=$CLOUDFLARE_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$CLOUDFLARE_SECRET_ACCESS_KEY
+export AWS_RETRY_MODE=adaptive
+export AWS_MAX_ATTEMPTS=10
+
+aws s3 cp "$version_file" s3://mise/VERSION \
+	--cache-control "max-age=86400,s-maxage=86400,public,immutable" \
+	--no-progress \
+	--content-type "text/plain"
+
+# Purge every zone that fronts release artifacts only after VERSION points at
+# the public release. This also makes the already-uploaded latest assets and
+# install scripts visible in the same post-publication cache refresh.
+ZONES=(
+	"jdx.dev:90dfd7997bdcfa8579c52d8ee8dd4cd1"
+	"en.dev:531d003297f1f4ae2415b41f7f5da8fa"
+	"mise.run:782fc08181b7bbd26c529a00df52a277"
+)
+for entry in "${ZONES[@]}"; do
+	IFS=":" read -r HOST ZONE_ID <<<"$entry"
+	echo "Purging CDN cache for $HOST (zone=$ZONE_ID)"
+	curl --fail-with-body -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/purge_cache" \
+		-H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+		-H "Content-Type: application/json" \
+		--data '{ "purge_everything": true }'
+done


### PR DESCRIPTION
## Summary

- stop publishing the CDN VERSION pointer while the GitHub release is still a draft
- publish VERSION from a dedicated release-published workflow after verifying the release is stable and public
- move CDN cache invalidation into that post-publication step and support manual reruns for recovery

## Testing

- mocked successful R2 upload and Cloudflare cache purges
- verified invalid release tags fail before publication
- bash -n scripts/publish-release.sh scripts/publish-s3.sh scripts/publish-version.sh
- shellcheck -x scripts/publish-release.sh scripts/publish-s3.sh scripts/publish-version.sh
- shfmt -d scripts/publish-release.sh scripts/publish-s3.sh scripts/publish-version.sh
- actionlint .github/workflows/publish-version.yml .github/workflows/release.yml (with repository ShellCheck exclusions)
- git diff --check

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when users see a new latest version and when CDN caches refresh; mis-timed or failed publish-version runs could leave VERSION stale or mismatched with staged assets until recovery.
> 
> **Overview**
> Release publishing now **stages R2/CDN assets while the GitHub release is still a draft** without updating the public **`VERSION`** pointer or purging Cloudflare caches.
> 
> A new **`publish-version`** workflow runs when a stable release is **published** (or via manual dispatch). It validates the tag format, confirms the release is non-draft/non-prerelease and matches GitHub’s **latest** stable tag, then runs **`scripts/publish-version.sh`**, which checks required platform archives/checksums exist in R2, uploads **`VERSION`**, and purges the release CDN zones.
> 
> **`publish-release.sh`** / **`publish-s3.sh`** drop VERSION upload and zone-wide cache purges; **`release.yml`** no longer passes **`CLOUDFLARE_API_TOKEN`** into the draft asset publish step since invalidation moved to the post-publication path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5df803c3cdf5e2658286a1accb54e5db914431. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated publication of stable release versions after a release is publicly available.
  - Added automatic CDN cache refresh for supported domains when a version is published.

- **Improvements**
  - Release assets can now be staged before publication, helping ensure downloads are available in the correct release sequence.
  - Added validation for valid, published, non-prerelease versions.
  - Added safeguards to confirm required platform assets and checksums are available before publishing a version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->