### PR TITLE
test(doctor): scope dotfiles warning assertion

### DIFF
--- a/e2e/cli/test_dotfiles_watch_throttle
+++ b/e2e/cli/test_dotfiles_watch_throttle
@@ -90,7 +90,7 @@ assert_contains "cat watch.log" '"event":"throttled"'
 assert_contains "mise bootstrap dotfiles paths --noisy" "state.json"
 assert_contains "mise bootstrap dotfiles status" "throttled: ~/.config/hypr/state.json changes constantly"
 assert_contains "mise doctor 2>&1 || true" "state.json changes constantly"
-assert_not_contains "mise doctor 2>&1 || true" "warning"
+assert "mise doctor --json 2>/dev/null | jq '[.warnings[]? | select(contains(\"state.json changes constantly\"))] | length'" "0"
 # never excluded, never switched to manual saving
 assert_not_contains "cat $MISE_CONFIG_DIR/config.toml" "exclude"
 assert_not_contains "cat $MISE_CONFIG_DIR/config.toml" "autosave"


### PR DESCRIPTION
## Summary
- check the structured `mise doctor --json` warnings in the dotfiles throttle E2E test
- reject only warnings about the throttled file instead of every unrelated doctor warning

The previous assertion searched the entire human-readable `mise doctor` output for the word `warning`. This made the test fail whenever another valid warning was present, including the new-version warning seen in jdx/mise#13001 after 2026.9.3 was published.

## Testing
- `MBX_DISABLE=1 mise run test:e2e e2e/cli/test_dotfiles_watch_throttle`
- `mise run lint-fix`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test-only change; no production behavior modified.
> 
> **Overview**
> **Tightens the dotfiles watch throttle E2E test** so it no longer fails when `mise doctor` prints unrelated warnings (e.g. a new-version notice).
> 
> The test still checks human `mise doctor` output for the throttled `state.json` message, but replaces a blanket `assert_not_contains` on the word `warning` with a structured check: **`mise doctor --json` must have zero entries in `warnings` that mention `state.json changes constantly`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc5070afb8345aa666ab89c7a220c9f12c91fdf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->