### PR TITLE
fix(packslip): fall back to musl for old glibc

### DIFF
--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -292,7 +292,8 @@ transparency-log evidence. Signature and artifact verification still apply.
 
 Set to `true` to install despite confirmed [host requirement](#host-requirements)
 failures. This does not supply missing libraries or make an incompatible
-executable run. Other verification checks still apply.
+executable run. It also bypasses the glibc-to-musl fallback, retaining the GNU
+artifact selected for the host. Other verification checks still apply.
 
 ## Advanced policies
 
@@ -322,8 +323,9 @@ publisher's signature. No stamps are required by default. See
 mise selects a build using the signed OS, architecture, libc, and variant
 metadata, then checks its declared host requirements. When a GNU build's
 declared `glibc_min` is newer than the host, mise selects a matching static musl
-build when one is available. An ambiguous build or another confirmed
-incompatibility can prevent installation. See
+build when one is available. Setting `ignore_requirements = true` bypasses this
+fallback and keeps the GNU artifact selected. An ambiguous build or another
+confirmed incompatibility can prevent installation. See
 [artifact selection](/dev-tools/packslip-verification.html#artifact-selection)
 and [host requirements](/dev-tools/packslip-verification.html#host-requirements).
 

--- a/docs/dev-tools/backends/packslip.md
+++ b/docs/dev-tools/backends/packslip.md
@@ -320,8 +320,10 @@ publisher's signature. No stamps are required by default. See
 <span id="host-requirements"></span>
 
 mise selects a build using the signed OS, architecture, libc, and variant
-metadata, then checks its declared host requirements. An ambiguous build or a
-confirmed incompatible host can prevent installation. See
+metadata, then checks its declared host requirements. When a GNU build's
+declared `glibc_min` is newer than the host, mise selects a matching static musl
+build when one is available. An ambiguous build or another confirmed
+incompatibility can prevent installation. See
 [artifact selection](/dev-tools/packslip-verification.html#artifact-selection)
 and [host requirements](/dev-tools/packslip-verification.html#host-requirements).
 

--- a/docs/dev-tools/packslip-verification.md
+++ b/docs/dev-tools/packslip-verification.md
@@ -253,5 +253,6 @@ unknown. On Linux, the OS version is the kernel release from `uname -r`, read up
 to the distribution's suffix: `6.8.0-31-generic` is compared as `6.8.0`.
 
 The [`ignore_requirements`](/dev-tools/backends/packslip.html#ignore-requirements)
-tool option permits installation despite confirmed failures. It does not supply
-missing libraries or make an incompatible executable run.
+tool option permits installation despite confirmed failures. It also bypasses
+the glibc-to-musl fallback and retains the selected GNU artifact. It does not
+supply missing libraries or make an incompatible executable run.

--- a/docs/dev-tools/packslip-verification.md
+++ b/docs/dev-tools/packslip-verification.md
@@ -223,20 +223,25 @@ mise uses signed metadata to select one artifact:
 4. Refuse an unresolved tie rather than guessing between builds.
 
 Installer formats such as `deb`, `dmg`, and `msi` are not selected. A glibc host
-with no matching GNU artifact may use a musl artifact; mise reports that
-fallback in the debug log. The publisher must distinguish alternative builds
-with variants. A client option cannot resolve two identically described artifacts.
+may use a matching static musl artifact when there is no GNU artifact, or when
+the selected GNU artifact declares a `glibc_min` above the host's detected
+version. mise reports that fallback in the debug log. The publisher must
+distinguish alternative builds with variants. A client option cannot resolve
+two identically described artifacts.
 
 ## Host requirements
 
 After selecting an artifact, mise checks its declared requirements before
-downloading it. Requirements do not break a selection tie or select another build.
+downloading it. Requirements do not break a selection tie. A confirmed
+`glibc_min` incompatibility may select the matching static musl build as
+described above; other requirements do not select another build.
 
-| Requirement result                                                        | mise behavior                                      |
-| ------------------------------------------------------------------------- | -------------------------------------------------- |
-| Confirmed missing library, insufficient glibc, or insufficient OS version | Refuse installation.                               |
-| Missing or outdated required command                                      | Warn and continue.                                 |
-| A check cannot be completed                                               | Warn instead of assuming the host is incompatible. |
+| Requirement result                                                                           | mise behavior                                      |
+| -------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Insufficient glibc with a matching static musl artifact                                      | Select the musl artifact.                          |
+| Confirmed missing library, insufficient glibc without a fallback, or insufficient OS version | Refuse installation.                               |
+| Missing or outdated required command                                                         | Warn and continue.                                 |
+| A check cannot be completed                                                                  | Warn instead of assuming the host is incompatible. |
 
 Command checks prefer active mise tools over ambient PATH. mise checks for a
 path the OS can execute: on Windows, `git.exe` or `node.cmd` counts, but a

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -49,6 +49,7 @@ pub(crate) const EXPERIMENTAL: bool = false;
 /// The verified statement, kept beside the install so the rest of mise can
 /// read what the release declared without verifying it again.
 pub(crate) const STATEMENT_FILE: &str = ".mise-packslip.json";
+pub(crate) const SELECTED_ARTIFACT_FILE: &str = ".mise-packslip-artifact";
 
 /// Archive formats mise can unpack, best first. Installers (`deb`, `dmg`,
 /// `msi`, ...) are not among them: mise installs into its own directory.
@@ -395,6 +396,32 @@ async fn select_compatible_artifact<'a>(
     select_glibc_fallback(artifacts, host, variant, artifact, &actual, min)
 }
 
+/// Return the artifact pinned by this platform's lock entry, when the current
+/// signed statement still contains that exact URL and digest.
+fn select_locked_artifact<'a>(
+    statement: &'a Statement,
+    info: Option<&PlatformInfo>,
+) -> Option<&'a Artifact> {
+    let info = info?;
+    statement.predicate.artifacts.iter().find(|artifact| {
+        let url_matches = info
+            .url
+            .as_ref()
+            .is_some_and(|url| artifact.url.as_ref() == Some(url));
+        let checksum_matches = info.checksum.as_ref().is_some_and(|checksum| {
+            statement
+                .digest_of(&artifact.name)
+                .is_some_and(|digest| checksum == &format!("sha256:{digest}"))
+        });
+        match (&info.url, &info.checksum) {
+            (Some(_), Some(_)) => url_matches && checksum_matches,
+            (Some(_), None) => url_matches,
+            (None, Some(_)) => checksum_matches,
+            (None, None) => false,
+        }
+    })
+}
+
 fn select_glibc_fallback<'a>(
     artifacts: &'a [Artifact],
     host: &HostPlatform,
@@ -427,10 +454,23 @@ fn select_glibc_fallback<'a>(
     }
 }
 
-/// The artifact this host would select from a stored statement, for
-/// scoping resources to it later. `None` when nothing fits, in which case
-/// only unscoped resources apply.
-pub(crate) fn selected_artifact(statement: &Statement, variant: Option<&str>) -> Option<Artifact> {
+/// The artifact installed from a stored statement, for scoping resources to it
+/// later. New installs record it explicitly; old installs fall back to host
+/// selection. `None` means only unscoped resources apply.
+pub(crate) fn selected_artifact(
+    statement: &Statement,
+    install_path: &Path,
+    variant: Option<&str>,
+) -> Option<Artifact> {
+    if let Ok(name) = std::fs::read_to_string(install_path.join(SELECTED_ARTIFACT_FILE))
+        && let Some(artifact) = statement
+            .predicate
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.name == name.trim())
+    {
+        return Some(artifact.clone());
+    }
     select_artifact(
         &statement.predicate.artifacts,
         &HostPlatform::current(),
@@ -1293,15 +1333,22 @@ impl PackslipBackend {
             }
         }
 
-        // Then the one artifact for this host, by what the manifest says.
-        let artifact = select_compatible_artifact(
-            &statement.predicate.artifacts,
-            &HostPlatform::current(),
-            opts.variant().as_deref(),
-            raw_opts.get("ignore_requirements") == Some("true"),
-        )
-        .await?
-        .clone();
+        // A lockfile pins the exact artifact. Without one, choose the best
+        // compatible artifact for this host, including the glibc fallback.
+        let artifact =
+            match select_locked_artifact(&statement, tv.lock_platforms.get(&platform_key)) {
+                Some(artifact) => artifact,
+                None => {
+                    select_compatible_artifact(
+                        &statement.predicate.artifacts,
+                        &HostPlatform::current(),
+                        opts.variant().as_deref(),
+                        raw_opts.get("ignore_requirements") == Some("true"),
+                    )
+                    .await?
+                }
+            }
+            .clone();
         if vfox_plugin {
             crate::plugins::packslip::validate_artifact(&artifact)?;
         }
@@ -1400,6 +1447,10 @@ impl PackslipBackend {
         file::write(
             tv.install_path().join(STATEMENT_FILE),
             serde_json::to_vec_pretty(&statement)?,
+        )?;
+        file::write(
+            tv.install_path().join(SELECTED_ARTIFACT_FILE),
+            artifact.name.as_bytes(),
         )?;
         // Completions and CLI specs the vendor keeps outside the artifact.
         if !vfox_plugin {
@@ -1662,9 +1713,9 @@ impl Backend for PackslipBackend {
         })
     }
 
-    /// `variant` decides which artifact is downloaded, so a lock entry for a
-    /// variant build is not the entry for the plain one. `trust` is kept so
-    /// an install from the lock does not quietly relax to the vendor alone.
+    /// `variant` and `ignore_requirements` can decide which artifact is
+    /// downloaded, so distinct choices need distinct lock entries. `trust` is
+    /// kept so an install from the lock does not quietly relax to the vendor.
     fn resolve_lockfile_options(
         &self,
         request: &ToolRequest,
@@ -1675,6 +1726,9 @@ impl Backend for PackslipBackend {
         let mut options = BTreeMap::new();
         if let Some(variant) = opts.variant() {
             options.insert("variant".to_string(), variant);
+        }
+        if raw_opts.get("ignore_requirements") == Some("true") {
+            options.insert("ignore_requirements".to_string(), "true".to_string());
         }
         if let Some(trust) = opts.trust() {
             options.insert("trust".to_string(), trust);
@@ -2162,6 +2216,45 @@ list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packsl
             "t-linux-x64",
             "what the bin entry's path must be"
         );
+    }
+
+    #[test]
+    fn lock_entry_pins_the_exact_artifact() {
+        let digest = "a".repeat(64);
+        let statement: Statement = serde_json::from_value(serde_json::json!({
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [{"name": "t-musl.tar.xz", "digest": {"sha256": digest}}],
+            "predicateType": "https://packslip.dev/release/v1",
+            "predicate": {
+                "project": "github.com/o/r",
+                "version": "1.0.0",
+                "published_at": "2026-09-01T00:00:00Z",
+                "source": {"repo": "https://github.com/o/r", "commit": "cccccccccccccccccccccccccccccccccccccccc"},
+                "artifacts": [
+                    {"name": "t-gnu.tar.xz", "os": "linux", "arch": "x86_64", "libc": "gnu", "size": 1, "url": "https://example.com/t-gnu.tar.xz", "format": "tar.xz", "bin": ["t"]},
+                    {"name": "t-musl.tar.xz", "os": "linux", "arch": "x86_64", "libc": "musl", "size": 1, "url": "https://example.com/t-musl.tar.xz", "format": "tar.xz", "bin": ["t"]}
+                ],
+                "identity": {"scheme": "sigstore-key", "key_id": "key"}
+            }
+        }))
+        .unwrap();
+        let info = PlatformInfo {
+            checksum: Some(format!("sha256:{digest}")),
+            url: Some("https://example.com/t-musl.tar.xz".into()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            select_locked_artifact(&statement, Some(&info))
+                .unwrap()
+                .name,
+            "t-musl.tar.xz"
+        );
+        let mismatched = PlatformInfo {
+            checksum: Some(format!("sha256:{}", "b".repeat(64))),
+            ..info
+        };
+        assert!(select_locked_artifact(&statement, Some(&mismatched)).is_none());
     }
 
     #[test]

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -372,6 +372,61 @@ pub(crate) fn select_artifact<'a>(
     .into())
 }
 
+async fn select_compatible_artifact<'a>(
+    artifacts: &'a [Artifact],
+    host: &HostPlatform,
+    variant: Option<&str>,
+    ignore_requirements: bool,
+) -> Result<&'a Artifact> {
+    let artifact = select_artifact(artifacts, host, variant)?;
+    if ignore_requirements || host.libc.as_deref() != Some("gnu") {
+        return Ok(artifact);
+    }
+    let Some(min) = artifact
+        .requires
+        .as_ref()
+        .and_then(|requires| requires.glibc_min.as_deref())
+    else {
+        return Ok(artifact);
+    };
+    let Some(actual) = crate::packslip_requirements::glibc_version().await else {
+        return Ok(artifact);
+    };
+    select_glibc_fallback(artifacts, host, variant, artifact, &actual, min)
+}
+
+fn select_glibc_fallback<'a>(
+    artifacts: &'a [Artifact],
+    host: &HostPlatform,
+    variant: Option<&str>,
+    artifact: &'a Artifact,
+    actual: &str,
+    min: &str,
+) -> Result<&'a Artifact> {
+    if crate::packslip_requirements::meets_minimum(actual, min) != Some(false) {
+        return Ok(artifact);
+    }
+
+    let musl = Host {
+        libc: Some("musl"),
+        ..host.as_host()
+    };
+    match packslip::select_artifact(artifacts, &musl, variant, &FORMAT_PREFERENCE) {
+        Ok(fallback) => {
+            debug!(
+                "{} requires glibc>={min}, but this host has {actual}; taking the static musl build {}",
+                artifact.name, fallback.name
+            );
+            Ok(fallback)
+        }
+        Err(Selection::Ambiguous(a, b)) => bail!(
+            "the packslip lists {a} and {b} as musl fallbacks for {}, and mise will not guess between them",
+            artifact.name
+        ),
+        Err(Selection::NoMatch) => Ok(artifact),
+    }
+}
+
 /// The artifact this host would select from a stored statement, for
 /// scoping resources to it later. `None` when nothing fits, in which case
 /// only unscoped resources apply.
