### PR TITLE
fix(backend): handle unsupported ARM32 artifacts safely

### DIFF
--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1108,10 +1108,7 @@ impl AquaBackend {
             "macos" => "darwin",
             other => other,
         };
-        let target_arch = match target.arch_name() {
-            "x64" => "amd64",
-            other => other,
-        };
+        let target_arch = to_aqua_arch(target.arch_name());
         (target_os, target_arch)
     }
 
@@ -3654,6 +3651,13 @@ mod tests {
     use super::*;
     use aqua_registry::{AquaFile, AquaVar, ParsedRegistry};
 
+    #[test]
+    fn aqua_uses_go_arch_name_for_32_bit_arm() {
+        assert_eq!(to_aqua_arch("arm"), "arm");
+        assert_eq!(to_aqua_arch("x64"), "amd64");
+        assert_eq!(to_aqua_arch("arm64"), "arm64");
+    }
+
     // `--dry-run` reaches `validate` through `resolve_validated_package`, and this is the sentence
     // it has to be able to produce before the install starts. Pinned here because
     // `e2e/cli/test_install_dry_run_feasibility` greps for it: aqua marks specific versions
@@ -5227,14 +5231,13 @@ pub(crate) fn os() -> &'static str {
 }
 
 pub(crate) fn arch() -> &'static str {
