### PR TITLE
chore: release 2026.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## [2026.9.5](https://github.com/jdx/mise/compare/v2026.9.4..v2026.9.5) - 2026-09-10
+
+### 🚀 Features
+
+- **(bootstrap)** support current-host macOS defaults by @azohra in [#12983](https://github.com/jdx/mise/pull/12983)
+- **(bootstrap)** extend friendly macos preferences by @jdx in [#13032](https://github.com/jdx/mise/pull/13032)
+- **(bootstrap)** patch nested macOS preference values by @azohra in [#12984](https://github.com/jdx/mise/pull/12984)
+- **(bootstrap)** support pre-packages file phases by @jdx in [#13052](https://github.com/jdx/mise/pull/13052)
+- **(brew-cask)** support structured set_permissions flight steps by @azohra in [#13043](https://github.com/jdx/mise/pull/13043)
+- **(dotfiles)** support platform-specific destination variants by @jdx in [#13050](https://github.com/jdx/mise/pull/13050)
+- **(lock)** trial complete lockfile generation by @jdx in [#13031](https://github.com/jdx/mise/pull/13031)
+- **(task)** support usage variables in sources and outputs by @jdx in [#13051](https://github.com/jdx/mise/pull/13051)
+
+### 🐛 Bug Fixes
+
+- **(bootstrap)** detect the origin default branch when connecting dotfiles by @Dhaulagiri in [#13037](https://github.com/jdx/mise/pull/13037)
+- **(bootstrap)** render vars in file templates by @nettlesh in [#13033](https://github.com/jdx/mise/pull/13033)
+- **(brew-cask)** drop stale brew advice from the cask metadata error by @Marukome0743 in [#12800](https://github.com/jdx/mise/pull/12800)
+- **(brew-cask)** leave a running self-updating app to update itself by @azohra in [#13041](https://github.com/jdx/mise/pull/13041)
+- **(dotfiles)** keep history locks independent of cache directories by @ascarter in [#13038](https://github.com/jdx/mise/pull/13038)
+- **(install)** summarize interactive progress without duplicate rows by @jdx in [#13030](https://github.com/jdx/mise/pull/13030)
+- **(install)** reduce progress output for long CI installs by @jdx in [#13036](https://github.com/jdx/mise/pull/13036)
+- **(sandbox)** allow metadata on ancestors of readable paths by @Marukome0743 in [#13039](https://github.com/jdx/mise/pull/13039)
+- **(self-update)** select the correct armv7 release archive by @jdx in [#13023](https://github.com/jdx/mise/pull/13023)
+- **(self-update)** correct npm update guidance and allow silencing warnings by @jdx in [#13028](https://github.com/jdx/mise/pull/13028)
+
+### 📦 Registry
+
+- add clipboard ([github:Slackadays/Clipboard](https://github.com/Slackadays/Clipboard)) by @i-api in [#13044](https://github.com/jdx/mise/pull/13044)
+
+### Ci
+
+- use the active mise binary in the nix docker test by @jdx in [#13026](https://github.com/jdx/mise/pull/13026)
+
+### New Contributors
+
+- @Dhaulagiri made their first contribution in [#13037](https://github.com/jdx/mise/pull/13037)
+
+### 📦 Aqua Registry Updates
+
+#### New Packages (9)
+
+- [`Jamf-Concepts/Notifier`](https://github.com/Jamf-Concepts/Notifier)
+- [`aubepkg/aube`](https://github.com/aubepkg/aube)
+- [`esengine/DeepSeek-Reasonix`](https://github.com/esengine/DeepSeek-Reasonix)
+- [`nklmilojevic/sofka`](https://github.com/nklmilojevic/sofka)
+- [`openai/tunnel-client`](https://github.com/openai/tunnel-client)
+- [`unikraft-cloud/cli`](https://github.com/unikraft-cloud/cli)
+- [`unikraft/kraftkit`](https://github.com/unikraft/kraftkit)
+- [`yadm-dev/yadm`](https://github.com/yadm-dev/yadm)
+- [`yarnpkg/zpm`](https://github.com/yarnpkg/zpm)
+
+#### Updated Packages (5)
+
+- [`Byron/dua-cli`](https://github.com/Byron/dua-cli)
+- [`editorconfig-checker/editorconfig-checker`](https://github.com/editorconfig-checker/editorconfig-checker)
+- [`gopasspw/gopass`](https://github.com/gopasspw/gopass)
+- [`masasuzu/clrnd`](https://github.com/masasuzu/clrnd)
+- [`pnpm/pnpm`](https://github.com/pnpm/pnpm)
+
 ## [2026.9.4](https://github.com/jdx/mise/compare/v2026.9.3..v2026.9.4) - 2026-09-09
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6495,7 +6495,7 @@ dependencies = [
 
 [[package]]
 name = "mise"
-version = "2026.9.4"
+version = "2026.9.5"
 dependencies = [
  "age 0.12.1",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "mise"
-version = "2026.9.4"
+version = "2026.9.5"
 edition = "2024"
 description = "Dev tools, env vars, and tasks in one CLI"
 authors = ["Jeff Dickey (@jdx)"]

--- a/crates/vfox/embedded-plugins/vfox-neovim/hooks/pre_install.lua
+++ b/crates/vfox/embedded-plugins/vfox-neovim/hooks/pre_install.lua
@@ -9,6 +9,16 @@ function PLUGIN:PreInstall(ctx)
     local os_type = RUNTIME.osType
     local arch_type = RUNTIME.archType
 
+    if arch_type ~= "amd64" and arch_type ~= "arm64" then
+        error(
+            "Unsupported platform: "
+                .. os_type
+                .. "/"
+                .. arch_type
+                .. "; Neovim publishes binaries only for amd64 and arm64"
+        )
+    end
+
     -- Map OS/arch to Neovim asset naming
     local platform, ext
 

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "mise";
-  version = "2026.9.4";
+  version = "2026.9.5";
 
   src = lib.cleanSource ./.;
 

--- a/docs/.vitepress/stars.data.ts
+++ b/docs/.vitepress/stars.data.ts
@@ -3,7 +3,7 @@
 export default {
   load() {
     return {
-      stars: "33.7k",
+      stars: "33.8k",
     };
   },
 };

--- a/mise.lock
+++ b/mise.lock
@@ -125,12 +125,14 @@ checksum = "sha256:561a16c933188ef14955989cf99bb368748df5a3903c4cf12d2b05c31d8f4
 url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-aarch64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553098701"
 provenance = "github-attestations"
+signer = "sigstore-oidc:https://github.com/aubepkg/aube/.github/workflows/release-plz.yml"
 
 [tools.aube."platforms.linux-arm64-musl"]
 checksum = "sha256:ad9fb86ad219ada9abc1c7907952505c540c41b5c8e0ffca828e8a2cd2017b11"
 url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-aarch64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553072698"
 provenance = "github-attestations"
+signer = "sigstore-oidc:https://github.com/aubepkg/aube/.github/workflows/release-plz.yml"
 
 [tools.aube."platforms.linux-x64"]
 checksum = "sha256:0b0e734d5fe6e90a286229136d1e97e217b1836e297408cbf9d07cd020cfb4c2"
@@ -138,24 +140,28 @@ url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x8
 url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553074742"
 provenance = "github-attestations"
 provenance_verified = true
+signer = "sigstore-oidc:https://github.com/aubepkg/aube/.github/workflows/release-plz.yml"
 
 [tools.aube."platforms.linux-x64-baseline"]
 checksum = "sha256:0b0e734d5fe6e90a286229136d1e97e217b1836e297408cbf9d07cd020cfb4c2"
 url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553074742"
 provenance = "github-attestations"
+signer = "sigstore-oidc:https://github.com/aubepkg/aube/.github/workflows/release-plz.yml"
 
 [tools.aube."platforms.linux-x64-musl"]
 checksum = "sha256:894bb4991b2cb8054b562dd85682d7e7f21e4479ace26c8f13d4aa362dec0b63"
 url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553073513"
 provenance = "github-attestations"
+signer = "sigstore-oidc:https://github.com/aubepkg/aube/.github/workflows/release-plz.yml"
 
 [tools.aube."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:894bb4991b2cb8054b562dd85682d7e7f21e4479ace26c8f13d4aa362dec0b63"
 url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553073513"
 provenance = "github-attestations"
+signer = "sigstore-oidc:https://github.com/aubepkg/aube/.github/workflows/release-plz.yml"
 
 [tools.aube."platforms.macos-arm64"]
 checksum = "sha256:f999226cddee14afc8d0d2d461191888b65064262e66e83ce1fc8e9069792c1e"
@@ -163,18 +169,21 @@ url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-aa
 url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553104973"
 provenance = "github-attestations"
 provenance_verified = true
+signer = "sigstore-oidc:https://github.com/aubepkg/aube/.github/workflows/release-plz.yml"
 
 [tools.aube."platforms.windows-x64"]
 checksum = "sha256:84b052e0233b37b875af71487a342f6c170da7827ea57ab36ff29102801d56ac"
 url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553097930"
 provenance = "github-attestations"
+signer = "sigstore-oidc:https://github.com/aubepkg/aube/.github/workflows/release-plz.yml"
 
 [tools.aube."platforms.windows-x64-baseline"]
 checksum = "sha256:84b052e0233b37b875af71487a342f6c170da7827ea57ab36ff29102801d56ac"
 url = "https://github.com/aubepkg/aube/releases/download/v2.2.13/aube-v2.2.13-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/aubepkg/aube/releases/assets/553097930"
 provenance = "github-attestations"
+signer = "sigstore-oidc:https://github.com/aubepkg/aube/.github/workflows/release-plz.yml"
 
 [[tools.bun]]
 version = "1.4.2"

--- a/packaging/rpm/mise.spec
+++ b/packaging/rpm/mise.spec
@@ -1,6 +1,6 @@
 Summary: Dev tools, env vars, and tasks in one CLI
 Name: mise
-Version: 2026.9.4
+Version: 2026.9.5
 Release: 1
 URL: https://github.com/jdx/mise/
 Group: System

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@
 
 name: mise
 title: mise-en-place
-version: "2026.9.4"
+version: "2026.9.5"
 summary: Dev tools, env vars, and tasks in one CLI
 description: |
   mise-en-place prepares your development environment before each command runs.

--- a/vendor/aqua-registry/metadata.json
+++ b/vendor/aqua-registry/metadata.json
@@ -1,4 +1,4 @@
 {
   "repository": "aquaproj/aqua-registry",
-  "tag": "85b9f0cee7c3274257a594dbb0a552a586be382e"
+  "tag": "052dea10c705278164eeef72e1725fef67b07615"
 }

--- a/vendor/aqua-registry/registry.yml
+++ b/vendor/aqua-registry/registry.yml
@@ -1625,6 +1625,7 @@ packages:
     repo_owner: Byron
     repo_name: dua-cli
     description: View disk space usage and delete unwanted data, fast
+    version_filter: not (Version startsWith "dua-core-")
     files:
       - name: dua
     version_constraint: "false"
@@ -4751,6 +4752,30 @@ packages:
           algorithm: md5
         supported_envs:
           - linux
+          - darwin
+  - type: github_release
+    repo_owner: Jamf-Concepts
+    repo_name: Notifier
+    aliases:
+      - name: jamf/Notifier
+    description: Swift project which can post macOS alert or banner notifications on 10.15+ clients
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.3.0")
+        asset: dataJAR-Notifier-{{.Version}}.{{.Format}}
+        format: pkg
+        files:
+          - name: Notifier
+            src: Payload/Applications/Utilities/Notifier.app/Contents/MacOS/Notifier
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: Notifier-{{.Version}}.{{.Format}}
+        format: pkg
+        files:
+          - name: Notifier
+            src: Payload/Applications/Utilities/Notifier.app/Contents/MacOS/Notifier
+        supported_envs:
           - darwin
   - type: github_release
     repo_owner: JanDeDobbeleer
@@ -17184,6 +17209,157 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
+  - type: github_release
+    repo_owner: aubepkg
+    repo_name: aube
+    aliases:
+      - name: endevco/aube
+      - name: jdx/aube
+    description: A fast Node.js package manager
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.0.0-beta.1"
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux/amd64
+          - darwin
+          - windows
+      - version_constraint: semver("<= 1.0.0-beta.11")
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: semver("<= 1.1.0")
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: semver("<= 2.2.4")
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: semver("<= 2.2.8")
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            variants:
+              - key: libc
+                value: glibc
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+        github_artifact_attestations:
+          signer_workflow: aubepkg/aube/.github/workflows/release.yml
+      - version_constraint: "true"
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            variants:
+              - key: libc
+                value: musl
+            replacements:
+              linux: unknown-linux-musl
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+        github_artifact_attestations:
+          signer_workflow: aubepkg/aube/.github/workflows/release.yml
   - type: github_release
     repo_owner: aurc
     repo_name: loggo
@@ -36461,7 +36637,7 @@ packages:
         overrides:
           - goos: windows
             asset: ec-{{.OS}}-{{.Arch}}.exe.{{.Format}}
-      - version_constraint: "true"
+      - version_constraint: semver("< 4.0.0")
         asset: ec-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -36472,6 +36648,20 @@ packages:
           asset: checksums.txt
           algorithm: sha256
         overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: editorconfig-checker-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: editorconfig-checker
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: editorconfig-checker-{{.OS}}-all.{{.Format}}
           - goos: windows
             format: zip
   - type: github_release
@@ -37418,6 +37608,27 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+  - type: github_release
+    repo_owner: esengine
+    repo_name: DeepSeek-Reasonix
+    description: DeepSeek-native AI coding agent for the terminal
+    version_filter: Version startsWith "v"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 1.0.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: reasonix-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: reasonix
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
   - type: github_release
     repo_owner: estesp
     repo_name: manifest-tool
@@ -45919,13 +46130,33 @@ packages:
     description: The slightly more awesome standard unix password manager for teams
     asset: gopass-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
     format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    checksum:
-      type: github_release
-      asset: gopass_{{trimV .Version}}_SHA256SUMS
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.16.1")
+        checksum:
+          type: github_release
+          asset: gopass_{{trimV .Version}}_SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        checksum:
+          type: github_release
+          asset: gopass_{{trimV .Version}}_SHA256SUMS
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: "gopass_{{trimV .Version}}_SHA256SUMS.sigstore.json"
+            opts:
+              - --certificate-identity
+              - https://github.com/gopasspw/gopass/.github/workflows/autorelease.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: goph
     repo_name: licensei
@@ -52538,28 +52769,6 @@ packages:
     path: desk
     description: A lightweight workspace manager for the shell
   - type: github_release
-    repo_owner: jamf
-    repo_name: Notifier
-    description: Swift project which can post macOS alert or banner notifications on 10.15+ clients
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 2.3.0")
-        asset: dataJAR-Notifier-{{.Version}}.{{.Format}}
-        format: pkg
-        files:
-          - name: Notifier
-            src: Payload/Applications/Utilities/Notifier.app/Contents/MacOS/Notifier
-        supported_envs:
-          - darwin
-      - version_constraint: "true"
-        asset: Notifier-{{.Version}}.{{.Format}}
-        format: pkg
-        files:
-          - name: Notifier
-            src: Payload/Applications/Utilities/Notifier.app/Contents/MacOS/Notifier
-        supported_envs:
-          - darwin
-  - type: github_release
     repo_owner: jamietsao
     repo_name: random-winner
     description: Wrote a silly program to select a random winner from my team
@@ -52619,128 +52828,6 @@ packages:
       type: github_release
       asset: terradozer_{{trimV .Version}}_checksums.txt
       algorithm: sha256
-  - type: github_release
-    repo_owner: jdx
-    repo_name: aube
-    aliases:
-      - name: endevco/aube
-    description: A fast Node.js package manager
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: Version == "v1.0.0-beta.1"
-        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - linux/amd64
-          - darwin
-          - windows
-      - version_constraint: semver("<= 1.0.0-beta.11")
-        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: darwin
-            replacements:
-              amd64: amd64
-          - goos: windows
-            format: zip
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows
-      - version_constraint: semver("<= 1.1.0")
-        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: darwin
-            replacements:
-              amd64: amd64
-          - goos: windows
-            format: zip
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows
-      - version_constraint: semver("<= 1.18.1")
-        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            variants:
-              - key: libc
-                value: glibc
-          - goos: linux
-            replacements:
-              linux: unknown-linux-musl
-            variants:
-              - key: libc
-                value: musl
-          - goos: darwin
-            replacements:
-              amd64: amd64
-          - goos: windows
-            format: zip
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows
-      - version_constraint: "true"
-        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            variants:
-              - key: libc
-                value: glibc
-          - goos: linux
-            replacements:
-              linux: unknown-linux-musl
-            variants:
-              - key: libc
-                value: musl
-          - goos: darwin
-            replacements:
-              amd64: amd64
-          - goos: windows
-            format: zip
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows
-        github_artifact_attestations:
-          signer_workflow: jdx/aube/.github/workflows/release.yml
   - type: github_release
     repo_owner: jdx
     repo_name: fnox
@@ -64733,6 +64820,16 @@ packages:
     version_overrides:
       - version_constraint: Version == "v0.1.0"
         no_asset: true
+      - version_constraint: semver("<= 0.2.0")
+        asset: clrnd_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: clrnd_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -64740,6 +64837,15 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.bundle
+            opts:
+              - --certificate-identity
+              - https://github.com/masasuzu/clrnd/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip
@@ -71083,6 +71189,49 @@ packages:
           asset: SHA256SUMS.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: nklmilojevic
+    repo_name: sofka
+    description: "A Kubernetes TUI, reimagined in Rust - built on kube-rs and ratatui, async-first from the ground up"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.13.4"
+        asset: sofka-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.23.0")
+        asset: sofka-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: sofka-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: nmstate
     repo_name: nmstate
     description: Nmstate is a library with an accompanying command line tool that manages host networking settings in a declarative manner
@@ -72786,6 +72935,21 @@ packages:
       algorithm: sha256
     supported_envs:
       - darwin
+  - type: github_release
+    repo_owner: openai
+    repo_name: tunnel-client
+    description: "Customer-run client for Secure MCP Tunnel: connect private or localhost MCP servers to ChatGPT, Codex, the Responses API, and AgentKit without exposing them to the public internet"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.6--context-conduit-saphire"
+        no_asset: true
+      - version_constraint: "true"
+        asset: tunnel-client-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: SHA256SUMS.txt
+          algorithm: sha256
   - name: openbao/openbao/bao
     type: github_release
     repo_owner: openbao
@@ -77135,7 +77299,7 @@ packages:
           - linux
           - windows
           - darwin/arm64
-      - version_constraint: "true"
+      - version_constraint: semver("< 12.0.0")
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -77172,6 +77336,43 @@ packages:
           - linux
           - windows
           - darwin/arm64
+      - version_constraint: "true"
+        asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: pnpm
+          - name: pn
+            src: pnpm
+            link: pn
+          - name: pnpx
+            src: pnpm
+            link: pnpx
+            hard: true
+          - name: pnx
+            src: pnpm
+            link: pnx
+            hard: true
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: pnpm/pnpm/.github/workflows/release.yml
+        supported_envs:
+          - linux
+          - windows
+          - darwin
   - type: github_release
     repo_owner: po3rin
     repo_name: github_link_creator
@@ -98695,6 +98896,65 @@ packages:
             format: raw
             asset: dug
   - type: github_release
+    repo_owner: unikraft-cloud
+    repo_name: cli
+    description: Command-line interface for Unikraft Cloud
+    version_filter: not (Version contains "-staging.")
+    asset: unikraft-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: unikraft
+    checksum:
+      type: github_release
+      asset: cli_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+    supported_envs:
+      - linux
+      - darwin
+  - type: github_release
+    repo_owner: unikraft
+    repo_name: kraftkit
+    description: Build and use highly customized and ultra-lightweight unikernel VMs
+    version_filter: not (Version matches "-\\d+-g[0-9a-f]+$")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.6.4")
+        asset: kraftkit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: kraft
+        checksum:
+          type: github_release
+          asset: kraftkit_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.7.0")
+        asset: kraftkit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: kraft
+        checksum:
+          type: github_release
+          asset: kraftkit_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: kraft_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: kraft
+          - name: kraftld
+        checksum:
+          type: github_release
+          asset: kraftkit_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: updatecli
     repo_name: updatecli
     description: A Declarative Dependency Management tool
@@ -103205,6 +103465,16 @@ packages:
       - darwin
       - linux
       - amd64
+  - type: github_content
+    repo_owner: yadm-dev
+    repo_name: yadm
+    description: Yet Another Dotfiles Manager
+    path: yadm
+    aliases:
+      - name: TheLocehiliosan/yadm
+    supported_envs:
+      - darwin
+      - linux
   - type: github_release
     repo_owner: yamafaktory
     repo_name: jql
@@ -103459,6 +103729,25 @@ packages:
         files:
           - name: yarn
             src: "{{.AssetWithoutExt}}/bin/yarn"
+  - type: github_release
+    repo_owner: yarnpkg
+    repo_name: zpm
+    description: Safe, stable, reproducible projects
+    files:
+      - name: yarn
+    asset: yarn-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: zip
+    overrides:
+      - goos: linux
+        replacements:
+          amd64: x86_64
+    replacements:
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+    supported_envs:
+      - linux
+      - darwin/arm64
   - type: github_release
     repo_owner: yashikota
     repo_name: exiftool-go


### PR DESCRIPTION
### 🚀 Features

- **(bootstrap)** support current-host macOS defaults by @azohra in [#12983](https://github.com/jdx/mise/pull/12983)
- **(bootstrap)** extend friendly macos preferences by @jdx in [#13032](https://github.com/jdx/mise/pull/13032)
- **(bootstrap)** patch nested macOS preference values by @azohra in [#12984](https://github.com/jdx/mise/pull/12984)
- **(bootstrap)** support pre-packages file phases by @jdx in [#13052](https://github.com/jdx/mise/pull/13052)
- **(brew-cask)** support structured set_permissions flight steps by @azohra in [#13043](https://github.com/jdx/mise/pull/13043)
- **(dotfiles)** support platform-specific destination variants by @jdx in [#13050](https://github.com/jdx/mise/pull/13050)
- **(lock)** trial complete lockfile generation by @jdx in [#13031](https://github.com/jdx/mise/pull/13031)
- **(task)** support usage variables in sources and outputs by @jdx in [#13051](https://github.com/jdx/mise/pull/13051)

### 🐛 Bug Fixes

- **(bootstrap)** detect the origin default branch when connecting dotfiles by @Dhaulagiri in [#13037](https://github.com/jdx/mise/pull/13037)
- **(bootstrap)** render vars in file templates by @nettlesh in [#13033](https://github.com/jdx/mise/pull/13033)
- **(brew-cask)** drop stale brew advice from the cask metadata error by @Marukome0743 in [#12800](https://github.com/jdx/mise/pull/12800)
- **(brew-cask)** leave a running self-updating app to update itself by @azohra in [#13041](https://github.com/jdx/mise/pull/13041)
- **(dotfiles)** keep history locks independent of cache directories by @ascarter in [#13038](https://github.com/jdx/mise/pull/13038)
- **(install)** summarize interactive progress without duplicate rows by @jdx in [#13030](https://github.com/jdx/mise/pull/13030)
- **(install)** reduce progress output for long CI installs by @jdx in [#13036](https://github.com/jdx/mise/pull/13036)
- **(sandbox)** allow metadata on ancestors of readable paths by @Marukome0743 in [#13039](https://github.com/jdx/mise/pull/13039)
- **(self-update)** select the correct armv7 release archive by @jdx in [#13023](https://github.com/jdx/mise/pull/13023)
- **(self-update)** correct npm update guidance and allow silencing warnings by @jdx in [#13028](https://github.com/jdx/mise/pull/13028)

### 📦 Registry

- add clipboard ([github:Slackadays/Clipboard](https://github.com/Slackadays/Clipboard)) by @i-api in [#13044](https://github.com/jdx/mise/pull/13044)

### Ci

- use the active mise binary in the nix docker test by @jdx in [#13026](https://github.com/jdx/mise/pull/13026)

### New Contributors

- @Dhaulagiri made their first contribution in [#13037](https://github.com/jdx/mise/pull/13037)

## 📦 Aqua Registry Updates

### New Packages (9)

- [`Jamf-Concepts/Notifier`](https://github.com/Jamf-Concepts/Notifier)
- [`aubepkg/aube`](https://github.com/aubepkg/aube)
- [`esengine/DeepSeek-Reasonix`](https://github.com/esengine/DeepSeek-Reasonix)
- [`nklmilojevic/sofka`](https://github.com/nklmilojevic/sofka)
- [`openai/tunnel-client`](https://github.com/openai/tunnel-client)
- [`unikraft-cloud/cli`](https://github.com/unikraft-cloud/cli)
- [`unikraft/kraftkit`](https://github.com/unikraft/kraftkit)
- [`yadm-dev/yadm`](https://github.com/yadm-dev/yadm)
- [`yarnpkg/zpm`](https://github.com/yarnpkg/zpm)

### Updated Packages (5)

- [`Byron/dua-cli`](https://github.com/Byron/dua-cli)
- [`editorconfig-checker/editorconfig-checker`](https://github.com/editorconfig-checker/editorconfig-checker)
- [`gopasspw/gopass`](https://github.com/gopasspw/gopass)
- [`masasuzu/clrnd`](https://github.com/masasuzu/clrnd)
- [`pnpm/pnpm`](https://github.com/pnpm/pnpm)