### PR TITLE
ci: use the active mise binary in the nix docker test

### DIFF
--- a/e2e/cli/test_system_nix_docker_slow
+++ b/e2e/cli/test_system_nix_docker_slow
@@ -14,6 +14,7 @@ container=$(docker create "$image")
 # The Docker daemon may run outside the checkout's filesystem namespace.
 # Copy the binary rather than relying on a host bind mount.
 trap 'docker rm --force "$container" >/dev/null' EXIT
-docker cp "$ROOT/target/debug/mise" "$container:/input/mise"
+# Release CI runs the packaged binary from PATH without a local debug build.
+docker cp "$(command -v mise)" "$container:/input/mise"
 docker start --attach "$container"
 test "$(docker wait "$container")" = 0


### PR DESCRIPTION
The release PR installs the packaged mise binary on PATH without creating `target/debug/mise`. The Nix Docker test hardcodes that debug path, so `docker cp` fails before the fixture can run.

Copy the binary returned by `command -v mise` so the fixture uses the same binary as the surrounding e2e tests.

Validation: reproduced the missing-target failure before the change, then passed `mise run --skip-deps test:e2e e2e/cli/test_system_nix_docker_slow` using the 2026.9.4 tarball from release PR #12978 (run 34382023300), installed under a temporary `CARGO_TARGET_DIR`. Scoped hk checks/fixes passed shellcheck and shfmt.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to how the fixture copies the mise binary; no production code or runtime behavior changes.
> 
> **Overview**
> Fixes the **Nix Docker slow e2e** so it no longer assumes a local **`target/debug/mise`** build exists.
> 
> The test now **`docker cp`s** the same **`mise`** on **`PATH`** (`command -v mise`), matching **release CI** and other e2e tests that use the packaged binary instead of a debug artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32760e0c3aec93ccff258c3e8c27af7f087ec5bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Nix Docker integration test to use the `mise` executable available on the system path.
  * Improved compatibility with release CI environments where a local debug build is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->