-    if cfg!(target_arch = "x86_64") {
-        "amd64"
-    } else if cfg!(target_arch = "arm") {
-        "armv6l"
-    } else if cfg!(target_arch = "aarch64") {
-        "arm64"
-    } else {
-        &ARCH
+    to_aqua_arch(&ARCH)
+}
+
+fn to_aqua_arch(arch: &str) -> &str {
+    match arch {
+        "x64" => "amd64",
+        other => other,
     }
 }
 

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -345,9 +345,7 @@ impl AssetPicker {
         scored_assets
             .into_iter()
             .filter(|(score, asset)| {
-                *score > 0
-                    && !self.has_arch_mismatch(asset)
-                    && !is_package_or_installer_asset(asset)
+                *score > 0 && !self.has_arch_mismatch(asset) && !is_non_executable_asset(asset)
             })
             .min_by(|(score_a, name_a), (score_b, name_b)| {
                 score_b
@@ -701,13 +699,12 @@ impl AssetPicker {
     }
 }
 
-/// Package archives and installers are not directly executable and mise does
-/// not extract them. Keep them out of automatic selection while still allowing
-/// an explicit `asset_pattern` or URL to select one for custom installation
-/// logic.
-fn is_package_or_installer_asset(asset: &str) -> bool {
+/// Assets that cannot become a runnable tool through mise's normal extraction
+/// path. Keep them out of automatic selection while still allowing an explicit
+/// `asset_pattern` or URL to select one for custom installation logic.
+fn is_non_executable_asset(asset: &str) -> bool {
     let asset = asset.to_lowercase();
-    asset.split('.').any(|extension| {
+    let is_package_or_installer = asset.split('.').any(|extension| {
         matches!(
             extension,
             "apk"
@@ -722,7 +719,12 @@ fn is_package_or_installer_asset(asset: &str) -> bool {
                 | "pkg"
                 | "rpm"
         )
-    })
+    });
+    let filename = asset.rsplit('/').next().unwrap_or(&asset);
+    let is_generic_source_archive = extraction_suffix_len(filename)
+        .map(|suffix_len| &filename[..filename.len() - suffix_len])
+        .is_some_and(|stem| matches!(stem, "source" | "source-code" | "src"));
+    is_package_or_installer || is_generic_source_archive
 }
 
 fn asset_matches_preferred_name(asset: &str, preferred_name: &str) -> bool {
@@ -2660,6 +2662,24 @@ abc123def456abc123def456abc123def456abc123def456abc123def456abcd  tool-1.0.0-dar
 
         assert_eq!(picker.pick_best_asset(&assets), None);
         assert_eq!(picker.with_matching(".deb").pick_best_asset(&assets), None);
+    }
+
+    #[test]
+    fn test_source_archive_not_picked_when_platform_has_no_binary() {
+        // Regression test for https://github.com/jdx/mise/discussions/12996.
+        // Pixi publishes this generic source archive alongside binaries for
+        // other architectures. Extracting it does not build an ARM executable.
+        let assets = vec![
+            "pixi-aarch64-unknown-linux-musl.tar.gz".to_string(),
+            "pixi-riscv64gc-unknown-linux-gnu.tar.gz".to_string(),
+            "pixi-x86_64-unknown-linux-musl.tar.gz".to_string(),
+            "source.tar.gz".to_string(),
+            "source.tar.gz.sha256".to_string(),
+        ];
+        let picker = AssetPicker::with_libc("linux".to_string(), "arm".to_string(), None)
+            .with_preferred_name("pixi");
+
+        assert_eq!(picker.pick_best_asset(&assets), None);
     }
 
     #[test]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -84,9 +84,9 @@ impl Platform {
 
         // Validate architecture
         match self.arch.as_str() {
-            "x64" | "arm64" | "arm" | "x86" | "loongarch64" | "riscv64" => {}
+            "x64" | "arm64" | "x86" | "loongarch64" | "riscv64" => {}
             _ => bail!(
-                "Unsupported architecture '{}'. Supported: x64, arm64, arm, x86, loongarch64, riscv64",
+                "Unsupported architecture '{}'. Supported: x64, arm64, x86, loongarch64, riscv64",
                 self.arch
             ),
         }
@@ -412,16 +412,14 @@ mod tests {
     fn test_platform_multiple_parsing() {
         let platform_strings = vec![
             "linux-x64".to_string(),
-            "linux-arm".to_string(),
             "macos-arm64".to_string(),
             "linux-x64".to_string(), // duplicate should be removed
         ];
 
         let platforms = Platform::parse_multiple(&platform_strings).unwrap();
-        assert_eq!(platforms.len(), 3);
-        assert_eq!(platforms[0].to_key(), "linux-arm");
-        assert_eq!(platforms[1].to_key(), "linux-x64");
-        assert_eq!(platforms[2].to_key(), "macos-arm64");
+        assert_eq!(platforms.len(), 2);
+        assert_eq!(platforms[0].to_key(), "linux-x64");
+        assert_eq!(platforms[1].to_key(), "macos-arm64");
     }
 
     #[test]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -84,9 +84,9 @@ impl Platform {
 
         // Validate architecture
         match self.arch.as_str() {
-            "x64" | "arm64" | "x86" | "loongarch64" | "riscv64" => {}
+            "x64" | "arm64" | "arm" | "x86" | "loongarch64" | "riscv64" => {}
             _ => bail!(
-                "Unsupported architecture '{}'. Supported: x64, arm64, x86, loongarch64, riscv64",
+                "Unsupported architecture '{}'. Supported: x64, arm64, arm, x86, loongarch64, riscv64",
                 self.arch
             ),
         }
@@ -412,14 +412,16 @@ mod tests {
     fn test_platform_multiple_parsing() {
         let platform_strings = vec![
             "linux-x64".to_string(),
+            "linux-arm".to_string(),
             "macos-arm64".to_string(),
             "linux-x64".to_string(), // duplicate should be removed
         ];
 
         let platforms = Platform::parse_multiple(&platform_strings).unwrap();
-        assert_eq!(platforms.len(), 2);
-        assert_eq!(platforms[0].to_key(), "linux-x64");
-        assert_eq!(platforms[1].to_key(), "macos-arm64");
+        assert_eq!(platforms.len(), 3);
+        assert_eq!(platforms[0].to_key(), "linux-arm");
+        assert_eq!(platforms[1].to_key(), "linux-x64");
+        assert_eq!(platforms[2].to_key(), "macos-arm64");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- use the canonical Go architecture name `arm` for Aqua instead of inventing `armv6l`
- reject generic source archives during automatic GitHub release asset selection

## Context
Discussion #12996 exposed two mise-owned failure modes on 32-bit ARM. Aqua URL rendering used `armv6l`, which bypassed registry replacements keyed by the canonical `arm` architecture. Separately, the GitHub backend could choose `source.tar.gz` when every published binary targeted a different architecture, then report the extracted source tree as an installed tool.

This makes current-host and cross-platform Aqua resolution use the same architecture mapping. It also keeps generic source archives out of automatic selection, while preserving explicit `asset_pattern` and URL configuration for tools that intentionally consume them.

The neovim x86_64 selection reported in the discussion is in the separate vfox-neovim plugin and requires an upstream fix there. Individual Aqua packages may also need registry replacements for their ARM artifact spelling.

## Validation
- `mise run format`
- scoped `hk run check --safe --format json`
- `mise x -- cargo test --bin mise aqua_uses_go_arch_name_for_32_bit_arm`
- `mise x -- cargo test --bin mise test_source_archive_not_picked_when_platform_has_no_binary`

Closes the mise-owned parts of https://github.com/jdx/mise/discussions/12996.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*