### PR TITLE
fix(packslip): scope cached man paths

### DIFF
--- a/e2e/backend/test_packslip_resources
+++ b/e2e/backend/test_packslip_resources
@@ -160,6 +160,18 @@ actual_manpath="$(env -u MANPATH mise x -- env | sed -n 's/^MANPATH=//p')"
 [[ $actual_manpath == "$active_manpath:" ]] ||
   fail "MANPATH should retain system defaults: $actual_manpath"
 
+# The environment cache must not reuse the caller MANPATH captured by an
+# earlier process.
+export MISE_ENV_CACHE=1
+export __MISE_ENV_CACHE_KEY="dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleXRlc3Q="
+actual_manpath="$(MANPATH="/caller-one:" mise x -- env | sed -n 's/^MANPATH=//p')"
+[[ $actual_manpath == "$active_manpath:/caller-one:" ]] ||
+  fail "unexpected cached MANPATH for first caller: $actual_manpath"
+actual_manpath="$(MANPATH="/caller-two:" mise x -- env | sed -n 's/^MANPATH=//p')"
+[[ $actual_manpath == "$active_manpath:/caller-two:" ]] ||
+  fail "environment cache reused another caller's MANPATH: $actual_manpath"
+unset MISE_ENV_CACHE __MISE_ENV_CACHE_KEY
+
 # A tools-aware environment value resolves after the first tool environment
 # pass, but it must not replace the active Packslip man root.
 cd ../project-tools-manpath

--- a/src/toolset/env_cache.rs
+++ b/src/toolset/env_cache.rs
@@ -543,6 +543,7 @@ mod tests {
             Some(""),
         );
         assert_ne!(key1, key5);
+        assert_ne!(key4, key5);
     }
 
     #[test]

--- a/src/toolset/env_cache.rs
+++ b/src/toolset/env_cache.rs
@@ -154,6 +154,7 @@ impl CachedEnv {
         tool_versions: &[(String, String)], // (tool, version)
         settings_hash: &str,
         base_path: &str,
+        base_manpath: Option<&str>,
     ) -> String {
         let mut hasher = Hasher::new();
 
@@ -180,6 +181,14 @@ impl CachedEnv {
 
         // base PATH
         hasher.update(base_path.as_bytes());
+
+        // Packslip man roots are composed with the caller's MANPATH. Keep
+        // cache entries from capturing a value supplied by another process.
+        hasher.update(b"base-manpath");
+        hasher.update(&[base_manpath.is_some() as u8]);
+        if let Some(base_manpath) = base_manpath {
+            hasher.update(base_manpath.as_bytes());
+        }
 
         let hash = hasher.finalize();
         hex::encode(hash.as_bytes())
@@ -487,12 +496,22 @@ mod tests {
         let settings_hash = "abc123";
         let base_path = "/usr/bin:/bin";
 
-        let key1 =
-            CachedEnv::compute_cache_key(&config_files, &tool_versions, settings_hash, base_path);
+        let key1 = CachedEnv::compute_cache_key(
+            &config_files,
+            &tool_versions,
+            settings_hash,
+            base_path,
+            None,
+        );
 
         // Same inputs should produce same key
-        let key2 =
-            CachedEnv::compute_cache_key(&config_files, &tool_versions, settings_hash, base_path);
+        let key2 = CachedEnv::compute_cache_key(
+            &config_files,
+            &tool_versions,
+            settings_hash,
+            base_path,
+            None,
+        );
         assert_eq!(key1, key2);
 
         // Different mtime should produce different key
@@ -503,8 +522,27 @@ mod tests {
             &tool_versions,
             settings_hash,
             base_path,
+            None,
         );
         assert_ne!(key1, key3);
+
+        let key4 = CachedEnv::compute_cache_key(
+            &config_files,
+            &tool_versions,
+            settings_hash,
+            base_path,
+            Some("/caller/man"),
+        );
+        assert_ne!(key1, key4);
+
+        let key5 = CachedEnv::compute_cache_key(
+            &config_files,
+            &tool_versions,
+            settings_hash,
+            base_path,
+            Some(""),
+        );
+        assert_ne!(key1, key5);
     }
 
     #[test]

--- a/src/toolset/toolset_env.rs
+++ b/src/toolset/toolset_env.rs
@@ -5,6 +5,7 @@ use std::time::SystemTime;
 
 use eyre::Result;
 
+use crate::backend::backend_type::BackendType;
 use crate::config::env_directive::{EnvResolveOptions, EnvResults, ToolsFilter};
 use crate::config::{Config, Settings};
 use crate::env::{PATH_KEY, WARN_ON_MISSING_REQUIRED_ENV};
@@ -431,6 +432,7 @@ impl Toolset {
             &tool_versions,
             &settings_hash,
             &base_path,
+            env::PRISTINE_ENV.get("MANPATH").map(String::as_str),
         ))
     }
 
@@ -512,6 +514,7 @@ impl Toolset {
         let mut paths: Vec<PathBuf> = self
             .list_current_installed_versions(config)
             .into_iter()
+            .filter(|(backend, _)| backend.get_type() == BackendType::Packslip)
             .filter_map(|(_, tv)| crate::packslip::manpath(&tv.install_path()))
             .collect();
         if paths.is_empty() {


### PR DESCRIPTION
## Summary
- restrict activated man roots to Packslip-backed tool versions
- include the caller's pristine `MANPATH` in the environment-cache identity
- cover distinct caller `MANPATH` values across cache hits

Follow-up to #13012 for review feedback posted shortly before it merged:
- https://github.com/jdx/mise/pull/13012#discussion_r3970354251
- https://github.com/jdx/mise/pull/13012#discussion_r3970354262

## Testing
- `cargo test --locked --bin mise test_cache_key_computation`
- `mise run test:e2e e2e/backend/test_packslip_resources`
- `mise run lint`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes environment-cache keying and MANPATH composition for all cached activations; incorrect behavior would leak or drop caller MANPATH across processes.
> 
> **Overview**
> Fixes **Packslip `MANPATH` handling** when the environment cache is enabled so one process cannot serve another caller’s `MANPATH`.
> 
> **Environment cache identity** now mixes in the pristine caller `MANPATH` (presence and value) in `compute_cache_key`, matching how Packslip prepends man roots onto the caller path. **Packslip man prepending** is limited to **Packslip-backed** tool versions so other backends do not get man roots applied.
> 
> E2E coverage runs two `mise x` invocations with different `MANPATH` under `MISE_ENV_CACHE` and asserts each keeps its own caller suffix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24f123764a381c95fbb2fdcb02683ce81ad2038c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment caching so MANPATH values from one process are not reused by another.
  * Ensured each command preserves its own caller-provided MANPATH while adding the active Packslip manpath.
  * Limited automatic manpath additions to Packslip-managed tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->