### PR TITLE
feat(install): add per-tool force option

### DIFF
--- a/docs/dev-tools/index.md
+++ b/docs/dev-tools/index.md
@@ -164,6 +164,23 @@ precedence. Registry entries may set this option for tools known to follow
 semantic versioning; users can set `version_order = "source"` to restore the
 backend's default ordering.
 
+### Force reinstall
+
+Set `force = true` on a tool to have it always reinstall, even when a bare
+`mise install` would otherwise consider it already satisfied. This is the
+per-tool equivalent of [`mise install --force`](/cli/install.html), scoped to
+just that tool:
+
+```toml
+[tools]
+node = { version = "24", force = true }
+```
+
+Combine with [`lazy = true`](/dev-tools/shims.html#lazy-tools) to keep the
+tool out of a bare `mise install` entirely while still always reinstalling it
+fresh whenever it is installed, whether by a lazy bootstrap shim or an
+explicit `mise install node`.
+
 ### Tool postinstall commands
 
 Run a command immediately after a tool finishes installing by adding a `postinstall` field to that tool's configuration. This is separate from `[hooks].postinstall` and applies only when that specific tool is installed.

--- a/e2e/cli/test_install_force_tool_option
+++ b/e2e/cli/test_install_force_tool_option
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+rm -rf "$MISE_DATA_DIR/plugins/tiny"
+ln -s "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny"
+
+cat >mise.toml <<'EOF'
+[tools]
+tiny = { version = "1.0.0", force = true }
+dummy = "1.0.0"
+EOF
+
+mise install
+
+tiny_marker="$MISE_DATA_DIR/installs/tiny/1.0.0/force-marker"
+dummy_marker="$MISE_DATA_DIR/installs/dummy/1.0.0/force-marker"
+
+touch "$tiny_marker" "$dummy_marker"
+
+# A bare install reinstalls only the tool with force=true, leaving the other alone.
+mise install
+assert_fail "test -f '$tiny_marker'"
+assert "test -f '$dummy_marker'"

--- a/schema/mise-task.json
+++ b/schema/mise-task.json
@@ -908,6 +908,11 @@
                   },
                   "uniqueItems": true
                 },
+                "force": {
+                  "description": "always reinstall this tool version, even if it is already installed",
+                  "type": "boolean",
+                  "default": false
+                },
                 "postinstall": {
                   "description": "command to run after tool installation",
                   "type": "string"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -2841,6 +2841,11 @@
                   },
                   "uniqueItems": true
                 },
