### PR TITLE
fix(packslip): resolve cross-platform lockfile artifacts

### DIFF
--- a/e2e/backend/test_registry_min_version
+++ b/e2e/backend/test_registry_min_version
@@ -5,6 +5,7 @@
 export MISE_EXPERIMENTAL=0
 export MISE_MINIMUM_RELEASE_AGE=0
 export MISE_REGISTRY_FLOATING=0
+detect_platform
 
 # Registry CI must exercise the newly published preferred backend immediately.
 MISE_MINIMUM_RELEASE_AGE=90d mise test-tool hk
@@ -47,3 +48,14 @@ assert_contains "mise ls-remote hk@old_prefix" "1.57.0"
 
 # Explicit backends remain explicit; no fallback after a verification error.
 assert_fail_contains "mise install --force packslip:github.com/jdx/hk@1.57.0" "no release"
+
+# Packslip resolves signed artifact metadata for the host and non-host
+# platforms, and locked installation consumes the generated host entry.
+mise lock hk@1.58.1 --platform "$MISE_PLATFORM,windows-x64"
+assert_contains "cat mise.lock" '[tools.hk."platforms.windows-x64"]'
+assert_contains "awk '/\[tools.hk\.\"platforms.windows-x64\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'checksum = "sha256:'
+assert_contains "awk '/\[tools.hk\.\"platforms.windows-x64\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'url = "https://github.com/jdx/hk/releases/download/v1.58.1/hk-x86_64-pc-windows-msvc.zip"'
+assert_contains "awk '/\[tools.hk\.\"platforms.windows-x64\"\]/{f=1;next}/^\[/{f=0}f' mise.lock" 'signer = "sigstore-oidc:https://github.com/jdx/hk/.github/workflows/release.yml"'
+mise uninstall hk@1.58.1
+mise install --locked hk@1.58.1
+assert_contains "mise exec hk@1.58.1 -- hk --version" "hk 1.58.1"

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -37,6 +37,7 @@ use crate::file;
 use crate::github;
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
+use crate::lockfile::PlatformInfo;
 use crate::packslip_pins::{self, Observed};
 use crate::platform::Platform;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions};
@@ -769,6 +770,87 @@ impl PackslipBackend {
         })
     }
 