@@ -913,11 +968,14 @@ impl PackslipBackend {
                 "verified release time is after the allowed cutoff".into(),
             ));
         }
-        let artifact = match select_artifact(
+        let artifact = match select_compatible_artifact(
             &statement.predicate.artifacts,
             &HostPlatform::current(),
             opts.variant().as_deref(),
-        ) {
+            opts.raw.get("ignore_requirements") == Some("true"),
+        )
+        .await
+        {
             Ok(artifact) => artifact,
             Err(err) if err.is::<NoHostArtifact>() => return Ok(Some(err.to_string())),
             Err(err) => return Err(err),
@@ -1236,11 +1294,13 @@ impl PackslipBackend {
         }
 
         // Then the one artifact for this host, by what the manifest says.
-        let artifact = select_artifact(
+        let artifact = select_compatible_artifact(
             &statement.predicate.artifacts,
             &HostPlatform::current(),
             opts.variant().as_deref(),
-        )?
+            raw_opts.get("ignore_requirements") == Some("true"),
+        )
+        .await?
         .clone();
         if vfox_plugin {
             crate::plugins::packslip::validate_artifact(&artifact)?;
@@ -1564,11 +1624,22 @@ impl Backend for PackslipBackend {
             &verified.published_at,
             before,
         )?;
-        let artifact = select_artifact(
-            &statement.predicate.artifacts,
-            &HostPlatform::from_platform(&target.platform),
-            opts.variant().as_deref(),
-        )
+        let host = HostPlatform::from_platform(&target.platform);
+        let artifact = if target.is_current() {
+            select_compatible_artifact(
+                &statement.predicate.artifacts,
+                &host,
+                opts.variant().as_deref(),
+                raw_opts.get("ignore_requirements") == Some("true"),
+            )
+            .await
+        } else {
+            select_artifact(
+                &statement.predicate.artifacts,
+                &host,
+                opts.variant().as_deref(),
+            )
+        }
         .wrap_err_with(|| format!("selecting the packslip artifact for {}", target.to_key()))?;
         let url = artifact
             .url
@@ -2028,6 +2099,41 @@ list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packsl
             ..linux()
         };
         assert!(select_artifact(&musl_only, &no_libc, None).is_err());
+
+        // A GNU build's declared glibc floor can make the matching static
+        // musl build the compatible choice on an older glibc host.
+        let mut gnu_with_floor = artifacts[2].clone();
+        gnu_with_floor.requires = Some(packslip::model::Requires {
+            glibc_min: Some("2.39".into()),
+            ..Default::default()
+        });
+        let glibc_fallbacks = vec![gnu_with_floor, artifacts[3].clone()];
+        assert_eq!(
+            select_glibc_fallback(
+                &glibc_fallbacks,
+                &linux(),
+                None,
+                &glibc_fallbacks[0],
+                "2.38",
+                "2.39",
+            )
+            .unwrap()
+            .name,
+            "t-linux-x64-musl.tar.xz"
+        );
+        assert_eq!(
+            select_glibc_fallback(
+                &glibc_fallbacks,
+                &linux(),
+                None,
+                &glibc_fallbacks[0],
+                "2.39",
+                "2.39",
+            )
+            .unwrap()
+            .name,
+            "t-linux-x64.tar.xz"
+        );
 
         // A universal or portable artifact fits, and a build for the host
         // beats it; a compressed bare executable is installable.

--- a/src/packslip.rs
+++ b/src/packslip.rs
@@ -654,6 +654,7 @@ pub(crate) async fn active_skills(config: &Arc<Config>) -> Result<Vec<Skill>> {
         };
         let artifact = selected_artifact(
             &statement,
+            &install_path,
             tv.request.options().get_string("variant").as_deref(),
         );
         skills.extend(skills_of(
@@ -1156,6 +1157,7 @@ pub(crate) async fn completion_script(
     };
     let artifact = selected_artifact(
         &statement,
+        &install_path,
         tv.request.options().get_string("variant").as_deref(),
     );
     let sources = completion_sources(
@@ -1975,6 +1977,29 @@ mod tests {
             completion_sources(&s, root, "zsh", None, Some("t")),
             vec![CompletionSource::File(root.join("_t.any"))],
             "with no artifact selected only unscoped entries apply"
+        );
+    }
+
+    #[test]
+    fn installed_artifact_marker_controls_resource_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut statement = basic();
+        let mut musl = statement.predicate.artifacts[0].clone();
+        musl.name = "t-linux-x64-musl.tar.xz".into();
+        musl.libc = Some("musl".into());
+        statement.predicate.artifacts.push(musl.clone());
+        std::fs::write(
+            dir.path()
+                .join(crate::backend::packslip::SELECTED_ARTIFACT_FILE),
+            &musl.name,
+        )
+        .unwrap();
+
+        assert_eq!(
+            selected_artifact(&statement, dir.path(), None)
+                .unwrap()
+                .name,
+            musl.name
         );
     }
 

--- a/src/packslip/completions.rs
+++ b/src/packslip/completions.rs
@@ -89,6 +89,7 @@ pub(crate) fn activate(config: &Arc<Config>, ts: &Toolset, shell: &str) -> Strin
         };
         let artifact = crate::backend::packslip::selected_artifact(
             &statement,
+            &install,
             tv.request.options().get_string("variant").as_deref(),
         );
         for bin in statement

--- a/src/packslip_requirements.rs
+++ b/src/packslip_requirements.rs
@@ -61,6 +61,10 @@ fn numeric_cmp(actual: &str, min: &str) -> Option<Ordering> {
     Some(Ordering::Equal)
 }
 
+pub(crate) fn meets_minimum(actual: &str, min: &str) -> Option<bool> {
+    numeric_cmp(actual, min).map(|ordering| ordering != Ordering::Less)
+}
+
 fn version_from_output(output: &str) -> Option<String> {
     let words: Vec<_> = output
         .split_whitespace()
@@ -84,6 +88,16 @@ async fn probe(program: &str, args: &[&str]) -> Option<String> {
         .read_isolated(64 * 1024)
         .await
         .ok()
+}
+
+pub(crate) async fn glibc_version() -> Option<String> {
+    if !cfg!(target_os = "linux") {
+        return None;
+    }
+    probe("getconf", &["GNU_LIBC_VERSION"])
+        .await
+        .as_deref()
+        .and_then(version_from_output)
 }
 
 /// `uname -r` reports a release, not a version: `6.8.0-31-generic` on one
@@ -207,14 +221,7 @@ pub(crate) async fn check(artifact: &Artifact, commands: &BTreeMap<String, PathB
         check_min(&mut report, "OS", os_version().await.as_deref(), min, true);
     }
     if let Some(min) = &req.glibc_min {
-        let glibc = if cfg!(target_os = "linux") {
-            probe("getconf", &["GNU_LIBC_VERSION"])
-                .await
-                .as_deref()
-                .and_then(version_from_output)
-        } else {
-            None
-        };
+        let glibc = glibc_version().await;
         check_min(&mut report, "glibc", glibc.as_deref(), min, true);
     }
     for lib in req.libs.iter().flatten() {


### PR DESCRIPTION
## Summary

- use each Packslip artifact's `glibc_min` when selecting a Linux build
- fall back from an incompatible GNU artifact to the matching static musl artifact
- apply the same selection during version admission and installation while preserving `ignore_requirements=true`
- document the compatibility fallback

Closes the installation behavior raised in https://github.com/jdx/mise/discussions/12989 without adding tool-specific logic or adopting Aqua's musl-only policy.

## Validation

- `MBX_DISABLE=1 mise run format`
- `MBX_DISABLE=1 mise run test:unit packslip` (49 passed)
- `mise run docs:build`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Linux artifact is downloaded and how lockfiles pin artifacts; mistakes could cause wrong binaries or lock mismatches, though behavior is covered by new unit tests.
> 
> **Overview**
> Packslip installs on **glibc Linux** now treat an artifact’s **`glibc_min`** as part of selection: after the usual GNU match, mise compares the host glibc (via `getconf`) to that minimum and, when the GNU build is too new, **switches to a matching static musl artifact** when one exists. The same path runs for **version admission** (`latest` eligibility) and **install**; ambiguous musl fallbacks still fail instead of guessing.
> 
> **Lockfile and post-install behavior** also change: a platform lock entry can **pin the exact artifact** by URL/checksum in the signed statement, installs write **`.mise-packslip-artifact`** so completions/skills scope to what was actually installed (not a re-derived host pick), and **`ignore_requirements = true`** is recorded in lock options and **skips the glibc→musl fallback** while keeping the GNU selection.
> 
> Docs in `packslip.md` and `packslip-verification.md` describe the fallback and the updated host-requirements table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61bc03e5e2a22bd69e7405008078966b04f90bda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GNU builds with an incompatible host glibc version can now automatically use a compatible static musl build when available.
  - Artifact selections are preserved across reinstalls when the recorded build remains valid.
  - Glibc compatibility checks now apply consistently during installation and lock resolution.
  - Installations continue to be rejected when no suitable fallback exists or requirements remain ambiguous.
  - The `ignore_requirements` option can bypass glibc-to-musl fallback and retain the selected GNU build.

- **Documentation**
  - Updated artifact selection and verification guidance to describe compatibility checks, fallback behavior, and installation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->