### PR TITLE
fix(generate): honor tool stub os for Windows launchers

### DIFF
--- a/docs/dev-tools/tool-stubs.md
+++ b/docs/dev-tools/tool-stubs.md
@@ -65,6 +65,7 @@ are passed to the selected backend, while `tool`, `version`, `bin`, `os`,
 - `tool` - Explicit tool name or backend specification (e.g., "python", "github:cli/cli"). If omitted, a top-level or platform-specific URL selects the HTTP backend; otherwise mise uses the stub filename as the tool name.
 - `version` - The version request (defaults to `latest`)
 - `bin` - The binary name to execute within the tool (defaults to the stub filename)
+- `os` - Operating systems on which the stub is available, optionally narrowed by architecture (for example, `["linux", "macos/arm64"]`)
 
 ## HTTP Stubs
 
@@ -340,11 +341,12 @@ beside the stub. Run the stub by name and Windows picks it up through `PATHEXT`:
 .\bin\my-tool.cmd --version
 ```
 
-The launcher is generated whenever the stub could run on Windows — either it lists a
-`[platforms.windows-*]` entry, or it names no platforms at all. A stub that ships only for, say,
-Linux and macOS does not get one, and neither does a stub whose own name already ends in `.cmd`,
-`.bat` or `.exe`. The launcher is written on every platform, not just Windows, so a stub generated on Linux
-and committed to a repository still works for someone who clones it on Windows.
+The launcher is generated whenever the stub could run on Windows. An explicit `os` selector must
+include Windows, and any platform tables must include a `[platforms.windows-*]` entry. A stub that
+declares neither restriction also gets a launcher. A stub limited to Linux and macOS does not get
+one, and neither does a stub whose own name already ends in `.cmd`, `.bat` or `.exe`. The launcher
+is written on every platform, not just Windows, so a stub generated on Linux and committed to a
+repository still works for someone who clones it on Windows.
 
 If a stub later stops shipping for Windows, regenerating it removes the launcher, so it cannot keep
 running against platforms the stub no longer declares. Only a launcher mise generated is removed —

--- a/e2e/generate/test_generate_tool_stub_lock
+++ b/e2e/generate/test_generate_tool_stub_lock
@@ -17,6 +17,7 @@ cat >bin/tiny <<'EOF'
 tool = "github:jdx/tiny"
 version = "1"
 bin = "bin/tiny"
+os = ["macos", "linux"]
 EOF
 chmod +x bin/tiny
 
@@ -36,6 +37,10 @@ assert_contains "cat bin/tiny" "#!/usr/bin/env -S mise tool-stub"
 
 # Verify the tool field is preserved
 assert_contains "cat bin/tiny" 'tool = "github:jdx/tiny"'
+
+# The stub's OS selector is the support boundary. Lock coverage only controls which artifacts are
+# pre-resolved, so a missing lock platform alone must not decide whether a launcher is written.
+assert_fail "test -f bin/tiny.cmd"
 
 # Test 2: Bump version with --lock --version
 assert_succeed "mise generate tool-stub bin/tiny --lock --version 2"

--- a/src/cli/generate/tool_stub.rs
+++ b/src/cli/generate/tool_stub.rs
@@ -992,6 +992,7 @@ static WINDOWS_LAUNCHER: LazyLock<String> =
 ///
 /// - lists a `[platforms.*]` table with a windows entry → yes
 /// - lists `[platforms.*]` tables but none for windows → no, this tool does not ship for Windows
+/// - lists an `os` selector that excludes Windows → no, regardless of backend support
 /// - lists no platforms at all (`tool = "python"`, or a bare `url`) → yes, nothing was ruled out
 ///
 /// The stub's *name* is judged separately, by [`super::windows_launcher_path`].
@@ -1003,6 +1004,14 @@ fn wants_windows_launcher(stub_content: &str) -> bool {
         // launcher so a Windows user is not silently left without one.
         return true;
     };
+    if let Some(os) = doc.get("os").and_then(|os| os.as_array())
+        && !os.iter().filter_map(|entry| entry.as_str()).any(|entry| {
+            let os = entry.split_once('/').map_or(entry, |(os, _)| os);
+            crate::cli::version::normalize_os(os) == "windows"
+        })
+    {
+        return false;
+    }
     let Some(platforms) = doc.get("platforms").and_then(|p| p.as_table_like()) else {
         return true;
     };
@@ -1071,6 +1080,32 @@ url = "https://example.com/tool-linux.tar.gz"
 
 [platforms.macos-arm64]
 url = "https://example.com/tool-macos.tar.gz"
+"#;
+        assert!(!wants_windows_launcher(stub));
+    }
+
+    #[test]
+    fn a_stub_with_an_os_selector_that_excludes_windows_does_not() {
+        assert!(!wants_windows_launcher(
+            "tool = \"github:jdx/tiny\"\nos = [\"linux\", \"macos/arm64\"]\n"
+        ));
+    }
+
+    #[test]
+    fn a_stub_with_a_windows_os_selector_gets_a_launcher() {
+        for os in ["windows", "win/amd64"] {
+            let stub = format!("tool = \"github:example/tool\"\nos = [\"{os}\"]\n");
+            assert!(wants_windows_launcher(&stub), "{os}");
+        }
+    }
+
+    #[test]
+    fn a_windows_os_selector_does_not_bypass_platform_tables() {
+        let stub = r#"
+os = ["windows"]
+
+[platforms.linux-x64]
+url = "https://example.com/tool-linux.tar.gz"
 "#;
         assert!(!wants_windows_launcher(stub));
     }


### PR DESCRIPTION
## Summary
- use a tool stub's `os` selector when deciding whether to generate a Windows `.cmd` launcher
- keep `lockfile_platforms` limited to pre-resolved lock coverage rather than treating it as a platform support declaration
- document the existing tool-stub `os` field and launcher behavior

## Why
A backend tool stub can explicitly declare `os = ["linux", "macos"]`, but `mise generate tool-stub --lock` still wrote a `.cmd` launcher because launcher eligibility only inspected HTTP `[platforms.*]` tables. Missing lock metadata is not a reliable support boundary: a backend may resolve an omitted platform dynamically.

## Testing
- `cargo test --all-features windows_launcher_tests`
- `mise run test:e2e e2e/generate/test_generate_tool_stub_lock`
- `mise run lint-fix`
- `mise run docs:build`
- `mise x prettier -- prettier --check docs/dev-tools/tool-stubs.md`

Addresses https://github.com/jdx/mise/discussions/12999

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to tool-stub generator launcher side effects and docs; behavior change only affects stubs that declare a non-Windows `os` list.
> 
> **Overview**
> **Windows `.cmd` launchers** for generated tool stubs now respect the stub’s top-level **`os`** selector, not only HTTP `[platforms.windows-*]` tables. If `os` is set and none of its entries include Windows (including qualified forms like `win/amd64`), `mise generate tool-stub` no longer writes a launcher—even when `--lock` only embeds metadata for other platforms.
> 
> Launcher rules are documented under optional fields and the Windows usage section: Windows must appear in `os` when that field is used, and platform tables must still include a Windows entry when present. An e2e lock test asserts a linux/macos-only backend stub does not get `bin/tiny.cmd` after locking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d994f9d6fa16c5ca4119860abbfce1694907f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tool stubs can specify supported operating systems, optionally including architecture.
  - Windows launchers are generated when the stub’s operating-system selector includes Windows.

- **Bug Fixes**
  - Corrected launcher generation for platform-specific stubs, including qualified Windows targets such as `win/amd64`.
  - Prevented Windows launchers from being generated for non-Windows selectors.

- **Documentation**
  - Updated tool-stub documentation to explain operating-system selectors and Windows launcher conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->