+    /// Fetch and verify the release manifest without downloading its artifact.
+    /// Lock generation uses this to learn artifact URLs and signed digests for
+    /// any target platform, while latest-version selection uses the same policy
+    /// path to decide whether a candidate is eligible.
+    async fn verified_release(
+        &self,
+        project: &str,
+        tv: &ToolVersion,
+        pin: &Pin,
+        opts: &PackslipOptions<'_>,
+        stamp: Option<&crate::packslip_stamps::Stamp>,
+    ) -> Result<(Statement, packslip::Verified)> {
+        use sha2::{Digest, Sha256};
+
+        // With a stamp in hand the manifest is already named, so the vendor is
+        // asked only for withdrawals and its digest pin. Requiring the original
+        // release asset here would refuse a stamped mirror that install accepts.
+        let (url, vendor_digest) = match stamp {
+            Some(stamp) => {
+                if stamp.digest.is_none() {
+                    bail!(
+                        "the stamp for packslip:{project}@{} from {} records no sha256 for {}, so nothing says the manifest is the one that host reviewed",
+                        tv.version,
+                        stamp.host,
+                        stamp.entry.packslip
+                    );
+                }
+                (
+                    stamp.entry.packslip.clone(),
+                    self.vendor_entry(project, tv, pin, opts)
+                        .await?
+                        .and_then(|vendor| vendor.digest),
+                )
+            }
+            None => {
+                let vendor = self.locate_bundle(project, tv, pin, opts).await?;
+                (vendor.url, vendor.digest)
+            }
+        };
+        let text = HTTP_FETCH
+            .get_text_request(&url)
+            .headers(&headers_for(&url)?)
+            .send()
+            .await?;
+        let actual = hex::encode(Sha256::digest(text.as_bytes()));
+        for expected in vendor_digest
+            .iter()
+            .chain(stamp.and_then(|stamp| stamp.digest.as_ref()))
+        {
+            if &actual != expected {
+                bail!(
+                    "packslip:{project}@{}: manifest digest differs from signed list",
+                    tv.version
+                );
+            }
+        }
+        let verified = verify_bundle(&text, pin, !opts.allow_unlogged(), &[])?;
+        if verified.project != project || verified.version != tv.version {
+            bail!(
+                "packslip:{project}@{}: verified manifest project/version differs from discovery",
+                tv.version
+            );
+        }
+        let scheme = verified.scheme.to_string();
+        let attested_by = verified.attested_by.to_string();
+        packslip_pins::check(
+            project,
+            Observed {
+                scheme: &scheme,
+                key_id: &verified.key_id,
+                issuer: verified.issuer.as_deref(),
+                attested_by: &attested_by,
+                provenance: verified.provenance_linked,
+                logged: verified.logged_at.is_some(),
+            },
+        )?;
+        let payload = packslip::sigstore::peek_statement(&text).map_err(|e| eyre!("{e}"))?;
+        let statement: Statement = serde_json::from_slice(&payload)?;
+        Ok((statement, verified))
+    }
+
     async fn recommendation(
         &self,
         project: &str,
@@ -804,7 +886,6 @@ impl PackslipBackend {
         before: Option<jiff::Timestamp>,
         stamps: Option<&crate::packslip_stamps::Stamps>,
     ) -> Result<Option<String>> {
-        use sha2::{Digest, Sha256};
         let request = ToolRequest::new_with_options(
             self.ba.clone(),
             version,
@@ -819,57 +900,9 @@ impl PackslipBackend {
             },
             None => None,
         };
-        // The same reach `install` makes, and for the same reason: with a
-        // stamp in hand the manifest is already named, so the vendor is asked
-        // only for what the vendor decides. Going through `locate_bundle`
-        // would demand the original release asset too, and refuse a version
-        // `install` accepts.
-        let (url, vendor_digest) = match stamp {
-            Some(stamp) => (
-                stamp.entry.packslip.clone(),
-                self.vendor_entry(project, &tv, pin, opts)
-                    .await?
-                    .and_then(|vendor| vendor.digest),
-            ),
-            None => {
-                let vendor = self.locate_bundle(project, &tv, pin, opts).await?;
-                (vendor.url, vendor.digest)
-            }
-        };
-        let url = url.as_str();
-        let text = HTTP_FETCH
-            .get_text_request(url)
-            .headers(&headers_for(url)?)
-            .send()
+        let (statement, verified) = self
+            .verified_release(project, &tv, pin, opts, stamp)
             .await?;
-        let actual = hex::encode(Sha256::digest(text.as_bytes()));
-        for expected in vendor_digest
-            .iter()
-            .chain(stamp.and_then(|s| s.digest.as_ref()))
-        {
-            if &actual != expected {
-                bail!("packslip:{project}@{version}: manifest digest differs from signed list");
-            }
-        }
-        let verified = verify_bundle(&text, pin, !opts.allow_unlogged(), &[])?;
-        if verified.project != project || verified.version != version {
-            bail!(
-                "packslip:{project}@{version}: verified manifest project/version differs from discovery"
-            );
-        }
-        let scheme = verified.scheme.to_string();
-        let attested_by = verified.attested_by.to_string();
-        packslip_pins::check(
-            project,
-            Observed {
-                scheme: &scheme,
-                key_id: &verified.key_id,
-                issuer: verified.issuer.as_deref(),
-                attested_by: &attested_by,
-                provenance: verified.provenance_linked,
-                logged: verified.logged_at.is_some(),
-            },
-        )?;
         // Parse errors are verification errors, not age-policy exclusions.
         if !verified_age_allowed(
             verified.logged_at.as_deref(),
@@ -880,8 +913,6 @@ impl PackslipBackend {
                 "verified release time is after the allowed cutoff".into(),
             ));
         }
-        let payload = packslip::sigstore::peek_statement(&text).map_err(|e| eyre!("{e}"))?;
-        let statement: Statement = serde_json::from_slice(&payload)?;
         let artifact = match select_artifact(
             &statement.predicate.artifacts,
             &HostPlatform::current(),
@@ -1500,6 +1531,64 @@ impl Backend for PackslipBackend {
             return Err(error);
         }
         Ok(tv)
+    }
+
+    async fn resolve_lock_info(
+        &self,
+        tv: &ToolVersion,
+        target: &PlatformTarget,
+    ) -> Result<PlatformInfo> {
+        let project = self.project()?;
+        let raw_opts = tv.request.options();
+        let opts = PackslipOptions::new(&raw_opts);
+        let pin = pin(&project, &opts)?;
+        let stamps = crate::packslip_stamps::fetch(&project, &raw_opts).await?;
+        let stamp = match stamps.as_ref() {
+            Some(stamps) => Some(
+                stamps
+                    .stamp(&tv.version)
+                    .ok_or_else(|| stamps.refusal(&project, &tv.version))?,
+            ),
+            None => None,
+        };
+        let (statement, verified) = self
+            .verified_release(&project, tv, &pin, &opts, stamp)
+            .await?;
+        let before = crate::install_before::resolve_before_date_for_tool(
+            &self.ba,
+            tv.before_date,
+            raw_opts.minimum_release_age(),
+        )?;
+        check_verified_age(
+            verified.logged_at.as_deref(),
+            &verified.published_at,
+            before,
+        )?;
+        let artifact = select_artifact(
+            &statement.predicate.artifacts,
+            &HostPlatform::from_platform(&target.platform),
+            opts.variant().as_deref(),
+        )
+        .wrap_err_with(|| format!("selecting the packslip artifact for {}", target.to_key()))?;
+        let url = artifact
+            .url
+            .clone()
+            .ok_or_else(|| eyre!("the packslip gives no download URL for {}", artifact.name))?;
+        let scheme = verified.scheme.to_string();
+        Ok(PlatformInfo {
+            checksum: statement
+                .digest_of(&artifact.name)
+                .map(|digest| format!("sha256:{digest}")),
+            size: Some(artifact.size),
+            url: Some(url),
+            signer: Some(format!(
+                "{scheme}:{}",
+                packslip_pins::signer_of(&scheme, &verified.key_id)
+            )),
+            attested_by: (verified.attested_by == packslip::Attestor::Repackager)
+                .then(|| "repackager".to_string()),
+            ..Default::default()
+        })
     }
 
     /// `variant` decides which artifact is downloaded, so a lock entry for a


### PR DESCRIPTION
## Summary
- verify Packslip release manifests while generating lock metadata
- select the signed artifact for each requested target platform
- record its URL, SHA-256 checksum, and signer so locked installs work across platforms
- cover hk 1.58.1 with a non-host Windows lock target

Fixes the mise-side cause reported in jdx/hk Discussion #1351.

## Testing
- mise run format
- cargo test --locked --bin mise backend::packslip::tests
- mise run test:e2e e2e/backend/test_registry_min_version

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes packslip verification and lock metadata in security-sensitive paths, but behavior is constrained to verified manifests and existing pin/age checks with new e2e coverage.
> 
> **Overview**
> Packslip lock generation now **verifies the signed release manifest** and picks the artifact for each requested platform (not only the host), so `mise lock --platform` can record URL, SHA-256 checksum, size, and signer for targets like **windows-x64**.
> 
> Manifest fetch and verification are centralized in **`verified_release`**, which **`candidate_exclusion`** reuses for latest/eligibility checks instead of duplicating that logic.
> 
> E2E coverage locks **hk@1.58.1** for the host plus **windows-x64**, asserts the lock section contents, and confirms **`mise install --locked`** still works on the host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 246fb9e9f1e6ca4cd74361823d839afeb90106be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lock files now include verified release metadata for requested target platforms, including checksums, download URLs, package sizes, signer information, and attestation status.
  - Cross-platform resolution supports signed artifact metadata, including Windows x64 releases.

- **Bug Fixes**
  - Improved release verification helps ensure resolved artifacts match their published checksums and signatures.

- **Tests**
  - Added end-to-end coverage for generating Windows x64 lockfile entries with signed release details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->