### PR TITLE
registry: add basecamp

### DIFF
--- a/registry/basecamp.toml
+++ b/registry/basecamp.toml
@@ -1,0 +1,5 @@
+backends = ["github:basecamp/basecamp-cli"]
+bins = ["basecamp"]
+description = "Official command-line interface for Basecamp"
+test = { cmd = "basecamp --version", expected = "basecamp version {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
Add `basecamp` as a shorthand for `github:basecamp/basecamp-cli`, so users and Omarchy can select the official Basecamp CLI with `mise use basecamp`. Include the `basecamp` binary metadata for lazy shims and a version smoke test.

Cursor Agent and Muse already have registry entries, so this change only adds Basecamp. Upstream publishes GitHub release archives; no packslip asset or Aqua registry entry was found.

## Popularity

- [GitHub](https://github.com/basecamp/basecamp-cli): 270 stars and 22 forks, checked 2026-09-09.
- Latest release: [v0.10.0](https://github.com/basecamp/basecamp-cli/releases/tag/v0.10.0), published 2026-09-03; latest repository push 2026-09-09.
- Used by [Omarchy's default tool setup](https://github.com/omacom/omarchy/blob/5ead870507dfb68db696b3ddb948cc3d178e8d62/install/user/mise.sh#L22).
- This is below the usual registry popularity threshold; the addition was explicitly requested by @jdx for Omarchy integration.

## Validation

- `mise ls-remote github:basecamp/basecamp-cli` returned 17 versions through 0.10.0.
- `mise x github:basecamp/basecamp-cli@0.10.0 -- basecamp --version` installed the Linux x64 release, verified its GitHub artifact attestation, and printed `basecamp version 0.10.0`.
- File-scoped hk formatting and schema checks passed.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only registry addition with no runtime or security-sensitive code changes.
> 
> **Overview**
> Adds a new **mise registry entry** so users can install the official Basecamp CLI with `mise use basecamp` instead of the full `github:basecamp/basecamp-cli` backend path.
> 
> The entry wires the GitHub release backend, exposes the `basecamp` binary for shims, uses **semver** version ordering, and defines a post-install smoke test that runs `basecamp --version` and expects `basecamp version {{version}}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d9c0dbee5f7d9ceb308a95127f87cbe3f677295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Basecamp CLI registry support, including its binary name, description, version detection, and semantic-version ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->