### PR TITLE
fix(self-update): correct npm update guidance and allow silencing warnings

### DIFF
--- a/e2e/cli/test_version_update_hint
+++ b/e2e/cli/test_version_update_hint
@@ -26,3 +26,38 @@ assert_not_contains 'MISE_SELF_UPDATE_AVAILABLE=false MISE_SELF_UPDATE_INSTRUCTI
 # self-update available → unchanged advice
 assert_contains 'MISE_SELF_UPDATE_AVAILABLE=true mise version 2>&1' 'mise self-update'
 assert_not_contains 'MISE_SELF_UPDATE_AVAILABLE=true mise version 2>&1' 'self-update is disabled for this install'
+
+# Suppression is independent of self-update availability and packager instructions.
+export MISE_DISABLE_UPDATE_WARNING=true
+assert_not_contains 'MISE_SELF_UPDATE_AVAILABLE=true mise version 2>&1' 'mise WARN'
+assert_not_contains 'MISE_SELF_UPDATE_AVAILABLE=false MISE_SELF_UPDATE_INSTRUCTIONS=./instructions.toml mise --version 2>&1' 'mise WARN'
+assert_contains 'mise version --json' '9999.0.0'
+unset MISE_DISABLE_UPDATE_WARNING
+
+# The setting also works in configuration and both doctor output formats.
+cat >mise.toml <<'TOML'
+[settings]
+disable_update_warning = true
+TOML
+mise trust
+assert_not_contains 'mise version 2>&1' 'mise WARN'
+eval "$(mise activate bash)"
+assert_not_contains 'mise doctor 2>&1' '9999.0.0 available'
+assert_succeed "set -o pipefail; mise doctor --json | jq -e '(.warnings // []) | map(contains(\"9999.0.0 available\")) | any | not'"
+assert_contains 'MISE_DISABLE_UPDATE_WARNING=false mise version 2>&1' '9999.0.0 available'
+
+# Suppressing warnings still permits an explicit self-update. Requesting the
+# current version takes the up-to-date path without downloading anything.
+version="$(mise version | tail -n1 | awk '{print $1}' | sed 's/-DEBUG$//')"
+assert_contains "MISE_SELF_UPDATE_AVAILABLE=true mise self-update $version --no-plugins 2>&1" 'mise is already up to date'
+
+# A package-local instructions file is found next to the actual binary, even
+# when launched through a symlink like node_modules/.bin/mise.
+mkdir -p package/bin package/lib node_modules/.bin
+cp "$(type -P mise)" package/bin/mise
+cat >package/lib/mise-self-update-instructions.toml <<'TOML'
+message = "Update mise using the package manager that installed it (npm, pnpm, or yarn)."
+TOML
+ln -s "$PWD/package/bin/mise" node_modules/.bin/mise
+assert_contains 'MISE_DISABLE_UPDATE_WARNING=false node_modules/.bin/mise version 2>&1' 'npm, pnpm, or yarn'
+assert_fail 'node_modules/.bin/mise self-update --no-plugins' 'npm, pnpm, or yarn'

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -771,6 +771,11 @@
             "type": "string"
           }
         },