+                "force": {
+                  "description": "always reinstall this tool version, even if it is already installed",
+                  "type": "boolean",
+                  "default": false
+                },
                 "postinstall": {
                   "description": "command to run after tool installation",
                   "type": "string"

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -593,7 +593,7 @@ impl Install {
                         tr.is_install_satisfied(&install_config),
                     )
                     .await;
-                    if satisfied {
+                    if satisfied && tr.options().force != Some(true) {
                         if let Some(reporter) = reporter {
                             reporter.finish_with_icon(
                                 "already installed".into(),

--- a/src/toolset/tool_version_options.rs
+++ b/src/toolset/tool_version_options.rs
@@ -30,6 +30,8 @@ pub(crate) struct CoreToolOptions {
     pub lazy: Option<bool>,
     #[serde(default)]
     pub lazy_bins: Vec<String>,
+    #[serde(default)]
+    pub force: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -253,6 +255,12 @@ impl ResolvedToolOptions {
         {
             options.lazy_bins.clone_from(&self.options.lazy_bins);
         }
+        if self
+            .source_for_key("force")
+            .is_some_and(|source| sources.contains(&source))
+        {
+            options.force = self.options.force;
+        }
         options
     }
 
@@ -283,6 +291,9 @@ impl ResolvedToolOptions {
         if !options.lazy_bins.is_empty() {
             self.sources.insert("lazy_bins".to_string(), source);
         }
+        if options.force.is_some() {
+            self.sources.insert("force".to_string(), source);
+        }
     }
 }
 
@@ -300,6 +311,7 @@ impl std::hash::Hash for ToolOptions {
         self.depends.hash(state);
         self.lazy.hash(state);
         self.lazy_bins.hash(state);
+        self.force.hash(state);
 
         // Hash install_env in sorted order for deterministic hashing
         let mut install_env_sorted: Vec<_> = self.install_env.iter().collect();
@@ -351,6 +363,7 @@ impl ToolOptions {
             && self.install_env.is_empty()
             && self.lazy.is_none()
             && self.lazy_bins.is_empty()
+            && self.force.is_none()
             && self.opts.is_empty()
     }
 
@@ -417,6 +430,9 @@ impl ToolOptions {
         if !overrides.lazy_bins.is_empty() {
             self.lazy_bins.clone_from(&overrides.lazy_bins);
         }
+        if overrides.force.is_some() {
+            self.force = overrides.force;
+        }
     }
 
     pub(crate) fn insert_option(&mut self, key: String, value: toml::Value) -> Result<(), String> {
@@ -470,6 +486,14 @@ impl ToolOptions {
                 }
                 Ok(true)
             }
+            "force" => {
+                self.force = Some(
+                    value
+                        .as_bool()
+                        .ok_or_else(|| "force must be a boolean".to_string())?,
+                );
+                Ok(true)
+            }
             "postinstall" => {
                 let script = value
                     .as_str()
@@ -520,6 +544,9 @@ impl ToolOptions {
         }
         if key == "lazy_bins" {
             return !self.lazy_bins.is_empty();
+        }
+        if key == "force" {
+            return self.force.is_some();
         }
         if let Some(env_key) = key.strip_prefix("install_env.") {
             return self.install_env.contains_key(env_key);
@@ -1479,6 +1506,34 @@ mod tests {
             .unwrap();
         base.apply_overrides(&overrides);
         assert_eq!(base.lazy, Some(false));
+    }
+
+    #[test]
+    fn test_force_option_parse_and_override() {
+        let mut base = ToolVersionOptions::default();
+        base.insert_option("force".into(), toml::Value::Boolean(true))
+            .unwrap();
+        assert_eq!(base.force, Some(true));
+        assert!(base.contains_key("force"));
+        assert!(!base.is_empty());
+
+        let mut overrides = ToolVersionOptions::default();
+        overrides
+            .insert_option("force".into(), toml::Value::Boolean(false))
+            .unwrap();
+        base.apply_overrides(&overrides);
+        assert_eq!(base.force, Some(false));
+    }
+
+    #[test]
+    fn test_force_option_rejects_non_boolean() {
+        let mut options = ToolVersionOptions::default();
+        assert_eq!(
+            options
+                .insert_option("force".into(), toml::Value::String("yes".into()))
+                .unwrap_err(),
+            "force must be a boolean"
+        );
     }
 
     #[test]

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -772,7 +772,7 @@ impl Toolset {
             } else {
                 mpr.add_with_options(&tv.style(), opts.dry_run)
             }),
-            force: opts.force,
+            force: opts.force || tr.options().force == Some(true),
             dry_run: opts.dry_run,
             locked: config.invocation_locked_for(tr.source(), opts.locked)
                 || config.tool_config_locked(tr.source()),


### PR DESCRIPTION
Allows `node = { version = "24", force = true }` to always reinstall that tool on `mise install`, without requiring the global `--force` flag. Composes with `lazy` for tools that should skip bare installs but always reinstall fresh once triggered.

This is a bit of an edge case, so you may not want to pollute mise with it. Specifically, if I'm trying to support users who want to point their tool to `some_go_lib@stable`. To ensure they have the "newest" version of `stable` this allows an option to `force` for that individual tool any time `mise install` is run, or if the user has `mise install` on `cd,` to ensure they are up to date.

Thank you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a per-tool `force` option that reinstalls a tool even when its requested version is already installed.
  * The option can be combined with lazy installation behavior and applies to both automatic and explicit installs.

* **Documentation**
  * Added guidance for configuring and using the per-tool force reinstall option.

* **Tests**
  * Added coverage confirming forced tools reinstall while other satisfied tools remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->