### PR TITLE
chore(deps): update aube to v2.2.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,9 +557,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aube"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4011d45e502a1f591fd435ac76e66bb6f9dbc1a32f2d4a2515567eb50c24edd9"
+checksum = "0a480091a612a7cd504d62328cb9c9c74899fb798aab03c2536b9002c3cc0640"
 dependencies = [
  "aube-codes",
  "aube-linker",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "aube-codes"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60b2620e523b170ad8398d5e9c227debfcfe8d28ec6cc136e45a445c12b5c"
+checksum = "a0ce615dba0f654c6175b1ca4ee12cd45baff9355969084cdf719aeb475090c5"
 dependencies = [
  "serde",
  "serde_json",
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "aube-linker"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fba4cc28189031292a458a71838a7dacf9854c4c329f57ac2b6d9e2cd8d0c45"
+checksum = "452f9540580d1a7ae93eaf2742817f8c2aae22fb96a39432a80b05fd0859a83f"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "aube-lockfile"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0169ab4114e1cfbf496f580bfda050f2dce5365a9ba474a436ad4e73fab010b4"
+checksum = "b652f270869b94c9947bf451f1caff2020a65639d10a7f80a4943eb0c0d9b067"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "aube-manifest"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a28e732934138732f5aba00316a082f02e1133d2e9ca035e0bc71321e582f74"
+checksum = "960387dfe0a3790afc035f99e6ce3e407197e7c54b352518662947b58dc34d43"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "aube-registry"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f4dabaa42d7b33ba51b1389f96e2a48425855005668a6459d689614420c99a"
+checksum = "65554341fa1d1613ba2f270af22dc06039c80944aababe8cd08a0eb624074571"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "aube-resolver"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a00b0f30ad37d6a97f6a2404defcad0b2c95aa465aad7311e9cd5f35d9ec0"
+checksum = "71eeec7668b4930b108160a294acd5ed23b6083e92c1d447b7ab5ce40931977a"
 dependencies = [
  "aube-codes",
  "aube-lockfile",
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "aube-runtime"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675aa89d035aa03000ad9d4822035407123175d7323a0a94cdb6c95da8abf553"
+checksum = "46a9976625cb729e26d89424539c8fdc853c62be429464134d5871706e7ec99b"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -777,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "aube-scripts"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1610fc9cca4f1737a7d9b6aa932e6de0fe4e35cfcc65238d8e9b1c9f9cb0f894"
+checksum = "27a4ed30c5cffed974372767270dc854c7024d3e89d9581df9a8604cf36edb4d"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "aube-settings"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7875b5c2d777b61b9e0b74bd0b82df0ffa80b1bf157957934ea43d562162b0fc"
+checksum = "19f9199710c2d8bb0073cdfe856b751a5a8e759afbe2e1995f9c5c4ecde8b1d4"
 dependencies = [
  "aube-codes",
  "aube-util",
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "aube-store"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ea53e573fbec7f59854843092b87ded9fd76acbcb86b6d28c90a8cd7cd6765"
+checksum = "54f5a772c74cf7607a315d65a329ca828f91c59e6d0ebba7344e80b1c8b88487"
 dependencies = [
  "aube-util",
  "base64 0.23.1",
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "aube-util"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c102ecb4f034b90247a3d110f0b849423da3e514f4adda11001a8927a98e2b"
+checksum = "b9bb44d2b7808a4fe590d9a2c6b5d5f97daa2effccd9e21d355fe4068d745432"
 dependencies = [
  "aube-codes",
  "blake3",
@@ -860,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "aube-workspace"
-version = "2.2.12"
+version = "2.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a466a79dae60f1cb8a408ee5e555b299226122c704ce723c78c82a5d4a0b6b29"
+checksum = "d1679cfb8c8500a58a54be9bfcf6015bf17e88ef34738ffd8b7160de2cbfab37"
 dependencies = [
  "aube-codes",
  "aube-manifest",
@@ -7469,7 +7469,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfields",
  "block-padding 0.3.3",
  "blowfish",

--- a/mise.lock
+++ b/mise.lock
@@ -137,6 +137,7 @@ checksum = "sha256:0b0e734d5fe6e90a286229136d1e97e217b1836e297408cbf9d07cd020cfb
 url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553074742"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools.aube."platforms.linux-x64-baseline"]
 checksum = "sha256:0b0e734d5fe6e90a286229136d1e97e217b1836e297408cbf9d07cd020cfb4c2"

--- a/mise.lock
+++ b/mise.lock
@@ -117,62 +117,62 @@ url_api = "https://api.github.com/repos/FiloSottile/age/releases/assets/53554193
 provenance = "github-attestations"
 
 [[tools.aube]]
-version = "2.2.12"
+version = "2.2.13"
 backend = "github:endevco/aube"
 
 [tools.aube."platforms.linux-arm64"]
-checksum = "sha256:831f212a8b3f2f7a2de891eed7c95856bffadb9e3ec5981377a157f32bcff730"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.12/aube-v2.2.12-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/546510161"
+checksum = "sha256:561a16c933188ef14955989cf99bb368748df5a3903c4cf12d2b05c31d8f4ec8"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553098701"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-arm64-musl"]
-checksum = "sha256:b6df7f02c0e58257843c071efd14d65665cebb03fb3462633643c9aeaa36a61f"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.12/aube-v2.2.12-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/546500061"
+checksum = "sha256:ad9fb86ad219ada9abc1c7907952505c540c41b5c8e0ffca828e8a2cd2017b11"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553072698"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64"]
-checksum = "sha256:ad906bced7d1bf014a2dd8cfa1b03ad0e38a5764f92fe4b30e9e27e303bb7a03"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.12/aube-v2.2.12-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/546498432"
+checksum = "sha256:0b0e734d5fe6e90a286229136d1e97e217b1836e297408cbf9d07cd020cfb4c2"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553074742"
 provenance = "github-attestations"
-provenance_verified = true
 
 [tools.aube."platforms.linux-x64-baseline"]
-checksum = "sha256:ad906bced7d1bf014a2dd8cfa1b03ad0e38a5764f92fe4b30e9e27e303bb7a03"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.12/aube-v2.2.12-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/546498432"
+checksum = "sha256:0b0e734d5fe6e90a286229136d1e97e217b1836e297408cbf9d07cd020cfb4c2"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553074742"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl"]
-checksum = "sha256:81a1e1c3d041ce0db51483ad3b892e66dec1e63fff6489ae847880fbd081b92d"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.12/aube-v2.2.12-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/546495491"
+checksum = "sha256:894bb4991b2cb8054b562dd85682d7e7f21e4479ace26c8f13d4aa362dec0b63"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553073513"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:81a1e1c3d041ce0db51483ad3b892e66dec1e63fff6489ae847880fbd081b92d"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.12/aube-v2.2.12-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/546495491"
+checksum = "sha256:894bb4991b2cb8054b562dd85682d7e7f21e4479ace26c8f13d4aa362dec0b63"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553073513"
 provenance = "github-attestations"
 
 [tools.aube."platforms.macos-arm64"]
-checksum = "sha256:30235658a0f328f095ff7f178f352a6bfef753a8fe505d991bd9f5db3825f2f6"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.12/aube-v2.2.12-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/546517467"
+checksum = "sha256:f999226cddee14afc8d0d2d461191888b65064262e66e83ce1fc8e9069792c1e"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553104973"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools.aube."platforms.windows-x64"]
-checksum = "sha256:c734783dfba99509b54dfaf49aa897dffa017a82128a45302e01812231dfeb11"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.12/aube-v2.2.12-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/546508041"
+checksum = "sha256:84b052e0233b37b875af71487a342f6c170da7827ea57ab36ff29102801d56ac"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553097930"
 provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64-baseline"]
-checksum = "sha256:c734783dfba99509b54dfaf49aa897dffa017a82128a45302e01812231dfeb11"
-url = "https://github.com/aubepkg/aube/releases/download/v2.2.12/aube-v2.2.12-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/546508041"
+checksum = "sha256:84b052e0233b37b875af71487a342f6c170da7827ea57ab36ff29102801d56ac"
+url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553097930"
 provenance = "github-attestations"
 
 [[tools.bun]]


### PR DESCRIPTION
## Summary

- update the embedded `aube` and `aube-registry` dependency graph to v2.2.13
- refresh all aube workspace crates in `Cargo.lock`
- update the standalone development `aube` entry in `mise.lock`, including released platform URLs, checksums, asset IDs, and provenance metadata
- includes the malformed bundled-dependency metadata fix from [aubepkg/aube#1513](https://github.com/aubepkg/aube/pull/1513), released in [aube v2.2.13](https://github.com/aubepkg/aube/releases/tag/v2.2.13)

## Validation

- `mise exec -- cargo check --locked`
- `mise exec -- cargo test --locked --bin mise aube`
- `mise exec -- cargo test --locked --bin mise task::workspace::node::tests`
- `mise run test:e2e e2e/backend/test_npm_aube`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Patch bump to embedded aube and the release/publish toolchain; behavior changes are limited but touch package resolution and npm publishing metadata handling.
> 
> **Overview**
> Bumps **aube** from **v2.2.12** to **v2.2.13** in both the Rust dependency graph and the pinned dev tool in `mise.lock`.
> 
> `Cargo.lock` refreshes the full `aube-*` workspace (registry, resolver, linker, etc.) to the new release checksums. `mise.lock` points every platform at the v2.2.13 GitHub release assets (new URLs, SHA-256 checksums, and asset IDs) and records **`provenance_verified = true`** for **macOS arm64**. The lockfile also picks up a transitive **`pgp`** dependency change (`base64` 0.22.1 → 0.21.7).
> 
> This pulls in the **malformed bundled-dependency metadata** fix from upstream **aube v2.2.13** (aubepkg/aube#1513), which matters for npm/aube install and publish paths that rely on correct package metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50a2a64aacbb2c39839d75723e955b87c720896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->