+        "disable_update_warning": {
+          "default": false,
+          "description": "Suppress warnings when a newer mise version is available.",
+          "type": "boolean"
+        },
         "dotfiles": {
           "type": "object",
           "unevaluatedProperties": false,

--- a/scripts/release-npm.sh
+++ b/scripts/release-npm.sh
@@ -6,6 +6,13 @@ error() {
 	exit 1
 }
 
+write_update_instructions() {
+	mkdir -p "$RELEASE_DIR/npm/lib"
+	cat >"$RELEASE_DIR/npm/lib/mise-self-update-instructions.toml" <<'EOF'
+message = "Update mise using the package manager that installed it (npm, pnpm, or yarn)."
+EOF
+}
+
 mkdir -p "$RELEASE_DIR/npm"
 
 NPM_PLATFORM_PREFIX="${NPM_PLATFORM_PREFIX:-$NPM_PREFIX}"
@@ -41,6 +48,7 @@ if [ "$PUBLISH_PLATFORM_PACKAGES" != "0" ]; then
 		tar -xzvf "$RELEASE_DIR/mise-latest-$platform.tar.gz" -C "$RELEASE_DIR"
 		rm -rf "$RELEASE_DIR/npm"
 		mv "$RELEASE_DIR/mise" "$RELEASE_DIR/npm"
+		write_update_instructions
 		cat <<EOF >"$RELEASE_DIR/npm/package.json"
 {
   "name": "$NPM_PLATFORM_PREFIX-$os-$arch",
@@ -55,6 +63,7 @@ if [ "$PUBLISH_PLATFORM_PACKAGES" != "0" ]; then
   },
   "files": [
     "bin",
+    "lib",
     "README.md"
   ],
   "license": "MIT",
@@ -87,6 +96,9 @@ else
 fi
 
 cp README.md "$RELEASE_DIR/npm/README.md"
+# The installer hard-links the binary into the wrapper package, so both the
+# wrapper and platform packages need instructions relative to their own prefix.
+write_update_instructions
 
 cat <<EOF >"$RELEASE_DIR/npm/installArchSpecificPackage.js"
 var spawn = require('child_process').spawn;
@@ -159,6 +171,7 @@ cat <<EOF >"$RELEASE_DIR/npm/package.json"
   },
   "files": [
     "installArchSpecificPackage.js",
+    "lib",
     "README.md"
   ],
   "scripts": {

--- a/settings.toml
+++ b/settings.toml
@@ -559,6 +559,17 @@ parse_env = "set_by_comma"
 rust_type = "BTreeSet<String>"
 type = "SetString"
 
+[disable_update_warning]
+default = false
+description = "Suppress warnings when a newer mise version is available."
+docs = """
+Disables mise update notices in `mise version`, `mise --version`, and `mise doctor`.
+Other warnings are unaffected. This does not disable `mise self-update` or automatic updates
+enabled with [`auto_update`](#auto_update).
+"""
+env = "MISE_DISABLE_UPDATE_WARNING"
+type = "Bool"
+
 [dotfiles.default_mode]
 default = "symlink"
 description = "Default mode for dotfile entries when mode is omitted. Options: `symlink`, `symlink-each`, `copy`, `template`."

--- a/src/cli/doctor/mod.rs
+++ b/src/cli/doctor/mod.rs
@@ -453,6 +453,10 @@ impl Doctor {
     /// The stderr notice is presentation rather than diagnosis, and `-J` is asked for by something
     /// reading the JSON: it gets the warning below instead of a message aimed at a person.
     async fn analyze_new_version(&mut self) {
+        if crate::config::Settings::try_get().is_ok_and(|settings| settings.disable_update_warning)
+        {
+            return;
+        }
         if let Some(latest) = version::check_for_new_version(duration::HOURLY).await {
             if !self.json {
                 version::show_latest().await;

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -222,7 +222,9 @@ fn show_version() -> std::io::Result<()> {
 }
 
 pub(crate) async fn show_latest() {
-    if ci_info::is_ci() && !cfg!(test) {
+    if (ci_info::is_ci() && !cfg!(test))
+        || Settings::try_get().is_ok_and(|settings| settings.disable_update_warning)
+    {
         return;
     }
     if let Some(latest) = check_for_new_version(duration::DAILY).await {


### PR DESCRIPTION
Npm installations currently advertise `mise self-update` because their packages omit the instructions file that disables replacing a package-manager-owned binary. Ship that file in all platform packages and both wrapper packages, including their npm `files` lists; the wrapper needs its own copy because its installer hard-links the executable into its prefix.

Add `disable_update_warning` (also `MISE_DISABLE_UPDATE_WARNING`) to suppress newer-mise notices in version output and both `doctor` formats. Other warnings, explicit self-update, automatic updates, and the latest-version field in `mise version --json` retain their existing behavior.

Addresses https://github.com/jdx/mise/discussions/13019.

Validation:
- `mise run build` and scoped safe hk checks, including `cargo check --all-features`.
- `mise run test:e2e e2e/cli/test_version_update_hint e2e/cli/test_version e2e/cli/test_self_update_plugins_failure` passed. Coverage includes config/environment suppression, doctor text/JSON, explicit self-update, and package instructions discovered through a symlink.
- Exercised the npm release script with fixture archives and a local publish replacement using `npm pack --ignore-scripts`; verified that all five platform tarballs and both wrapper tarballs contain the update instructions. Nothing was published to npm.
- `mise run render:schema` and `git diff --check`.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing messaging and an opt-in quiet setting; npm release packaging adds a small static file with no auth or data-path changes.
> 
> **Overview**
> Fixes **misleading npm update advice** by bundling `lib/mise-self-update-instructions.toml` in every npm platform package and the main wrapper (including `lib` in published `files`), so users see package-manager guidance instead of `mise self-update`.
> 
> Adds **`disable_update_warning`** (`MISE_DISABLE_UPDATE_WARNING` / `settings.disable_update_warning`) to hide “newer mise available” notices in `mise version`, `mise --version`, and `mise doctor` (text and JSON). Other warnings, `mise version --json`’s latest field, explicit `mise self-update`, and auto-update behavior are unchanged.
> 
> E2E coverage expands for env/config suppression, doctor output, self-update when already current, and npm-style instructions resolved via a symlinked binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ed84a4bcf104ecb1b02aed1e4aaf4f893c9e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `disable_update_warning` setting to suppress notifications about newer mise versions.
  * Configure it in `mise.toml` or with `MISE_DISABLE_UPDATE_WARNING=true`.
  * When enabled, update warnings are hidden from `mise version`, `mise --version`, and `mise doctor`.
  * Explicit `mise self-update` commands and automatic updates continue to work normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->