### PR TITLE
perf(history): rebuild index metadata with gix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4220,6 +4220,7 @@ dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ gix = { version = "<1", default-features = false, features = [
   "max-performance-safe",
   "worktree-mutation",
   "sha1",
+  "sha256",
   "interrupt",
   "auto-chain-error",
 ] }

--- a/src/system/history/checkpoint.rs
+++ b/src/system/history/checkpoint.rs
@@ -119,7 +119,7 @@ impl Store {
         // missing but checkpoints exist
         if !store::index_exists_in(state_dir)
             && let Some(repo) = &store.repo
-            && !repo.checkpoint_refs()?.is_empty()
+            && repo.ref_oid(HistoryRepo::HISTORY_REF)?.is_some()
         {
             info!("history: rebuilding the checkpoint index from the repository");
             store.rebuild_index()?;
@@ -746,27 +746,42 @@ impl Store {
         };
         let existing = store::load_index_in(&self.state_dir)?;
         let mut entries = vec![];
-        let commits: Vec<_> = repo.checkpoint_refs()?.into_iter().rev().collect();
+        let commits: Vec<_> = repo
+            .history_messages()?
+            .into_iter()
+            .rev()
+            .map(|(commit, message)| Ok((commit, HistoryRepo::annotation_from_message(&message)?)))
+            .collect::<Result<_>>()?;
         let mut annotations: BTreeMap<String, Vec<Annotation>> = BTreeMap::new();
-        for (_, commit) in &commits {
-            if let Some((target, annotation)) = repo.read_annotation(commit)? {
-                annotations.entry(target).or_default().push(annotation);
+        for (_, annotation) in &commits {
+            if let Some((target, annotation)) = annotation {
+                annotations
+                    .entry(target.clone())
+                    .or_default()
+                    .push(annotation.clone());
             }
         }
-        for (uuid, commit) in commits {
+        for (commit, annotation) in commits {
             // Annotation commits remain in Git ancestry, but are not new file
             // checkpoints and must not move `latest` in the history browser.
-            if repo.read_annotation(&commit)?.is_some() {
+            if annotation.is_some() {
                 continue;
             }
-            let mut checkpoint = repo.read_meta(&commit)?;
+            let mut checkpoint = match store::read_commit_meta_cache_in(&self.state_dir, &commit)? {
+                Some(checkpoint) => checkpoint,
+                None => {
+                    let checkpoint = repo.read_meta(&commit)?;
+                    store::write_commit_meta_cache_in(&self.state_dir, &commit, &checkpoint)?;
+                    checkpoint
+                }
+            };
             if let Some(annotations) = annotations.get(&commit) {
                 for annotation in annotations {
                     annotation.apply_to(&mut checkpoint);
                 }
             }
             store::write_meta_cache_in(&self.state_dir, &checkpoint)?;
-            let id = existing.by_uuid(&uuid).map(|entry| entry.id);
+            let id = existing.by_uuid(&commit).map(|entry| entry.id);
             entries.push((id, checkpoint, commit));
         }
         let mut next_id = existing.next_id.max(1);
@@ -1120,6 +1135,61 @@ pub(crate) fn test_checkpoint(uuid: &str, snapshot: Option<&str>) -> Checkpoint 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rebuild_reuses_commit_metadata_without_retaining_removed_annotations() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store = Store::open_in(temp.path())?;
+        let Some(repo) = store.repo() else {
+            return Ok(());
+        };
+        let tree = repo.empty_object("tree")?;
+        let mut last = String::new();
+        for i in 0..8 {
+            let mut checkpoint = test_checkpoint(&format!("checkpoint-{i}"), Some(&tree));
+            checkpoint.description = format!("checkpoint {i}");
+            checkpoint.summary = checkpoint.description.clone();
+            last = repo.write_checkpoint(Some(&tree), &checkpoint)?;
+        }
+
+        shadow::reset_read_meta_calls();
+        let first = store.rebuild_index()?;
+        assert_eq!(first.entries.len(), 8);
+        assert_eq!(shadow::read_meta_calls(), 8);
+
+        shadow::reset_read_meta_calls();
+        let second = store.rebuild_index()?;
+        assert_eq!(second.entries.len(), 8);
+        assert_eq!(shadow::read_meta_calls(), 0);
+
+        repo.write_annotation(
+            &last,
+            &Annotation {
+                description: Some("renamed checkpoint".into()),
+                description_source: Some(DescriptionSource::User),
+                updated_at: store::now_rfc3339(),
+                ..Default::default()
+            },
+        )?;
+        let annotation = repo.ref_oid(HistoryRepo::HISTORY_REF)?.unwrap();
+        shadow::reset_read_meta_calls();
+        store.rebuild_index()?;
+        assert_eq!(shadow::read_meta_calls(), 0);
+        assert_eq!(
+            store.list()?.last().unwrap().checkpoint.description,
+            "renamed checkpoint"
+        );
+
+        repo.update_history_head(&last, Some(&annotation))?;
+        shadow::reset_read_meta_calls();
+        store.rebuild_index()?;
+        assert_eq!(shadow::read_meta_calls(), 0);
+        assert_eq!(
+            store.list()?.last().unwrap().checkpoint.description,
+            "checkpoint 7"
+        );
+        Ok(())
+    }
 
     #[test]
     fn automatic_capture_without_enrollment_does_not_create_a_root() -> Result<()> {

--- a/src/system/history/manifest.rs
+++ b/src/system/history/manifest.rs
@@ -397,18 +397,36 @@ impl Manifest {
         if mode != "100644" {
             bail!("dotfile enrollment metadata must be a regular file");
         }
+        let bytes = repo.cat_object_bounded(&oid, 4 * 1024 * 1024)?;
+        Self::from_bytes(&bytes).map(Some)
+    }
+
+    pub(crate) fn read_gix(tree: &gix::Tree<'_>) -> Result<Option<Self>> {
+        let Some(entry) = tree.lookup_entry_by_path(PATH)? else {
+            return Ok(None);
+        };
+        if entry.mode().value() != 0o100644 {
+            bail!("dotfile enrollment metadata must be a regular file");
+        }
+        let object = entry.object()?;
+        if object.data.len() > 4 * 1024 * 1024 {
+            bail!("dotfile enrollment metadata is too large");
+        }
+        Self::from_bytes(&object.data).map(Some)
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Result<Self> {
         #[derive(Deserialize)]
         struct FormatHeader {
             format: u64,
         }
-        let bytes = repo.cat_object_bounded(&oid, 4 * 1024 * 1024)?;
-        let header: FormatHeader = serde_json::from_slice(&bytes)?;
+        let header: FormatHeader = serde_json::from_slice(bytes)?;
         if header.format != 1 {
             bail!("unsupported dotfile repository format {}", header.format);
         }
-        let manifest: Self = serde_json::from_slice(&bytes)?;
+        let manifest: Self = serde_json::from_slice(bytes)?;
         manifest.validate()?;
-        Ok(Some(manifest))
+        Ok(manifest)
     }
 
     pub(crate) fn write(&self, repo: &HistoryRepo, tree: &str) -> Result<String> {

--- a/src/system/history/manifest.rs
+++ b/src/system/history/manifest.rs
@@ -408,10 +408,10 @@ impl Manifest {
         if entry.mode().value() != 0o100644 {
             bail!("dotfile enrollment metadata must be a regular file");
         }
-        let object = entry.object()?;
-        if object.data.len() > 4 * 1024 * 1024 {
+        if entry.id().header()?.size() > 4 * 1024 * 1024 {
             bail!("dotfile enrollment metadata is too large");
         }
+        let object = entry.object()?;
         Self::from_bytes(&object.data).map(Some)
     }
 
@@ -483,6 +483,31 @@ mod tests {
                     .contains(message)
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn gix_reader_rejects_oversized_manifest() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let repo = HistoryRepo::open_or_init_in(temp.path())?.unwrap();
+        let tree = repo.compose(
+            &repo.mktree("")?,
+            &[Overlay {
+                path: PATH.into(),
+                object: Some((
+                    "100644".into(),
+                    repo.hash_blob(&vec![b' '; 4 * 1024 * 1024 + 1])?,
+                )),
+            }],
+        )?;
+        let gix = gix::open_opts(repo.dir(), gix::open::Options::isolated())?;
+        let tree = gix.find_tree(gix::ObjectId::from_hex(tree.as_bytes())?)?;
+        assert!(
+            Manifest::read_gix(&tree)
+                .unwrap_err()
+                .to_string()
+                .contains("too large")
+        );
         Ok(())
     }
 

--- a/src/system/history/shadow.rs
+++ b/src/system/history/shadow.rs
@@ -1279,12 +1279,16 @@ impl HistoryRepo {
         commit: &str,
         expected: Option<&str>,
     ) -> Result<()> {
-        let zero = "0000000000000000000000000000000000000000";
+        eyre::ensure!(
+            matches!(commit.len(), 40 | 64),
+            "unsupported Git object id: {commit}"
+        );
+        let zero = "0".repeat(commit.len());
         self.git.run(PlumbingCall::new([
             "update-ref",
             name,
             commit,
-            expected.unwrap_or(zero),
+            expected.unwrap_or(&zero),
         ]))
     }
 
@@ -1498,6 +1502,30 @@ pub(crate) fn unavailable_reason() -> String {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn sha256_history_can_be_written_and_read() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("repo.git");
+        let output = std::process::Command::new(crate::git::plumbing_binary().unwrap())
+            .args(["init", "--bare", "--quiet", "--object-format=sha256"])
+            .arg(&path)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let repo = super::HistoryRepo {
+            git: crate::git::GitPlumbing::new(path),
+            transient: Default::default(),
+        };
+        let tree = repo.empty_object("tree").unwrap();
+        let commit = repo.commit_tree(&tree, vec![], "sha256 history").unwrap();
+        assert_eq!(commit.len(), 64);
+        repo.update_history_head(&commit, None).unwrap();
+        assert_eq!(
+            repo.history_messages().unwrap(),
+            vec![(commit, "sha256 history".into())]
+        );
+    }
+
     #[test]
     fn history_messages_match_git_topological_order() {
         let temp = tempfile::tempdir().unwrap();

--- a/src/system/history/shadow.rs
+++ b/src/system/history/shadow.rs
@@ -786,7 +786,7 @@ impl HistoryRepo {
                 let size = entry
                     .mode
                     .is_blob_or_symlink()
-                    .then(|| repo.find_object(entry.oid).map(|object| object.data.len() as u64))
+                    .then(|| repo.find_header(entry.oid).map(|header| header.size()))
                     .transpose()?;
                 Ok(TreeEntry {
                     mode,
@@ -1821,6 +1821,39 @@ mod tests {
             )])
             .unwrap();
         assert_eq!(again.tree, result.tree);
+    }
+
+    #[test]
+    fn gix_tree_entries_report_large_blob_size() {
+        if crate::git::plumbing_binary().is_none() {
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = repo(tmp.path());
+        let size = 8 * 1024 * 1024;
+        let oid = repo.hash_blob(&vec![0; size]).unwrap();
+        let tree = repo
+            .compose(
+                &repo.empty_object("tree").unwrap(),
+                &[Overlay {
+                    path: "home/large".into(),
+                    object: Some(("100644".into(), oid.clone())),
+                }],
+            )
+            .unwrap();
+        let gix = gix::open_opts(repo.dir(), gix::open::Options::isolated()).unwrap();
+        let tree = gix
+            .find_tree(gix::ObjectId::from_hex(tree.as_bytes()).unwrap())
+            .unwrap();
+        assert_eq!(
+            HistoryRepo::gix_tree_entries(&gix, &tree).unwrap(),
+            vec![TreeEntry {
+                mode: "100644".into(),
+                oid,
+                size: Some(size as u64),
+                path: "home/large".into(),
+            }]
+        );
     }
 
     #[test]

--- a/src/system/history/shadow.rs
+++ b/src/system/history/shadow.rs
@@ -570,61 +570,29 @@ impl HistoryRepo {
 
     /// Every commit and message in ordinary ancestry, newest first.
     ///
-    /// `cat-file --batch` prefixes each raw commit with its exact byte length,
-    /// so arbitrary commit messages remain unambiguous. Reading all messages
-    /// together avoids starting a Git process for every checkpoint merely to
-    /// distinguish annotations from file history.
+    /// Reading messages through gix avoids starting a Git process for every
+    /// checkpoint merely to distinguish annotations from file history. Open
+    /// the repository for each walk so objects and refs written by Git are
+    /// always visible.
     pub(crate) fn history_messages(&self) -> Result<Vec<(String, String)>> {
-        let Some(head) = self.ref_oid(Self::HISTORY_REF)? else {
+        let repo = gix::open_opts(self.dir(), gix::open::Options::isolated())
+            .wrap_err_with(|| format!("opening {} with gix", display_path(self.dir())))?;
+        let Some(mut head) = repo.try_find_reference(Self::HISTORY_REF)? else {
             return Ok(vec![]);
         };
-        let commits = self.rev_list(&head, usize::MAX)?;
-        let mut input = commits.join("\n").into_bytes();
-        input.push(b'\n');
-        let output = self
-            .git
-            .output(PlumbingCall::new(["cat-file", "--batch"]).stdin(&input))?;
-        let mut cursor = 0;
-        let mut messages = Vec::with_capacity(commits.len());
+        let head = head.peel_to_id()?.detach();
+        let commits = gix::traverse::commit::topo::Builder::new(&repo)
+            .with_tips([head])
+            .sorting(gix::traverse::commit::topo::Sorting::TopoOrder)
+            .build()?;
+        let mut messages = vec![];
         for commit in commits {
-            let header_end = output[cursor..]
-                .iter()
-                .position(|byte| *byte == b'\n')
-                .map(|offset| cursor + offset)
-                .ok_or_else(|| eyre::eyre!("Git batch output ended before its object header"))?;
-            let header = String::from_utf8_lossy(&output[cursor..header_end]);
-            let mut fields = header.split_whitespace();
-            let oid = fields.next().unwrap_or_default();
-            let kind = fields.next().unwrap_or_default();
-            let size = fields
-                .next()
-                .and_then(|size| size.parse::<usize>().ok())
-                .ok_or_else(|| eyre::eyre!("invalid Git batch object header: {header}"))?;
-            if oid != commit || kind != "commit" {
-                bail!("unexpected Git batch object header: {header}");
-            }
-            let object_start = header_end + 1;
-            let object_end = object_start
-                .checked_add(size)
-                .ok_or_else(|| eyre::eyre!("Git commit object size overflow for {commit}"))?;
-            let object = output
-                .get(object_start..object_end)
-                .ok_or_else(|| eyre::eyre!("Git batch output ended inside commit {commit}"))?;
-            let message_start = object
-                .windows(2)
-                .position(|bytes| bytes == b"\n\n")
-                .map(|offset| offset + 2)
-                .ok_or_else(|| eyre::eyre!("commit {commit} has no message separator"))?;
-            messages.push((
-                commit,
-                String::from_utf8_lossy(&object[message_start..])
-                    .trim()
-                    .to_string(),
-            ));
-            if output.get(object_end) != Some(&b'\n') {
-                bail!("Git batch output did not terminate commit object {oid}");
-            }
-            cursor = object_end + 1;
+            let commit = commit?;
+            let object = repo.find_commit(commit.id)?;
+            let message = String::from_utf8_lossy(object.message_raw()?.as_ref())
+                .trim()
+                .to_string();
+            messages.push((commit.id.to_string(), message));
         }
         Ok(messages)
     }
@@ -1530,6 +1498,42 @@ pub(crate) fn unavailable_reason() -> String {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn history_messages_match_git_topological_order() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = super::HistoryRepo::open_or_init_in(temp.path())
+            .unwrap()
+            .unwrap();
+        let tree = repo.empty_object("tree").unwrap();
+        let base = repo.commit_tree(&tree, vec![], "base").unwrap();
+        let first = repo.commit_tree(&tree, vec![&base], "first").unwrap();
+        let second = repo.commit_tree(&tree, vec![&base], "second").unwrap();
+        let merge = repo
+            .commit_tree(&tree, vec![&first, &second], "merge")
+            .unwrap();
+        repo.update_history_head(&merge, None).unwrap();
+
+        let messages = repo.history_messages().unwrap();
+        let commits = messages
+            .iter()
+            .map(|(commit, _)| commit.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(commits, repo.rev_list(&merge, usize::MAX).unwrap());
+        for (commit, message) in messages {
+            let expected = [
+                (&base, "base"),
+                (&first, "first"),
+                (&second, "second"),
+                (&merge, "merge"),
+            ]
+            .into_iter()
+            .find_map(|(expected_commit, expected_message)| {
+                (expected_commit == &commit).then_some(expected_message)
+            });
+            assert_eq!(Some(message.as_str()), expected);
+        }
+    }
+
     #[test]
     fn annotations_are_ordinary_commits_not_parallel_refs() {
         let temp = tempfile::tempdir().unwrap();

--- a/src/system/history/shadow.rs
+++ b/src/system/history/shadow.rs
@@ -28,6 +28,21 @@ pub(crate) const MAX_FILES: u64 = 100_000;
 /// An entry with more bytes than this is cut short.
 pub(crate) const MAX_BYTES: u64 = 1024 * 1024 * 1024;
 
+#[cfg(test)]
+thread_local! {
+    static READ_META_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_read_meta_calls() {
+    READ_META_CALLS.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn read_meta_calls() -> usize {
+    READ_META_CALLS.with(std::cell::Cell::get)
+}
+
 /// One top-level root of a snapshot tree and the files to add under it,
 /// relative to `path`.
 #[derive(Clone, Debug)]
@@ -544,20 +559,79 @@ impl HistoryRepo {
     }
 
     /// Ordinary ancestry is the source of truth, not per-checkpoint refs.
+    #[cfg(test)]
     pub(crate) fn checkpoint_refs(&self) -> Result<Vec<(String, String)>> {
+        Ok(self
+            .history_messages()?
+            .into_iter()
+            .map(|(commit, _)| (commit.clone(), commit))
+            .collect())
+    }
+
+    /// Every commit and message in ordinary ancestry, newest first.
+    ///
+    /// `cat-file --batch` prefixes each raw commit with its exact byte length,
+    /// so arbitrary commit messages remain unambiguous. Reading all messages
+    /// together avoids starting a Git process for every checkpoint merely to
+    /// distinguish annotations from file history.
+    pub(crate) fn history_messages(&self) -> Result<Vec<(String, String)>> {
         let Some(head) = self.ref_oid(Self::HISTORY_REF)? else {
             return Ok(vec![]);
         };
-        self.rev_list(&head, usize::MAX)?
-            .into_iter()
-            .map(|commit| {
-                let record = self.read_meta(&commit)?;
-                Ok((record.uuid, commit))
-            })
-            .collect()
+        let commits = self.rev_list(&head, usize::MAX)?;
+        let mut input = commits.join("\n").into_bytes();
+        input.push(b'\n');
+        let output = self
+            .git
+            .output(PlumbingCall::new(["cat-file", "--batch"]).stdin(&input))?;
+        let mut cursor = 0;
+        let mut messages = Vec::with_capacity(commits.len());
+        for commit in commits {
+            let header_end = output[cursor..]
+                .iter()
+                .position(|byte| *byte == b'\n')
+                .map(|offset| cursor + offset)
+                .ok_or_else(|| eyre::eyre!("Git batch output ended before its object header"))?;
+            let header = String::from_utf8_lossy(&output[cursor..header_end]);
+            let mut fields = header.split_whitespace();
+            let oid = fields.next().unwrap_or_default();
+            let kind = fields.next().unwrap_or_default();
+            let size = fields
+                .next()
+                .and_then(|size| size.parse::<usize>().ok())
+                .ok_or_else(|| eyre::eyre!("invalid Git batch object header: {header}"))?;
+            if oid != commit || kind != "commit" {
+                bail!("unexpected Git batch object header: {header}");
+            }
+            let object_start = header_end + 1;
+            let object_end = object_start
+                .checked_add(size)
+                .ok_or_else(|| eyre::eyre!("Git commit object size overflow for {commit}"))?;
+            let object = output
+                .get(object_start..object_end)
+                .ok_or_else(|| eyre::eyre!("Git batch output ended inside commit {commit}"))?;
+            let message_start = object
+                .windows(2)
+                .position(|bytes| bytes == b"\n\n")
+                .map(|offset| offset + 2)
+                .ok_or_else(|| eyre::eyre!("commit {commit} has no message separator"))?;
+            messages.push((
+                commit,
+                String::from_utf8_lossy(&object[message_start..])
+                    .trim()
+                    .to_string(),
+            ));
+            if output.get(object_end) != Some(&b'\n') {
+                bail!("Git batch output did not terminate commit object {oid}");
+            }
+            cursor = object_end + 1;
+        }
+        Ok(messages)
     }
 
     pub(crate) fn read_meta(&self, commit: &str) -> Result<Checkpoint> {
+        #[cfg(test)]
+        READ_META_CALLS.with(|count| count.set(count.get() + 1));
         let manifest = super::manifest::Manifest::read(self, commit)?;
         let message = self.output_str(PlumbingCall::new(["show", "-s", "--format=%B", commit]))?;
         let own_record = message
@@ -1410,11 +1484,18 @@ impl HistoryRepo {
         self.update_history_head(&commit, Some(&head))
     }
 
+    #[cfg(test)]
     pub(crate) fn read_annotation(
         &self,
         commit: &str,
     ) -> Result<Option<(String, super::store::Annotation)>> {
         let message = self.output_str(PlumbingCall::new(["show", "-s", "--format=%B", commit]))?;
+        Self::annotation_from_message(&message)
+    }
+
+    pub(crate) fn annotation_from_message(
+        message: &str,
+    ) -> Result<Option<(String, super::store::Annotation)>> {
         message
             .lines()
             .rev()

--- a/src/system/history/shadow.rs
+++ b/src/system/history/shadow.rs
@@ -63,7 +63,7 @@ pub(crate) struct CaptureResult {
     pub omitted: Vec<super::store::PathReason>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct TreeEntry {
     pub mode: String,
     pub oid: String,
@@ -600,8 +600,15 @@ impl HistoryRepo {
     pub(crate) fn read_meta(&self, commit: &str) -> Result<Checkpoint> {
         #[cfg(test)]
         READ_META_CALLS.with(|count| count.set(count.get() + 1));
-        let manifest = super::manifest::Manifest::read(self, commit)?;
-        let message = self.output_str(PlumbingCall::new(["show", "-s", "--format=%B", commit]))?;
+        let repo = gix::open_opts(self.dir(), gix::open::Options::isolated())
+            .wrap_err_with(|| format!("opening {} with gix", display_path(self.dir())))?;
+        let id = gix::ObjectId::from_hex(commit.as_bytes())?;
+        let commit_object = repo.find_commit(id)?;
+        let tree = commit_object.tree()?;
+        let manifest = super::manifest::Manifest::read_gix(&tree)?;
+        let message = String::from_utf8_lossy(commit_object.message_raw()?.as_ref())
+            .trim()
+            .to_string();
         let own_record = message
             .lines()
             .rev()
@@ -632,8 +639,9 @@ impl HistoryRepo {
             changes: Default::default(),
             operation: None,
         };
-        record.created_at =
-            self.output_str(PlumbingCall::new(["show", "-s", "--format=%cI", commit]))?;
+        record.created_at = commit_object
+            .time()?
+            .format(gix::date::time::format::ISO8601_STRICT)?;
         record.description = message
             .lines()
             .next()
@@ -656,11 +664,16 @@ impl HistoryRepo {
                 metadata.incomplete.into_iter().map(missing).collect();
             record.operation = metadata.operation.map(|op| op.localize()).transpose()?;
         }
-        record.tree.snapshot = Some(self.output_tree_of(commit)?);
+        record.tree.snapshot = Some(tree.id().to_string());
         record.changes = Default::default();
-        let parents = self.output_str(PlumbingCall::new(["show", "-s", "--format=%P", commit]))?;
-        record.changes.since = parents.split_whitespace().next().map(str::to_owned);
-        for change in self.changes(parents.split_whitespace().next(), commit)? {
+        let parent = commit_object.parent_ids().next().map(|id| id.detach());
+        record.changes.since = parent.map(|id| id.to_string());
+        let parent_tree = parent
+            .map(|parent| repo.find_commit(parent))
+            .transpose()?
+            .map(|commit| commit.tree())
+            .transpose()?;
+        for change in Self::gix_changes(&repo, parent_tree.as_ref(), &tree)? {
             if change.path.starts_with(".mise-history/") {
                 continue;
             }
@@ -673,17 +686,14 @@ impl HistoryRepo {
         }
         // The commit tree is authoritative even if a normal Git operation
         // reused a message containing metadata from an older commit.
-        record.tree.snapshot = Some(self.output_tree_of(commit)?);
+        record.tree.snapshot = Some(tree.id().to_string());
         record.tree.available = true;
         if let Some(manifest) = manifest {
-            let previous = record
-                .changes
-                .since
-                .as_deref()
-                .map(|parent| super::manifest::Manifest::read(self, parent))
-                .transpose()?
-                .flatten()
-                .unwrap_or_default();
+            let previous = if let Some(tree) = parent_tree.as_ref() {
+                super::manifest::Manifest::read_gix(tree)?.unwrap_or_default()
+            } else {
+                Default::default()
+            };
             for path in manifest
                 .permissions
                 .keys()
@@ -735,7 +745,7 @@ impl HistoryRepo {
             record.tree.coverage = coverage;
             let mut roots: BTreeMap<String, RootRecord> = BTreeMap::new();
             let layout = super::sync::layout::Roots::current();
-            for file in self.ls_tree(commit)? {
+            for file in Self::gix_tree_entries(&repo, &tree)? {
                 if layout.locate(&file.path).path().is_none() {
                     continue;
                 }
@@ -758,6 +768,69 @@ impl HistoryRepo {
             };
         }
         Ok(record)
+    }
+
+    fn gix_tree_entries(repo: &gix::Repository, tree: &gix::Tree<'_>) -> Result<Vec<TreeEntry>> {
+        let mut entries = tree
+            .traverse()
+            .breadthfirst
+            .files()?
+            .into_iter()
+            .filter(|entry| entry.mode.is_no_tree())
+            .map(|entry| {
+                let path = std::str::from_utf8(entry.filepath.as_ref())
+                    .wrap_err("history cannot represent a non-UTF-8 filename; refusing to change its bytes")?
+                    .to_string();
+                let mut mode = [0; 6];
+                let mode = std::str::from_utf8(entry.mode.as_bytes(&mut mode))?.to_string();
+                let size = entry
+                    .mode
+                    .is_blob_or_symlink()
+                    .then(|| repo.find_object(entry.oid).map(|object| object.data.len() as u64))
+                    .transpose()?;
+                Ok(TreeEntry {
+                    mode,
+                    oid: entry.oid.to_string(),
+                    size,
+                    path,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        entries.sort_by(|left, right| left.path.cmp(&right.path));
+        Ok(entries)
+    }
+
+    fn gix_changes(
+        repo: &gix::Repository,
+        from: Option<&gix::Tree<'_>>,
+        to: &gix::Tree<'_>,
+    ) -> Result<Vec<Change>> {
+        let from = if let Some(tree) = from {
+            Self::gix_tree_entries(repo, tree)?
+        } else {
+            vec![]
+        }
+        .into_iter()
+        .map(|entry| (entry.path, (entry.mode, entry.oid)))
+        .collect::<BTreeMap<_, _>>();
+        let to = Self::gix_tree_entries(repo, to)?
+            .into_iter()
+            .map(|entry| (entry.path, (entry.mode, entry.oid)))
+            .collect::<BTreeMap<_, _>>();
+        let mut changes = vec![];
+        for path in from.keys().chain(to.keys()).collect::<BTreeSet<_>>() {
+            let status = match (from.get(path), to.get(path)) {
+                (None, Some(_)) => 'A',
+                (Some(_), None) => 'D',
+                (Some(left), Some(right)) if left != right => 'M',
+                _ => continue,
+            };
+            changes.push(Change {
+                status,
+                path: path.clone(),
+            });
+        }
+        Ok(changes)
     }
 
     /// Recursive listing of a tree (or a path inside it).
@@ -1522,8 +1595,11 @@ mod tests {
         repo.update_history_head(&commit, None).unwrap();
         assert_eq!(
             repo.history_messages().unwrap(),
-            vec![(commit, "sha256 history".into())]
+            vec![(commit.clone(), "sha256 history".into())]
         );
+        let checkpoint = repo.read_meta(&commit).unwrap();
+        assert_eq!(checkpoint.uuid, commit);
+        assert_eq!(checkpoint.description, "sha256 history");
     }
 
     #[test]
@@ -1728,6 +1804,14 @@ mod tests {
             vec!["home/.config/app/a.toml", "home/.gitignore", "home/.zshrc"]
         );
         assert_eq!(result.roots[0].files, 3);
+        let gix = gix::open_opts(repo.dir(), gix::open::Options::isolated()).unwrap();
+        let tree = gix
+            .find_tree(gix::ObjectId::from_hex(result.tree.as_bytes()).unwrap())
+            .unwrap();
+        assert_eq!(
+            HistoryRepo::gix_tree_entries(&gix, &tree).unwrap(),
+            repo.ls_tree(&result.tree).unwrap()
+        );
         // the same content is the same tree
         let again = repo
             .capture(&[root(
@@ -1934,6 +2018,17 @@ mod tests {
                     path: "home/.zshrc".into()
                 },
             ]
+        );
+        let gix = gix::open_opts(repo.dir(), gix::open::Options::isolated()).unwrap();
+        let a_tree = gix
+            .find_tree(gix::ObjectId::from_hex(a.tree.as_bytes()).unwrap())
+            .unwrap();
+        let b_tree = gix
+            .find_tree(gix::ObjectId::from_hex(b.tree.as_bytes()).unwrap())
+            .unwrap();
+        assert_eq!(
+            HistoryRepo::gix_changes(&gix, Some(&a_tree), &b_tree).unwrap(),
+            changes
         );
         let initial = repo.changes(None, &a.tree).unwrap();
         assert_eq!(initial.len(), 2);

--- a/src/system/history/store.rs
+++ b/src/system/history/store.rs
@@ -43,6 +43,10 @@ fn meta_cache_dir_in(state_dir: &Path) -> PathBuf {
     index_dir_in(state_dir).join("meta")
 }
 
+fn commit_meta_cache_dir_in(state_dir: &Path) -> PathBuf {
+    index_dir_in(state_dir).join("commits")
+}
+
 pub(crate) fn pending_dir_in(state_dir: &Path) -> PathBuf {
     index_dir_in(state_dir).join("pending")
 }
@@ -67,6 +71,7 @@ pub(crate) fn ensure_store_dir_in(state_dir: &Path) -> Result<()> {
     create_private_dir(&dir)?;
     create_private_dir(&index_dir_in(state_dir))?;
     create_private_dir(&meta_cache_dir_in(state_dir))?;
+    create_private_dir(&commit_meta_cache_dir_in(state_dir))?;
     create_private_dir(&pending_dir_in(state_dir))?;
     Ok(())
 }
@@ -760,6 +765,87 @@ pub(crate) fn read_meta_cache_in(state_dir: &Path, uuid: &str) -> Result<Option<
     Ok(Some(checkpoint))
 }
 
+const COMMIT_META_CACHE_VERSION: u32 = 1;
+
+/// The local context used while deriving display paths and active variants.
+/// A commit cache is reusable only while every input to that derivation is
+/// unchanged. Both configured and resolved roots are retained so changing a
+/// symlinked ancestor invalidates the cache as well.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct CommitMetaContext {
+    version: u32,
+    schema_version: u32,
+    home: PathBuf,
+    config_dir: PathBuf,
+    resolved_home: PathBuf,
+    resolved_config_dir: PathBuf,
+    environments: Vec<String>,
+}
+
+impl CommitMetaContext {
+    fn current() -> Self {
+        let roots = super::sync::layout::Roots::current();
+        Self {
+            version: COMMIT_META_CACHE_VERSION,
+            schema_version: SCHEMA_VERSION,
+            home: crate::dirs::HOME.to_path_buf(),
+            config_dir: super::tracked::global_config_dir(),
+            resolved_home: roots.home,
+            resolved_config_dir: roots.config_dir,
+            environments: super::select::active_environments(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CommitMetaCache {
+    context: CommitMetaContext,
+    commit: String,
+    checkpoint: Checkpoint,
+}
+
+fn commit_meta_cache_path_in(state_dir: &Path, commit: &str) -> PathBuf {
+    commit_meta_cache_dir_in(state_dir).join(format!("{commit}.json"))
+}
+
+/// Reads metadata derived directly from a commit, before annotations.
+pub(crate) fn read_commit_meta_cache_in(
+    state_dir: &Path,
+    commit: &str,
+) -> Result<Option<Checkpoint>> {
+    let path = commit_meta_cache_path_in(state_dir, commit);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let text = file::read_to_string(&path)?;
+    let Ok(cache) = serde_json::from_str::<CommitMetaCache>(&text) else {
+        return Ok(None);
+    };
+    if cache.context != CommitMetaContext::current()
+        || cache.commit != commit
+        || cache.checkpoint.uuid != commit
+        || cache.checkpoint.schema_version != SCHEMA_VERSION
+    {
+        return Ok(None);
+    }
+    Ok(Some(cache.checkpoint))
+}
+
+pub(crate) fn write_commit_meta_cache_in(
+    state_dir: &Path,
+    commit: &str,
+    checkpoint: &Checkpoint,
+) -> Result<()> {
+    write_json(
+        &commit_meta_cache_path_in(state_dir, commit),
+        &CommitMetaCache {
+            context: CommitMetaContext::current(),
+            commit: commit.to_string(),
+            checkpoint: checkpoint.clone(),
+        },
+    )
+}
+
 pub(crate) fn pending_path_in(state_dir: &Path, uuid: &str) -> PathBuf {
     pending_dir_in(state_dir).join(format!("{uuid}.json"))
 }
@@ -949,6 +1035,37 @@ pub(crate) fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
         let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod commit_cache_tests {
+    use super::*;
+
+    #[test]
+    fn commit_metadata_cache_requires_current_context_and_identity() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        ensure_store_dir_in(temp.path())?;
+        let checkpoint = super::super::checkpoint::test_checkpoint("abc123", None);
+        write_commit_meta_cache_in(temp.path(), "abc123", &checkpoint)?;
+        assert_eq!(
+            read_commit_meta_cache_in(temp.path(), "abc123")?
+                .unwrap()
+                .uuid,
+            "abc123"
+        );
+
+        let path = commit_meta_cache_path_in(temp.path(), "abc123");
+        let mut cache: CommitMetaCache = serde_json::from_str(&file::read_to_string(&path)?)?;
+        cache.context.version += 1;
+        write_json(&path, &cache)?;
+        assert!(read_commit_meta_cache_in(temp.path(), "abc123")?.is_none());
+
+        cache.context = CommitMetaContext::current();
+        cache.commit = "different".into();
+        write_json(&path, &cache)?;
+        assert!(read_commit_meta_cache_in(temp.path(), "abc123")?.is_none());
+        Ok(())
+    }
 }
 
 #[cfg(all(test, unix))]

--- a/src/system/history/store.rs
+++ b/src/system/history/store.rs
@@ -817,7 +817,9 @@ pub(crate) fn read_commit_meta_cache_in(
     if !path.exists() {
         return Ok(None);
     }
-    let text = file::read_to_string(&path)?;
+    let Ok(text) = file::read_to_string(&path) else {
+        return Ok(None);
+    };
     let Ok(cache) = serde_json::from_str::<CommitMetaCache>(&text) else {
         return Ok(None);
     };
@@ -1063,6 +1065,9 @@ mod commit_cache_tests {
         cache.context = CommitMetaContext::current();
         cache.commit = "different".into();
         write_json(&path, &cache)?;
+        assert!(read_commit_meta_cache_in(temp.path(), "abc123")?.is_none());
+
+        std::fs::write(&path, [0xff])?;
         assert!(read_commit_meta_cache_in(temp.path(), "abc123")?.is_none());
         Ok(())
     }


### PR DESCRIPTION
## Summary

- rebuild history index metadata in-process with gix, including commit headers and messages, manifests, recursive tree entries, blob sizes, and no-rename change summaries
- preserve Git's topological ordering and `ls-tree -r` path ordering without a bidirectional subprocess pipe or per-checkpoint Git processes
- cache immutable commit-derived metadata and reuse it only when the commit, schema, active environments, configured roots, and resolved filesystem roots still match
- apply annotations from the currently selected ancestry after loading cached metadata so rewinding history cannot retain removed descriptions or labels
- treat unreadable derived-cache entries as cache misses so the repository remains the recoverable source of truth
- support both SHA-1 and SHA-256 history repositories in the gix reader and atomic ref creation

This addresses the rebuild behavior reported in https://github.com/jdx/mise/discussions/12993.

## Performance

Using the discussion's 80-checkpoint, 44-file reproducer:

| Build | Cold cache population | Warm cache rebuild | Git processes, cold / warm |
| --- | ---: | ---: | ---: |
| Official v2026.9.3 release, reported | 25.965 s | 27.684 s | 3,288 / 3,288 |
| This change, debug build | 2.275 s | 0.773 s | 11 / 11 |

The earlier revision of this PR measured 17.786 seconds and 1,049 Git processes on the cold pass because gix handled only ancestry and commit messages; `read_meta()` still reconstructed every manifest, parent, tree, and diff through Git plumbing. That measurement is now obsolete. The complete read-only reconstruction path uses gix, so cold and warm rebuilds both start 11 fixed Git processes outside per-checkpoint metadata reads. Both passes returned identical checkpoint records.

The profiles and local Git versions differ, and elapsed times vary with concurrent build load, so timings are illustrative; process counts show the stable reduction. Git remains responsible for repository writes, ref transactions, merge behavior, network operations, and patch rendering, where replacing it would broaden this fix into a backend rewrite.

## Object format compatibility

The history store supports both Git object formats that its object IDs recognize. The gix dependency enables SHA-1 and SHA-256, and atomic creation of a missing ref selects Git's 40- or 64-zero sentinel from the concrete commit ID. A regression test creates a real SHA-256 bare repository, writes its first history commit and ref, and reconstructs its checkpoint metadata through gix.

## Tests

- `cargo test --locked --bin mise system::history --no-fail-fast` (155 passed)
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `mise run lint-fix`
- Git/gix equivalence checks for recursive tree entries and change summaries
- focused end-to-end scenarios covering history, bootstrap/policies, annotations, managed manual files, and manual/automatic synchronization
- discussion reproducer with `GIT_TRACE2_EVENT`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - History indexes rebuild more efficiently by reusing cached checkpoint metadata.
  - Removed history annotations are correctly reflected after an index rebuild.
  - History data can now be used with repositories using SHA-256 commit identifiers.
  - Large repository objects are processed more efficiently during history and manifest operations.

- **Bug Fixes**
  - Oversized manifest data is now rejected reliably before being fully processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core history index reconstruction and metadata parsing; mistakes could mis-order checkpoints, show wrong descriptions after ancestry changes, or mishandle SHA-256 repos, though extensive tests and cache invalidation mitigate this.
> 
> **Overview**
> **History index rebuilds** now walk commit ancestry and reconstruct checkpoint metadata in-process with **gix** instead of spawning Git per checkpoint. `read_meta`, manifest reads, recursive tree listings, parent diffs, and commit messages all go through gix; `gix` gains the **sha256** feature and ref updates accept 40- or 64-character object IDs.
> 
> **Rebuild logic** uses `history_messages()` (topological order) and parses annotations from commit messages. A new **per-commit metadata cache** on disk stores immutable commit-derived checkpoints and is reused when schema, environments, and filesystem roots still match; annotations are applied afterward so rewinding history does not keep stale labels/descriptions.
> 
> **Index bootstrap** checks for `HISTORY_REF` instead of enumerating checkpoint refs. Tests cover cache invalidation, gix/Git equivalence, SHA-256 repos, and zero `read_meta` calls on warm rebuilds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3113822334d1b6ac1368175fe773315680a8fc7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->