### PR TITLE
fix(packslip): preserve executable extensions on Windows

### DIFF
--- a/e2e-win/packslip.Tests.ps1
+++ b/e2e-win/packslip.Tests.ps1
@@ -1,0 +1,17 @@
+Describe 'packslip' {
+    It 'puts a Packslip executable on PATH with its Windows extension' {
+        $previousMinimumReleaseAge = $env:MISE_MINIMUM_RELEASE_AGE
+        $env:MISE_MINIMUM_RELEASE_AGE = '0'
+        try {
+            mise x packslip:github.com/jdx/fnox@1.35.1 -- fnox --version |
+                Out-String | Should -Match 'fnox 1\.35\.1'
+
+            $installPath = (mise where packslip:github.com/jdx/fnox@1.35.1).Trim()
+            Join-Path $installPath '.mise-bins\fnox.exe' | Should -Exist
+            Join-Path $installPath '.mise-bins\fnox' | Should -Not -Exist
+        }
+        finally {
+            $env:MISE_MINIMUM_RELEASE_AGE = $previousMinimumReleaseAge
+        }
+    }
+}

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -1539,6 +1539,7 @@ impl Backend for PackslipBackend {
     }
 }
 
+/// The PATH entry for a canonical Packslip command name.
 fn bin_link_path(bins_dir: &Path, name: &str) -> PathBuf {
     if cfg!(windows) {
         bins_dir.join(format!("{name}.exe"))

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -939,7 +939,7 @@ impl PackslipBackend {
                 );
             };
             file::make_executable(&src)?;
-            let dst = bins_dir.join(&bin.name);
+            let dst = bin_link_path(&bins_dir, &bin.name);
             if dst.exists() || dst.is_symlink() {
                 file::remove_all(&dst)?;
             }
@@ -1539,6 +1539,14 @@ impl Backend for PackslipBackend {
     }
 }
 
+fn bin_link_path(bins_dir: &Path, name: &str) -> PathBuf {
+    if cfg!(windows) {
+        bins_dir.join(format!("{name}.exe"))
+    } else {
+        bins_dir.join(name)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2021,5 +2029,16 @@ list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packsl
             None,
             "a file is not a dir"
         );
+    }
+
+    #[test]
+    fn links_bins_under_platform_executable_names() {
+        let bins_dir = Path::new("install").join(MISE_BINS_DIR);
+        let expected = if cfg!(windows) {
+            bins_dir.join("tool.exe")
+        } else {
+            bins_dir.join("tool")
+        };
+        assert_eq!(bin_link_path(&bins_dir, "tool"), expected);
     }
 }


### PR DESCRIPTION
## Summary

- append `.exe` to Packslip command names when creating the Windows `.mise-bins` directory
- keep the existing extensionless command names on Unix
- add unit coverage plus a Windows end-to-end regression that executes fnox and checks the generated path

Discussion: https://github.com/jdx/mise/discussions/12994

## Validation

- `mise run format`
- `mise run test:unit backend::packslip::tests::links_bins_under_platform_executable_names`
- Windows end-to-end test added for CI (`e2e-win/packslip.Tests.ps1`)

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized install-time path naming for packslip shims with tests; no auth, lockfile, or verification logic changes.
> 
> **Overview**
> Packslip installs now create shim links in `.mise-bins` using **platform-correct executable names**: `tool.exe` on Windows and extensionless `tool` elsewhere, via a new `bin_link_path` helper used when symlinking/copying packslip-declared binaries.
> 
> A **Windows E2E test** installs `fnox` through packslip, runs it on PATH, and asserts only `fnox.exe` exists under `.mise-bins`. A **unit test** locks in `bin_link_path` behavior per OS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4072cb600c874dc75f10f3193a6bc72622683ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows executable links so installed command-line tools use the correct `.exe` filename.
  * Added coverage to verify Windows installation and execution behavior for packaged tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->