### PR TITLE
fix(self-update): select the correct armv7 release archive

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -4,6 +4,7 @@ use console::style;
 #[cfg(windows)]
 use indoc::formatdoc;
 use self_update::backends::github::Update;
+use self_update::update::ReleaseAsset;
 use self_update::{VersionStatus, cargo_crate_version};
 
 use crate::cli::version::{ARCH, OS, SelfUpdateSource};
@@ -21,6 +22,33 @@ use std::process::Command;
 use std::time::Duration;
 
 const AUTO_UPDATE_REEXEC_ENV: &str = "__MISE_AUTO_UPDATE_REEXEC";
+
+fn release_archive_name(version: &str, os: &str, arch: &str, build_target: &str) -> String {
+    // Rust reports every 32-bit ARM target as `arm`, but our releases use `armv7`.
+    // Preserve the build's ARM variant rather than upgrading an unsupported ARM CPU to v7.
+    let arch = if arch == "arm" {
+        build_target.split('-').next().unwrap_or(arch)
+    } else {
+        arch
+    };
+    let libc = if build_target.contains("-musl") {
+        "-musl"
+    } else {
+        ""
+    };
+    let extension = if os == "windows" { "zip" } else { "tar.gz" };
+    format!("mise-{version}-{os}-{arch}{libc}.{extension}")
+}
+
+fn release_archive_asset(assets: &[ReleaseAsset], archive_name: &str) -> Option<ReleaseAsset> {
+    // The default matcher falls back to architecture/OS substrings when the requested
+    // archive is missing, which can select a raw binary or another architecture.
+    assets
+        .iter()
+        .find(|asset| asset.name() == archive_name)
+        .cloned()
+}
+
 #[derive(Debug, Default, serde::Deserialize)]
 struct InstructionsToml {
     message: Option<String>,
@@ -523,20 +551,15 @@ impl SelfUpdate {
             return Ok(VersionStatus::UpToDate(current_version));
         }
 
-        let target = format!("{}-{}", *OS, *ARCH);
-        #[cfg(target_env = "musl")]
-        let target = format!("{target}-musl");
+        let target = release_archive_name(&v, &OS, &ARCH, crate::build_time::TARGET);
         // Always set release_tag to ensure we download the correct release
         // (fixes semver mismatch across year boundaries, e.g. 2025.x -> 2026.x)
         update.release_tag(&v);
-        #[cfg(windows)]
-        let target = format!("mise-{v}-{target}.zip");
-        #[cfg(not(windows))]
-        let target = format!("mise-{v}-{target}.tar.gz");
         let status = update
             .verifying_keys([*include_bytes!("../../zipsign.pub")])
             .show_download_progress(true)
             .target(&target)
+            .asset_matcher(move |assets| release_archive_asset(assets, &target))
             .no_confirm(settings.is_ok_and(|s| s.yes) || self.yes)
             .build()?
             .update()?;
@@ -743,6 +766,128 @@ impl SelfUpdate {
 
         debug!("macOS binary signature verified successfully");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod release_asset_tests {
+    use super::*;
+    use self_update::update::Release;
+
+    #[test]
+    fn archive_names_match_release_platforms() {
+        for (os, arch, build_target, platform) in [
+            (
+                "linux",
+                "arm",
+                "armv7-unknown-linux-gnueabihf",
+                "linux-armv7.tar.gz",
+            ),
+            (
+                "linux",
+                "arm",
+                "armv7-unknown-linux-musleabi",
+                "linux-armv7-musl.tar.gz",
+            ),
+            (
+                "linux",
+                "arm",
+                "arm-unknown-linux-gnueabi",
+                "linux-arm.tar.gz",
+            ),
+            (
+                "linux",
+                "arm64",
+                "aarch64-unknown-linux-gnu",
+                "linux-arm64.tar.gz",
+            ),
+            (
+                "linux",
+                "arm64",
+                "aarch64-unknown-linux-musl",
+                "linux-arm64-musl.tar.gz",
+            ),
+            (
+                "linux",
+                "x64",
+                "x86_64-unknown-linux-gnu",
+                "linux-x64.tar.gz",
+            ),
+            (
+                "linux",
+                "x64",
+                "x86_64-unknown-linux-musl",
+                "linux-x64-musl.tar.gz",
+            ),
+            (
+                "macos",
+                "arm64",
+                "aarch64-apple-darwin",
+                "macos-arm64.tar.gz",
+            ),
+            ("macos", "x64", "x86_64-apple-darwin", "macos-x64.tar.gz"),
+            (
+                "windows",
+                "arm64",
+                "aarch64-pc-windows-msvc",
+                "windows-arm64.zip",
+            ),
+            (
+                "windows",
+                "x64",
+                "x86_64-pc-windows-msvc",
+                "windows-x64.zip",
+            ),
+        ] {
+            assert_eq!(
+                release_archive_name("v2026.9.3", os, arch, build_target),
+                format!("mise-v2026.9.3-{platform}"),
+                "{build_target}",
+            );
+        }
+    }
+
+    fn release_with_assets(names: &[&str]) -> Release {
+        Release::builder()
+            .version("2026.9.3")
+            .assets(names.iter().map(|name| ReleaseAsset::new(*name, "")))
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn armv7_selects_its_archive_with_arm64_and_raw_binaries_present() {
+        let release = release_with_assets(&[
+            "mise-v2026.9.3-linux-arm64",
+            "mise-v2026.9.3-linux-arm64.tar.gz",
+            "mise-v2026.9.3-linux-armv7",
+            "mise-v2026.9.3-linux-armv7-musl.tar.gz",
+            "mise-v2026.9.3-linux-armv7.tar.gz",
+        ]);
+        for build_target in [
+            "armv7-unknown-linux-gnueabihf",
+            "armv7-unknown-linux-musleabi",
+        ] {
+            let name = release_archive_name("v2026.9.3", "linux", "arm", build_target);
+            let asset = release_archive_asset(release.assets(), &name).unwrap();
+            assert_eq!(asset.name(), name);
+        }
+    }
+
+    #[test]
+    fn missing_archive_does_not_fall_back_to_other_assets() {
+        let release = release_with_assets(&[
+            "mise-v2026.9.3-linux-arm64",
+            "mise-v2026.9.3-linux-arm64.tar.gz",
+            "mise-v2026.9.3-linux-armv7",
+            "mise-v2026.9.3-linux-armv7-musl.tar.gz",
+            "mise-v2026.9.3-linux-armv7.tar.xz",
+            "mise-v2026.9.3-linux-armv7.tar.gz.sig",
+            "mise-v2026.9.2-linux-armv7.tar.gz",
+        ]);
+        let name =
+            release_archive_name("v2026.9.3", "linux", "arm", "armv7-unknown-linux-gnueabihf");
+        assert!(release_archive_asset(release.assets(), &name).is_none());
     }
 }
 


### PR DESCRIPTION
On ARMv7, `mise self-update` requests a `linux-arm` archive even though releases publish `linux-armv7`. When that archive is missing, the update library's fallback can select the raw ARM64 binary, which then fails signature verification with `Plain(None)`.

Derive the ARM variant from the compiled target triple and require an exact archive filename match. Missing archives now fail asset selection instead of falling back to another architecture, libc, raw binary, or signature file. Signature verification remains enabled. Unsupported ARM variants retain their own target name rather than being mapped to ARMv7.

Related discussion: https://github.com/jdx/mise/discussions/13021

Validation:
- Regression coverage for ARMv7 GNU/musl selection with ARM64 and raw assets present, missing-archive rejection, and release names across the supported platforms.
- `mise run test:unit --bin mise cli::self_update:: --locked` — 9 passed.
- `mise run lint-fix` — passed, including `cargo check --all-features`.
- `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings` — passed via mise/mbx.
- Tests run on Linux x64 with explicit ARM target fixtures; no ARM hardware run.

Existing affected binaries will need a manual update to a release containing this fix.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which release binary self-update downloads and fails closed when the exact archive is missing, which is correct but could block updates on misnamed or incomplete releases.
> 
> **Overview**
> **Fixes `mise self-update` picking the wrong GitHub release asset on 32-bit ARM**, especially ARMv7 builds that previously asked for a `linux-arm` archive while releases ship `linux-armv7`.
> 
> Self-update now builds the download filename with **`release_archive_name`**, using the compile-time target triple (`build_time::TARGET`) to map Rust’s generic `arm` label to **`armv7`** (or keep other ARM variants), append **`-musl`** when appropriate, and choose **`.zip` / `.tar.gz`**. A custom **`asset_matcher`** via **`release_archive_asset`** requires an **exact** asset name match so the updater no longer falls back to ARM64 raw binaries, wrong libc, or signature sidecars when the intended archive is missing.
> 
> Adds **unit tests** for platform archive names, ARMv7 selection when other assets exist, and rejection when the expected archive is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4544eabb1fc65705344480a1e1a3cc5f6b54bd0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-update package selection for ARM variants and musl-based systems.
  * Ensured updates use the correct archive format for each operating system.
  * Prevented downloads from selecting similarly named binaries or packages for other architectures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->