### PR TITLE
fix(install): summarize interactive progress without duplicate rows

### DIFF
--- a/e2e/cli/test_install_tty_progress
+++ b/e2e/cli/test_install_tty_progress
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # An interactive terminal gets the live install region: a header with the
-# install-wide bar, one row per active tool, and the same permanent completion
-# lines the append-only reporter prints. This drives mise through a PTY with CI
+# install-wide bar, one row per active tool, and a final summary naming changed
+# versions. Successful rows disappear. This drives mise through a PTY with CI
 # unset so the animated display is actually chosen.
 export CI=0 MISE_DEBUG=0 MISE_TRACE=0 MISE_LOG_LEVEL=info
 export MISE_FORCE_PROGRESS=0
@@ -70,20 +70,18 @@ for line in plain.splitlines():
     if "0/1" in line and "█" * 24 in line:
         raise AssertionError("bar was full before the install finished:\n" + plain)
 
-# The permanent record matches the append-only reporter: one completion line
-# per tool with its duration, then a summary. The old per-tool "installed"
-# row and the old "[cur/total]" header are gone.
-assert re.search(r"✓ dummy@1\.0\.0\s+\d+(\.\d+)?(ms|s)", plain), plain
+# The summary retains the installed version without a per-tool completion line.
+assert not re.search(r"✓ dummy@1\.0\.0", plain), plain
+assert re.search(r"installed 1 tool in .*: dummy@1\.0\.0", plain), plain
 assert "installed 1 tool in" in plain, plain
 assert "[0/1]" not in plain and "[1/1]" not in plain, plain
 
-# A version that is already installed is reported as such, not as a fresh
-# install. (A bare `mise install` with nothing to do says "all tools are
-# installed" before any reporter exists, so ask for the version explicitly.)
+# Already-installed checks leave no completion rows or progress summary.
 code, raw = run(["mise", "install", "dummy@1.0.0"], env)
 assert code == 0, raw
 plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
-assert "already installed" in plain, plain
+assert "already installed" not in plain, plain
+assert "installed 0 tools" not in plain, plain
 
 # A narrow terminal gets a layout that fits it rather than wrapped lines: the
 # header drops its version and shrinks the bar, rows drop their bar, and the
@@ -92,12 +90,39 @@ assert "already installed" in plain, plain
 code, raw = run(["mise", "install", "--force", "dummy@1.0.0"], env, columns=50)
 assert code == 0, raw
 plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
-assert re.search(r"✓ dummy@1\.0\.0\s+\d+(\.\d+)?(ms|s)", plain), plain
+assert re.search(r"installed 1 tool in .*: dummy@1\.0\.0", plain), plain
 for line in plain.replace("\r", "\n").splitlines():
     assert len(line.rstrip()) <= 50, f"{len(line)} cells at 50 columns: {line!r}\n{plain}"
 assert "█" * 11 not in plain, plain
 # The byline is the last thing the header gives up, and at 50 columns it goes.
 assert "by @jdx" not in plain, plain
+
+# Implicit installation leaves its version summary before the command runs.
+code, raw = run(["mise", "exec", "dummy@1.0.1", "--", "true"], env)
+assert code == 0, raw
+plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
+assert re.search(r"installed 1 tool in .*: dummy@1\.0\.1", plain), plain
+assert "✓ dummy@1.0.1" not in plain, plain
+
+# Failed hooks retain diagnostics and a failure summary, never success rows.
+with open("mise.toml", "w") as config:
+    config.write('[tools]\ndummy = { version = "1.0.2", postinstall = "echo hook-failed >&2; exit 1" }\n')
+code, raw = run(["mise", "install"], env)
+assert code != 0, raw
+plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
+assert "✗ dummy@1.0.2" in plain, plain
+assert "hook-failed" in plain, plain
+assert "1 failed" in plain, plain
+assert "✓ dummy@1.0.2" not in plain, plain
+with open("mise.toml", "w") as config:
+    config.write('[tools]\ndummy = "1.0.0"\n')
+
+# Removal keeps the version that was removed, with no duplicate completion row.
+code, raw = run(["mise", "uninstall", "dummy@1.0.1"], env)
+assert code == 0, raw
+plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
+assert re.search(r"removed 1 tool in .*: dummy@1\.0\.1", plain), plain
+assert "✓ dummy@1.0.1" not in plain, plain
 
 # An AI agent's terminal is a PTY that records frames instead of redrawing
 # them. It must get the append-only output CI gets, or every tick reprints

--- a/e2e/cli/test_upgrade_multiple_errors
+++ b/e2e/cli/test_upgrade_multiple_errors
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+export MISE_DEBUG=0 MISE_TRACE=0 MISE_LOG_LEVEL=info
+
+ln -s "$ROOT/test/data/plugins/tiny" "$MISE_DATA_DIR/plugins/tiny"
+mise install dummy@1.0.0 tiny@1.0.0
+cat >mise.toml <<'TOML'
+[tools]
+dummy = { version = "1.0.0", postinstall = "false" }
+tiny = { version = "1.0.0", postinstall = "mv mise.toml saved.toml; mkdir mise.toml" }
+TOML
+
+# One install fails, another succeeds, and saving its updated config fails too.
+if output=$(MISE_FORCE_PROGRESS=1 mise upgrade --bump 2>&1); then
+  fail "upgrade should report installation and config-save errors: $output"
+fi
+printf '%s' "$output" | python3 -c 'import re, sys; print(re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", sys.stdin.read()))' >output.log
+assert_contains 'cat output.log' 'Upgraded 1 tool:'
+assert_contains 'cat output.log' 'tiny 1.0.0 → 3.1.0'
+# Check the final error after the summary, not the earlier progress diagnostics.
+python3 -c 'from pathlib import Path; print(Path("output.log").read_text().split("Upgraded 1 tool:", 1)[1])' >final-error.log
+assert_contains 'cat final-error.log' 'Failed to install asdf:dummy@2.0.0'
+assert_contains 'cat final-error.log' 'Failed to save config'

--- a/e2e/cli/test_upgrade_no_prune
+++ b/e2e/cli/test_upgrade_no_prune
@@ -30,7 +30,8 @@ assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 # The default schedules the old version but leaves its path intact.
 mise uninstall dummy --all
 mise install dummy@1.0.0
-mise upgrade dummy
+mise upgrade dummy >upgrade.log 2>&1
+assert_contains "cat upgrade.log" "1 old version will be pruned after 24h"
 assert_contains "mise ls --installed dummy" "1.1.0"
 assert_contains "mise ls --installed dummy" "1.0.0 (pruned in"
 assert "mise ls --installed dummy -J | jq -r '.[] | select(.version == \"1.0.0\") | .scheduled_for_pruning'" "true"
@@ -104,13 +105,13 @@ mise --version >/dev/null
 assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 
 # A due receipt remains pending while a config reselects the old version.
-sed -i 's/dummy = "1"/dummy = "1.0.0"/' mise.toml
+sed -i.bak 's/dummy = "1"/dummy = "1.0.0"/' mise.toml
 mise current >/dev/null
 assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 assert "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
 
 # Once the reference goes away, the next invocation can remove it.
-sed -i 's/dummy = "1.0.0"/dummy = "1.1.0"/' mise.toml
+sed -i.bak 's/dummy = "1.0.0"/dummy = "1.1.0"/' mise.toml
 ln -s ./1.0.0 "$MISE_DATA_DIR/installs/dummy/retired"
 touch "$MISE_DATA_DIR/shims/deferred-prune-orphan"
 chmod +x "$MISE_DATA_DIR/shims/deferred-prune-orphan"
@@ -160,7 +161,7 @@ assert_fail "test -f '$MISE_STATE_DIR/deferred-prune-invocations'"
 assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 
 timeout 15 mise config ls >/dev/null
-assert "awk 'END { print NR < 10 }' '$MISE_STATE_DIR/deferred-prune-invocations'" "1"
+assert "awk 'END { print (NR < 10) }' '$MISE_STATE_DIR/deferred-prune-invocations'" "1"
 assert_fail "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 assert_fail "test -f '$MISE_STATE_DIR/tool-purgatory.json'"
 

--- a/e2e/cli/test_upgrade_no_prune
+++ b/e2e/cli/test_upgrade_no_prune
@@ -31,7 +31,7 @@ assert "ls $MISE_DATA_DIR/installs/dummy/1.0.0"
 mise uninstall dummy --all
 mise install dummy@1.0.0
 mise upgrade dummy >upgrade.log 2>&1
-assert_contains "cat upgrade.log" "1 old version will be pruned after 24h"
+assert_not_contains "cat upgrade.log" "will be pruned after"
 assert_contains "mise ls --installed dummy" "1.1.0"
 assert_contains "mise ls --installed dummy" "1.0.0 (pruned in"
 assert "mise ls --installed dummy -J | jq -r '.[] | select(.version == \"1.0.0\") | .scheduled_for_pruning'" "true"

--- a/e2e/cli/test_upgrade_progress_summary
+++ b/e2e/cli/test_upgrade_progress_summary
@@ -18,10 +18,11 @@ if grep -q $'\033\\[[0-9;]*J' <<<"$after_summary"; then
 fi
 
 # Lookup/install sessions leave the richer upgrade summary as the only success
-# record. Deferred pruning is one notice, independent of the tool count.
+# record. The one-time pruning hint stays out of captured output.
 printf '%s' "$output" | python3 -c 'import re, sys; print(re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", sys.stdin.read()))' >output.log
 assert_contains 'cat output.log' 'tiny 1.0.0 → 1.1.0'
-assert_contains 'cat output.log' '2 old versions will be pruned after 24h'
+assert_not_contains 'cat output.log' 'will be pruned after'
+assert_not_contains 'cat output.log' 'automatic pruning'
 assert_not_contains 'cat output.log' '✓ dummy'
 assert_not_contains 'cat output.log' '✓ tiny'
 assert_not_contains 'cat output.log' 'resolved 2 tools'

--- a/e2e/cli/test_upgrade_progress_summary
+++ b/e2e/cli/test_upgrade_progress_summary
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-echo 'dummy 1' >.tool-versions
-mise install dummy@1.0.0 >/dev/null 2>&1 || fail "pre-install of dummy@1.0.0 failed"
+export MISE_DEBUG=0 MISE_TRACE=0 MISE_LOG_LEVEL=info
 
-output="$(MISE_FORCE_PROGRESS=1 mise up dummy 2>&1)"
+printf 'dummy 1\ntiny 1\n' >.tool-versions
+mise install dummy@1.0.0 tiny@1.0.0 >/dev/null 2>&1 || fail "pre-install of dummy@1.0.0 failed"
+
+output="$(MISE_FORCE_PROGRESS=1 mise up 2>&1)"
 summary_line="  dummy 1.0.0 → 1.1.0"
 
 if [[ $output != *"$summary_line"* ]]; then
@@ -14,3 +16,14 @@ after_summary="${output#*"$summary_line"}"
 if grep -q $'\033\\[[0-9;]*J' <<<"$after_summary"; then
   fail "upgrade summary was followed by a terminal clear sequence"
 fi
+
+# Lookup/install sessions leave the richer upgrade summary as the only success
+# record. Deferred pruning is one notice, independent of the tool count.
+printf '%s' "$output" | python3 -c 'import re, sys; print(re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", sys.stdin.read()))' >output.log
+assert_contains 'cat output.log' 'tiny 1.0.0 → 1.1.0'
+assert_contains 'cat output.log' '2 old versions will be pruned after 24h'
+assert_not_contains 'cat output.log' '✓ dummy'
+assert_not_contains 'cat output.log' '✓ tiny'
+assert_not_contains 'cat output.log' 'resolved 2 tools'
+assert_not_contains 'cat output.log' 'installed 2 tools'
+assert_not_contains 'cat output.log' 'dummy@1.0.0 will be pruned'

--- a/e2e/cli/test_upgrade_prune_hint
+++ b/e2e/cli/test_upgrade_prune_hint
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+export CI=0 MISE_DEBUG=0 MISE_TRACE=0 MISE_LOG_LEVEL=info MISE_FORCE_PROGRESS=0
+
+cat >mise.toml <<'TOML'
+[tools]
+dummy = "1"
+[settings]
+upgrade.prune_after = "12h"
+TOML
+mise install dummy@1.0.0 >/dev/null 2>&1
+
+python3 - <<'PYTHON'
+import errno
+import os
+from pathlib import Path
+import pty
+import re
+import subprocess
+
+
+def upgrade(env, *args):
+    master, slave = pty.openpty()
+    # Hints require an attended terminal for both stdout and stderr.
+    proc = subprocess.Popen(
+        ["mise", "upgrade", *args], stdin=slave, stdout=slave, stderr=slave, env=env
+    )
+    os.close(slave)
+    output = bytearray()
+    try:
+        while True:
+            try:
+                chunk = os.read(master, 8192)
+            except OSError as error:
+                if error.errno == errno.EIO:
+                    break
+                raise
+            if not chunk:
+                break
+            output.extend(chunk)
+    finally:
+        os.close(master)
+    plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", output.decode(errors="replace"))
+    assert proc.wait() == 0, plain
+    return plain
+
+
+env = dict(os.environ)
+hint = "old tool versions are kept for 12h before automatic pruning"
+first = upgrade(env)
+assert hint in first, first
+assert "mise settings set upgrade.auto_prune false" in first, first
+assert "dummy 1.0.0 → 1.1.0" in first, first
+marker = Path(env["MISE_STATE_DIR"]) / "hints" / "upgrade_auto_prune"
+assert marker.is_file()
+second = upgrade(env, "--bump")
+assert "dummy 1.1.0 → 2.0.0" in second, second
+assert hint not in second, second
+
+# A fresh hint state proves disable_hints suppresses the hint before its first
+# display, without disabling the pruning schedule itself.
+subprocess.run(["mise", "uninstall", "dummy", "--all"], check=True, capture_output=True)
+subprocess.run(["mise", "install", "dummy@1.0.0"], check=True, capture_output=True)
+Path("mise.toml").write_text('[tools]\ndummy = "1"\n[settings]\nupgrade.prune_after = "12h"\n')
+disabled = dict(env, MISE_STATE_DIR=str(Path.cwd() / "disabled-state"),
+                MISE_DISABLE_HINTS="upgrade_auto_prune")
+output = upgrade(disabled)
+assert hint not in output, output
+assert "dummy 1.0.0 → 1.1.0" in output, output
+state = Path(disabled["MISE_STATE_DIR"])
+assert not (state / "hints" / "upgrade_auto_prune").exists()
+assert (state / "tool-purgatory.json").is_file()
+PYTHON

--- a/e2e/cli/test_upgrade_summary_on_config_error
+++ b/e2e/cli/test_upgrade_summary_on_config_error
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+export MISE_DEBUG=0 MISE_TRACE=0 MISE_LOG_LEVEL=info
+
+mise install dummy@1.0.0
+cat >mise.toml <<'TOML'
+[tools]
+dummy = { version = "1.0.0", postinstall = "mv mise.toml saved.toml; mkdir mise.toml" }
+TOML
+
+# The hook lets installation succeed but makes the subsequent config save fail.
+# A directory at the destination fails even when the test runs as root.
+if output=$(MISE_FORCE_PROGRESS=1 mise upgrade --bump 2>&1); then
+  fail "upgrade should fail when its config cannot be saved: $output"
+fi
+printf '%s' "$output" | python3 -c 'import re, sys; print(re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", sys.stdin.read()))' >output.log
+assert_contains 'cat output.log' 'Failed to save config'
+assert_contains 'cat output.log' 'Upgraded 1 tool:'
+assert_contains 'cat output.log' 'dummy 1.0.0 → 2.0.0'
+assert_not_contains 'cat output.log' '✓ dummy@2.0.0'
+assert "test -d '$MISE_DATA_DIR/installs/dummy/2.0.0'"

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -651,7 +651,7 @@ impl Upgrade {
             // and are not needed by any tracked config. Immediate removals are
             // collected and run as one session below, with a summary of removed versions.
             let mut immediate: Vec<ToolVersion> = Vec::new();
-            let mut deferred_count = 0;
+            let mut scheduled_pruning = false;
             for (o, old_version) in to_remove {
                 if successful_versions
                     .iter()
@@ -681,7 +681,7 @@ impl Upgrade {
                                     o.name, old_version
                                 );
                             } else {
-                                deferred_count += 1;
+                                scheduled_pruning = true;
                                 debug!(
                                     "{}@{} will be pruned after {}",
                                     o.name,
@@ -695,12 +695,12 @@ impl Upgrade {
                 }
             }
 
-            if deferred_count > 0 {
-                info!(
-                    "{} old version{} will be pruned after {}",
-                    deferred_count,
-                    if deferred_count == 1 { "" } else { "s" },
-                    Settings::get().upgrade.prune_after
+            if scheduled_pruning {
+                let prune_after = &Settings::get().upgrade.prune_after;
+                hint!(
+                    "upgrade_auto_prune",
+                    "old tool versions are kept for {prune_after} before automatic pruning. Disable this for future upgrades with",
+                    "mise settings set upgrade.auto_prune false"
                 );
             }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -789,8 +789,11 @@ impl Upgrade {
         mpr.finish_progress();
         Self::print_summary(&outdated, &successful_versions)?;
 
-        post_install_result?;
-        install_error
+        match (install_error, post_install_result) {
+            (Err(install), Err(post)) => Err(eyre!("{install:#}\n{post:#}")),
+            (Err(install), Ok(())) => Err(install),
+            (Ok(()), post) => post,
+        }
     }
 
     async fn uninstall_old_version(

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -428,6 +428,7 @@ impl Upgrade {
 
         let opts = InstallOptions {
             reason: "upgrade".to_string(),
+            hide_success_summary: true,
             force: false,
             jobs: self.jobs,
             raw: self.raw,
@@ -645,9 +646,9 @@ impl Upgrade {
 
         // Only uninstall old versions of tools that were successfully upgraded
         // and are not needed by any tracked config. Immediate removals are
-        // collected and run as one session below, so each finished removal is
-        // a single permanent line rather than a kept row.
+        // collected and run as one session below, with a summary of removed versions.
         let mut immediate: Vec<ToolVersion> = Vec::new();
+        let mut deferred_count = 0;
         for (o, old_version) in to_remove {
             if successful_versions
                 .iter()
@@ -677,7 +678,8 @@ impl Upgrade {
                                 o.name, old_version
                             );
                         } else {
-                            info!(
+                            deferred_count += 1;
+                            debug!(
                                 "{}@{} will be pruned after {}",
                                 o.name,
                                 old_version,
@@ -688,6 +690,15 @@ impl Upgrade {
                     PruneMode::None => unreachable!(),
                 }
             }
+        }
+
+        if deferred_count > 0 {
+            info!(
+                "{} old version{} will be pruned after {}",
+                deferred_count,
+                if deferred_count == 1 { "" } else { "s" },
+                Settings::get().upgrade.prune_after
+            );
         }
 
         if !immediate.is_empty() {

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -502,233 +502,236 @@ impl Upgrade {
             ))
         };
 
-        // Only update config files for tools that were successfully installed
-        let mut config_file_updates_by_path = IndexMap::new();
-        for (o, cf) in config_file_updates {
-            if successful_versions
-                .iter()
-                .any(|v| v.ba() == o.tool_version.ba())
-            {
-                config_file_updates_by_path
-                    .entry(cf.get_path().to_path_buf())
-                    .or_insert_with(|| (cf, vec![]))
-                    .1
-                    .push(o);
-            }
-        }
-        let mut config_file_errors = vec![];
-        for (path, (cf, updates)) in config_file_updates_by_path {
-            let mut update_failed = false;
-            for o in updates {
-                if let Err(e) =
-                    cf.replace_versions(o.tool_request.ba(), vec![o.tool_request.clone()])
+        // Installation has already changed disk state. Always report those results,
+        // even if updating config, pruning, or rebuilding links subsequently fails.
+        let post_install_result: Result<()> = async {
+            // Only update config files for tools that were successfully installed
+            let mut config_file_updates_by_path = IndexMap::new();
+            for (o, cf) in config_file_updates {
+                if successful_versions
+                    .iter()
+                    .any(|v| v.ba() == o.tool_version.ba())
                 {
-                    config_file_errors.push(eyre!("Failed to update config for {}: {}", o.name, e));
-                    update_failed = true;
-                    break;
+                    config_file_updates_by_path
+                        .entry(cf.get_path().to_path_buf())
+                        .or_insert_with(|| (cf, vec![]))
+                        .1
+                        .push(o);
                 }
             }
-            if update_failed {
-                continue;
-            }
-            if let Err(e) = cf.save() {
-                config_file_errors.push(eyre!(
-                    "Failed to save config {}: {}",
-                    display_path(&path),
-                    e
-                ));
-            }
-        }
-        if config_file_errors.len() == 1 {
-            return Err(config_file_errors.pop().unwrap());
-        }
-        if !config_file_errors.is_empty() {
-            let errors = config_file_errors
-                .into_iter()
-                .map(|e| format!("{e:#}"))
-                .collect::<Vec<_>>()
-                .join("\n");
-            return Err(eyre!("Failed to update config files:\n{errors}"));
-        }
-
-        // When a specific version is provided via CLI (e.g., `mise upgrade tiny@3.0.1`),
-        // update the config file prefix if the new version doesn't match the current specifier.
-        // Skip if --bump was used since it already handles config updates.
-        if !self.bump {
-            use crate::toolset::outdated_info::{apply_config_bumps, compute_config_bumps};
-            let tool_versions: Vec<(String, String)> = self
-                .tool
-                .iter()
-                .filter_map(|t| {
-                    t.tvr.as_ref().and_then(|tvr| {
-                        let name = t.ba.short.clone();
-                        // Only process tools that were successfully installed
-                        if successful_versions.iter().any(|v| v.ba().short == name) {
-                            Some((name, tvr.version()))
-                        } else {
-                            None
-                        }
-                    })
-                })
-                .collect();
-            let refs: Vec<(&str, &str)> = tool_versions
-                .iter()
-                .map(|(n, v)| (n.as_str(), v.as_str()))
-                .collect();
-            let bumps = compute_config_bumps(config, &refs);
-            apply_config_bumps(config, &bumps)?;
-        }
-
-        // Reset config after upgrades so tracked configs resolve with new versions
-        *config = Config::reset().await?;
-
-        // Rebuild symlinks BEFORE getting versions needed by tracked configs
-        // This ensures "latest" symlinks point to the new versions, not the old ones
-        let ts = config.get_toolset().await?;
-        runtime_symlinks::rebuild_for_toolset(config, ts)
-            .await
-            .wrap_err("failed to rebuild runtime symlinks")?;
-
-        // Get versions needed by tracked configs AFTER upgrade. Preserve lockfile pins
-        // from other projects, but ignore stale pre-upgrade locks for configs we just
-        // upgraded so their old versions can still be removed.
-        let successful_backends: HashSet<_> = successful_versions
-            .iter()
-            .flat_map(|v| {
-                [
-                    v.ba().short.clone(),
-                    v.ba().tool_name.clone(),
-                    v.ba().full(),
-                    v.ba().full_without_opts(),
-                ]
-            })
-            .collect();
-        let mut upgraded_config_paths: HashSet<_> = outdated
-            .iter()
-            .filter(|o| backend_matches(&successful_backends, o.tool_version.ba()))
-            .filter_map(|o| o.source.path().map(|path| path.to_path_buf()))
-            .collect();
-        for tvl in ts.versions.values() {
-            if backend_matches(&successful_backends, &tvl.backend)
-                && let Some(path) = tvl.source.path()
-            {
-                upgraded_config_paths.insert(path.to_path_buf());
-            }
-        }
-        for (path, cf) in config.config_files.iter() {
-            let Ok(trs) = cf.to_tool_request_set() else {
-                continue;
-            };
-            if trs
-                .tools
-                .keys()
-                .any(|ba| backend_matches(&successful_backends, ba))
-            {
-                upgraded_config_paths.insert(path.clone());
-            }
-        }
-        // Resolving every tracked config and stub is only worth doing when something is
-        // actually up for removal — with --no-prune, or when every upgrade was in-place,
-        // the answer would be discarded.
-        let versions_needed_by_tracked = if to_remove.is_empty() {
-            NeededVersions::new()
-        } else {
-            let mut needed = get_versions_needed_by_tracked_configs_excluding_locks(
-                config,
-                true,
-                false,
-                &upgraded_config_paths,
-            )
-            .await?;
-            needed.extend(get_versions_needed_by_tracked_stubs(config).await?);
-            needed
-        };
-
-        // Only uninstall old versions of tools that were successfully upgraded
-        // and are not needed by any tracked config. Immediate removals are
-        // collected and run as one session below, with a summary of removed versions.
-        let mut immediate: Vec<ToolVersion> = Vec::new();
-        let mut deferred_count = 0;
-        for (o, old_version) in to_remove {
-            if successful_versions
-                .iter()
-                .any(|v| v.ba() == o.tool_version.ba())
-            {
-                // Build a ToolVersion that targets the actual installed old version
-                // (e.g., "1.0.0"), not the resolved latest (e.g., "2.0.0").
-                // When minimum_release_age forces a remote lookup for "latest",
-                // the toolset resolves to the remote version, and tv_pathname()
-                // on the toolset version would give the wrong key.
-                let old_tv = ToolVersion::new(o.tool_version.request.clone(), old_version.clone());
-                let version_key = (old_tv.ba().short.to_string(), old_tv.tv_pathname());
-                if versions_needed_by_tracked.contains_key(&version_key) {
-                    debug!(
-                        "Keeping {}@{} because it's still needed by a tracked config or tool stub",
-                        o.name, old_version
-                    );
+            let mut config_file_errors = vec![];
+            for (path, (cf, updates)) in config_file_updates_by_path {
+                let mut update_failed = false;
+                for o in updates {
+                    if let Err(e) =
+                        cf.replace_versions(o.tool_request.ba(), vec![o.tool_request.clone()])
+                    {
+                        config_file_errors.push(eyre!("Failed to update config for {}: {}", o.name, e));
+                        update_failed = true;
+                        break;
+                    }
+                }
+                if update_failed {
                     continue;
                 }
-
-                match prune_mode {
-                    PruneMode::Immediate => immediate.push(old_tv),
-                    PruneMode::Deferred(after) => {
-                        if let Err(err) = crate::tool_purgatory::schedule(&old_tv, after) {
-                            warn!(
-                                "failed to schedule {}@{} for pruning: {err:#}",
-                                o.name, old_version
-                            );
-                        } else {
-                            deferred_count += 1;
-                            debug!(
-                                "{}@{} will be pruned after {}",
-                                o.name,
-                                old_version,
-                                Settings::get().upgrade.prune_after
-                            );
-                        }
-                    }
-                    PruneMode::None => unreachable!(),
+                if let Err(e) = cf.save() {
+                    config_file_errors.push(eyre!(
+                        "Failed to save config {}: {}",
+                        display_path(&path),
+                        e
+                    ));
                 }
             }
-        }
+            if config_file_errors.len() == 1 {
+                return Err(config_file_errors.pop().unwrap());
+            }
+            if !config_file_errors.is_empty() {
+                let errors = config_file_errors
+                    .into_iter()
+                    .map(|e| format!("{e:#}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                return Err(eyre!("Failed to update config files:\n{errors}"));
+            }
 
-        if deferred_count > 0 {
-            info!(
-                "{} old version{} will be pruned after {}",
-                deferred_count,
-                if deferred_count == 1 { "" } else { "s" },
-                Settings::get().upgrade.prune_after
-            );
-        }
-
-        if !immediate.is_empty() {
-            let mut progress = removal_progress(
-                &mpr,
-                immediate
+            // When a specific version is provided via CLI (e.g., `mise upgrade tiny@3.0.1`),
+            // update the config file prefix if the new version doesn't match the current specifier.
+            // Skip if --bump was used since it already handles config updates.
+            if !self.bump {
+                use crate::toolset::outdated_info::{apply_config_bumps, compute_config_bumps};
+                let tool_versions: Vec<(String, String)> = self
+                    .tool
                     .iter()
-                    .map(|tv| (format!("{}@{}", tv.ba().short, tv.version), tv.style())),
-            );
-            for old_tv in immediate {
-                let key = format!("{}@{}", old_tv.ba().short, old_tv.version);
-                let tool = progress
-                    .as_ref()
-                    .and_then(|progress| progress.start_tool(&key));
-                let pr = match &tool {
-                    Some(tool) => tool.reporter(),
-                    None => mpr.add(&format!("uninstall {}", old_tv.style())),
-                };
-                let result = self
-                    .uninstall_old_version(config, &old_tv, pr.as_ref())
-                    .await;
-                if let Some(tool) = &tool {
-                    tool.complete(result.as_ref().err().map(|e| e.to_string()).as_deref());
+                    .filter_map(|t| {
+                        t.tvr.as_ref().and_then(|tvr| {
+                            let name = t.ba.short.clone();
+                            // Only process tools that were successfully installed
+                            if successful_versions.iter().any(|v| v.ba().short == name) {
+                                Some((name, tvr.version()))
+                            } else {
+                                None
+                            }
+                        })
+                    })
+                    .collect();
+                let refs: Vec<(&str, &str)> = tool_versions
+                    .iter()
+                    .map(|(n, v)| (n.as_str(), v.as_str()))
+                    .collect();
+                let bumps = compute_config_bumps(config, &refs);
+                apply_config_bumps(config, &bumps)?;
+            }
+
+            // Reset config after upgrades so tracked configs resolve with new versions
+            *config = Config::reset().await?;
+
+            // Rebuild symlinks BEFORE getting versions needed by tracked configs
+            // This ensures "latest" symlinks point to the new versions, not the old ones
+            let ts = config.get_toolset().await?;
+            runtime_symlinks::rebuild_for_toolset(config, ts)
+                .await
+                .wrap_err("failed to rebuild runtime symlinks")?;
+
+            // Get versions needed by tracked configs AFTER upgrade. Preserve lockfile pins
+            // from other projects, but ignore stale pre-upgrade locks for configs we just
+            // upgraded so their old versions can still be removed.
+            let successful_backends: HashSet<_> = successful_versions
+                .iter()
+                .flat_map(|v| {
+                    [
+                        v.ba().short.clone(),
+                        v.ba().tool_name.clone(),
+                        v.ba().full(),
+                        v.ba().full_without_opts(),
+                    ]
+                })
+                .collect();
+            let mut upgraded_config_paths: HashSet<_> = outdated
+                .iter()
+                .filter(|o| backend_matches(&successful_backends, o.tool_version.ba()))
+                .filter_map(|o| o.source.path().map(|path| path.to_path_buf()))
+                .collect();
+            for tvl in ts.versions.values() {
+                if backend_matches(&successful_backends, &tvl.backend)
+                    && let Some(path) = tvl.source.path()
+                {
+                    upgraded_config_paths.insert(path.to_path_buf());
                 }
-                match result {
-                    Err(e) => warn!(
-                        "Failed to uninstall old version of {}: {}",
-                        old_tv.ba().short,
-                        e
-                    ),
+            }
+            for (path, cf) in config.config_files.iter() {
+                let Ok(trs) = cf.to_tool_request_set() else {
+                    continue;
+                };
+                if trs
+                    .tools
+                    .keys()
+                    .any(|ba| backend_matches(&successful_backends, ba))
+                {
+                    upgraded_config_paths.insert(path.clone());
+                }
+            }
+            // Resolving every tracked config and stub is only worth doing when something is
+            // actually up for removal — with --no-prune, or when every upgrade was in-place,
+            // the answer would be discarded.
+            let versions_needed_by_tracked = if to_remove.is_empty() {
+                NeededVersions::new()
+            } else {
+                let mut needed = get_versions_needed_by_tracked_configs_excluding_locks(
+                    config,
+                    true,
+                    false,
+                    &upgraded_config_paths,
+                )
+                .await?;
+                needed.extend(get_versions_needed_by_tracked_stubs(config).await?);
+                needed
+            };
+
+            // Only uninstall old versions of tools that were successfully upgraded
+            // and are not needed by any tracked config. Immediate removals are
+            // collected and run as one session below, with a summary of removed versions.
+            let mut immediate: Vec<ToolVersion> = Vec::new();
+            let mut deferred_count = 0;
+            for (o, old_version) in to_remove {
+                if successful_versions
+                    .iter()
+                    .any(|v| v.ba() == o.tool_version.ba())
+                {
+                    // Build a ToolVersion that targets the actual installed old version
+                    // (e.g., "1.0.0"), not the resolved latest (e.g., "2.0.0").
+                    // When minimum_release_age forces a remote lookup for "latest",
+                    // the toolset resolves to the remote version, and tv_pathname()
+                    // on the toolset version would give the wrong key.
+                    let old_tv = ToolVersion::new(o.tool_version.request.clone(), old_version.clone());
+                    let version_key = (old_tv.ba().short.to_string(), old_tv.tv_pathname());
+                    if versions_needed_by_tracked.contains_key(&version_key) {
+                        debug!(
+                            "Keeping {}@{} because it's still needed by a tracked config or tool stub",
+                            o.name, old_version
+                        );
+                        continue;
+                    }
+
+                    match prune_mode {
+                        PruneMode::Immediate => immediate.push(old_tv),
+                        PruneMode::Deferred(after) => {
+                            if let Err(err) = crate::tool_purgatory::schedule(&old_tv, after) {
+                                warn!(
+                                    "failed to schedule {}@{} for pruning: {err:#}",
+                                    o.name, old_version
+                                );
+                            } else {
+                                deferred_count += 1;
+                                debug!(
+                                    "{}@{} will be pruned after {}",
+                                    o.name,
+                                    old_version,
+                                    Settings::get().upgrade.prune_after
+                                );
+                            }
+                        }
+                        PruneMode::None => unreachable!(),
+                    }
+                }
+            }
+
+            if deferred_count > 0 {
+                info!(
+                    "{} old version{} will be pruned after {}",
+                    deferred_count,
+                    if deferred_count == 1 { "" } else { "s" },
+                    Settings::get().upgrade.prune_after
+                );
+            }
+
+            if !immediate.is_empty() {
+                let mut progress = removal_progress(
+                    &mpr,
+                    immediate
+                        .iter()
+                        .map(|tv| (format!("{}@{}", tv.ba().short, tv.version), tv.style())),
+                );
+                for old_tv in immediate {
+                    let key = format!("{}@{}", old_tv.ba().short, old_tv.version);
+                    let tool = progress
+                        .as_ref()
+                        .and_then(|progress| progress.start_tool(&key));
+                    let pr = match &tool {
+                        Some(tool) => tool.reporter(),
+                        None => mpr.add(&format!("uninstall {}", old_tv.style())),
+                    };
+                    let result = self
+                        .uninstall_old_version(config, &old_tv, pr.as_ref())
+                        .await;
+                    if let Some(tool) = &tool {
+                        tool.complete(result.as_ref().err().map(|e| e.to_string()).as_deref());
+                    }
+                    match result {
+                        Err(e) => warn!(
+                            "Failed to uninstall old version of {}: {}",
+                            old_tv.ba().short,
+                            e
+                        ),
                     Ok(()) => {
                         if let Err(err) = crate::tool_purgatory::forget_path(&old_tv.install_path())
                         {
@@ -779,9 +782,14 @@ impl Upgrade {
                 });
         }
 
+            Ok(())
+        }
+        .await;
+
         mpr.finish_progress();
         Self::print_summary(&outdated, &successful_versions)?;
 
+        post_install_result?;
         install_error
     }
 

--- a/src/toolset/install_options.rs
+++ b/src/toolset/install_options.rs
@@ -6,6 +6,8 @@ use crate::toolset::tool_version::ResolveOptions;
 #[derive(Debug, Clone)]
 pub(crate) struct InstallOptions {
     pub reason: String,
+    /// The caller prints its own final installation results.
+    pub hide_success_summary: bool,
     pub force: bool,
     pub jobs: Option<usize>,
     pub raw: bool,
@@ -39,6 +41,7 @@ impl Default for InstallOptions {
             jobs: Some(Settings::get().jobs),
             raw: Settings::get().raw,
             reason: "install".to_string(),
+            hide_success_summary: false,
             force: false,
             missing_args_only: true,
             include_lazy: false,

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -326,6 +326,11 @@ impl Toolset {
                 })
                 .flatten()
         });
+        if opts.hide_success_summary
+            && let Some(progress) = &mut install_progress
+        {
+            progress.hide_success_summary();
+        }
         if install_progress.is_none() {
             mpr.init_footer(opts.dry_run, &footer_reason, versions.len());
         }

--- a/src/ui/install_progress.rs
+++ b/src/ui/install_progress.rs
@@ -40,6 +40,10 @@ pub(crate) trait InstallProgress: Send + Sync {
     /// Tools that never reached a worker (blocked by a failed dependency, or
     /// refused before scheduling) and the final summary.
     fn finish(&mut self, failures: Vec<(String, String)>);
+
+    /// The caller prints its own successful results (for example, upgrade).
+    /// Captured output still keeps its complete progress record.
+    fn hide_success_summary(&mut self) {}
 }
 
 /// Pick the renderer for this terminal, or `None` when the existing per-tool
@@ -59,8 +63,7 @@ pub(crate) fn resolution_progress(
 }
 
 /// The same session for `prune`, `uninstall` and `upgrade`'s old versions.
-/// Hundreds of `remove …` rows kept in a live region were what made a large
-/// prune unreadable; here each finished removal is one permanent line.
+/// Interactive removals leave a summary naming the versions removed.
 pub(crate) fn removal_progress(
     mpr: &Arc<MultiProgressReport>,
     tools: impl Iterator<Item = (String, String)>,

--- a/src/ui/tty_install_progress.rs
+++ b/src/ui/tty_install_progress.rs
@@ -2,8 +2,8 @@
 //!
 //! The live region is small on purpose: a header with the install-wide bar and
 //! one row per tool that is actually doing something. Finished tools leave the
-//! region as permanent lines above it — the same lines CI gets — so scrollback
-//! is the record and the screen never fills with rows that are done.
+//! region without leaving successful completion lines. A final summary records
+//! changed versions; failures remain visible as soon as they happen.
 //!
 //! Everything shown here comes from the shared [`State`]; clx is only asked to
 //! paint prop strings and animate a spinner.
@@ -16,7 +16,9 @@ use clx::progress::{ProgressJob, ProgressJobBuilder, ProgressJobDoneBehavior, Pr
 use super::install_progress::{InstallProgress, ToolProgress};
 use super::progress_report::{ProgressIcon, SingleReport};
 use super::style;
-use super::text_install_progress::{State, Tool, elapsed, filled_cells, first_line, format_bytes};
+use super::text_install_progress::{
+    Action, Outcome, State, Tool, elapsed, filled_cells, first_line, format_bytes,
+};
 use crate::cli::version::VERSION_PLAIN;
 
 /// Redraw cadence for elapsed times and rates. clx animates the spinner on its
@@ -93,6 +95,7 @@ pub(crate) struct TtyInstallProgress {
     stop: mpsc::Sender<()>,
     thread: Option<JoinHandle<()>>,
     finished: bool,
+    hide_success_summary: bool,
 }
 
 impl TtyInstallProgress {
@@ -143,6 +146,7 @@ impl TtyInstallProgress {
             stop,
             thread: Some(thread),
             finished: false,
+            hide_success_summary: false,
         }
     }
 
@@ -210,7 +214,6 @@ fn refresh(state: &State, header: &Arc<ProgressJob>, rows: &Rows, now: Instant) 
     header.progress_current(((progress * OSC_SCALE as f64).round() as usize).min(OSC_SCALE));
     header.prop("version", &version_text(layout.version));
     header.prop("byline", &byline_text(layout.byline));
-    header.prop("bar", &state.bar_only(layout.header_bar));
     let mut status = state.count_label();
     if layout.rate
         && let Some(rate) = state.aggregate_rate(now)
@@ -222,7 +225,10 @@ fn refresh(state: &State, header: &Arc<ProgressJob>, rows: &Rows, now: Instant) 
         status.push_str(&format!(" · {queued} queued"));
     }
     status.push_str(&format!(" · {}", elapsed(state.started, now)));
+    // clx may draw between prop updates. Publish the completed count before
+    // the full bar so a frame never pairs 100% with the previous count.
     header.prop("status", &status);
+    header.prop("bar", &state.bar_only(layout.header_bar));
 
     for (index, tool) in state.tools.iter().enumerate() {
         let Some(job) = rows.jobs.get(index).and_then(|j| j.as_ref()) else {
@@ -304,6 +310,10 @@ impl InstallProgress for TtyInstallProgress {
         }
     }
 
+    fn hide_success_summary(&mut self) {
+        self.hide_success_summary = true;
+    }
+
     fn finish(&mut self, failures: Vec<(String, String)>) {
         self.finished = true;
         self.stop();
@@ -328,11 +338,36 @@ impl InstallProgress for TtyInstallProgress {
         } else {
             ProgressIcon::Success
         };
-        self.header
-            .println(&format!("{icon} {}", state.summary_text(now)));
+        if let Some(summary) = final_summary(&state, now, self.hide_success_summary) {
+            self.header.println(&format!("{icon} {summary}"));
+        }
         self.header.progress_current(OSC_SCALE);
         self.header.set_status(ProgressStatus::Done);
     }
+}
+
+/// Preserve actual changes once, without retaining lookup or skipped-tool noise.
+/// Failures always get a summary, including on an interrupted/error path.
+fn final_summary(state: &State, now: Instant, hide_success: bool) -> Option<String> {
+    let failed = state.count(Outcome::Failed) > 0;
+    if !failed && (hide_success || state.action == Action::Resolve) {
+        return None;
+    }
+    let changed: Vec<_> = state
+        .tools
+        .iter()
+        .filter(|tool| tool.outcome == Some(Outcome::Installed))
+        .map(|tool| tool.prefix.as_str())
+        .collect();
+    if !failed && changed.is_empty() {
+        return None;
+    }
+    let mut summary = state.summary_text(now);
+    if state.action != Action::Resolve && !changed.is_empty() {
+        summary.push_str(": ");
+        summary.push_str(&changed.join(", "));
+    }
+    Some(summary)
 }
 
 impl Drop for TtyInstallProgress {
@@ -409,18 +444,21 @@ impl ToolProgress for TtyToolProgress {
     }
 
     fn complete(&self, error: Option<&str>) {
-        let line = {
+        let (line, failed) = {
             let mut state = self.state.lock().unwrap();
             let outcome = state.tools[self.index].outcome_for(error);
             if let Some(error) = error {
                 state.tools[self.index].message = first_line(error);
             }
-            state.finish_tool(self.index, outcome, Instant::now(), Some(columns()))
+            (
+                state.finish_tool(self.index, outcome, Instant::now(), Some(columns())),
+                outcome == Outcome::Failed,
+            )
         };
         let Some(line) = line else {
             return;
         };
-        // The permanent line goes above the live region; the row leaves it.
+        // Completed rows leave the live region; only failures enter scrollback.
         let mut rows = self.rows.lock().unwrap();
         if let Some(child) = rows.children[self.index].take() {
             child.remove();
@@ -429,7 +467,9 @@ impl ToolProgress for TtyToolProgress {
             job.remove();
         }
         drop(rows);
-        self.header.println(&line);
+        if failed {
+            self.header.println(&line);
+        }
     }
 
     fn reporter(&self) -> Box<dyn SingleReport> {
@@ -499,6 +539,60 @@ impl SingleReport for TtyToolProgress {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn interactive_summary_records_only_changed_versions() {
+        let mut state = State::new(
+            ["dummy@1.0.0", "tiny@2.0.0"]
+                .into_iter()
+                .map(|tool| (tool.into(), tool.into())),
+        );
+        let now = state.started;
+        state.finish_tool(0, Outcome::Installed, now, None);
+        state.finish_tool(1, Outcome::Skipped, now, None);
+        assert_eq!(
+            final_summary(&state, now, false).unwrap(),
+            "installed 1 tool · 1 already installed in 0ms: dummy@1.0.0"
+        );
+        assert!(final_summary(&state, now, true).is_none());
+        state.action = Action::Remove;
+        assert!(
+            final_summary(&state, now, false)
+                .unwrap()
+                .starts_with("removed 1 tool")
+        );
+        state.action = Action::Resolve;
+        assert!(final_summary(&state, now, false).is_none());
+    }
+
+    #[test]
+    fn interactive_summary_preserves_partial_failure_results() {
+        for action in [Action::Install, Action::Resolve, Action::Remove] {
+            let mut state = State::for_action(
+                action,
+                ["dummy@1.0.0", "tiny@2.0.0"]
+                    .into_iter()
+                    .map(|tool| (tool.into(), tool.into())),
+            );
+            let now = state.started;
+            state.finish_tool(0, Outcome::Installed, now, None);
+            state.finish_tool(1, Outcome::Failed, now, None);
+            let summary = final_summary(&state, now, true).unwrap();
+            assert!(summary.contains("1 failed"));
+            if action != Action::Resolve {
+                assert!(summary.ends_with(": dummy@1.0.0"));
+            }
+        }
+    }
+
+    #[test]
+    fn interactive_summary_omits_sessions_without_changes() {
+        let mut state = State::new(std::iter::once(("dummy".into(), "dummy".into())));
+        let now = state.started;
+        assert!(final_summary(&state, now, false).is_none());
+        state.finish_tool(0, Outcome::Skipped, now, None);
+        assert!(final_summary(&state, now, false).is_none());
+    }
 
     #[test]
     fn a_wide_terminal_shows_everything() {


### PR DESCRIPTION
Interactive installs leave a permanent line for every resolved, skipped, and installed tool. During `mise upgrade`, those lines duplicate the final old → new version list. This changes the interactive default without adding a setting: live progress explains what is happening, and the final summary records what changed.

## Before and after

These examples show terminal scrollback **after the command finishes**, with colors removed and illustrative timings. The live spinner, bars, and active tool rows still appear while work runs. The examples use the dummy/tiny tools exercised by the regression tests.

### `mise upgrade`: keep the version-change list once

For two tools moving from `1.0.0` to `1.1.0`, the previous output includes successful rows from both lookup passes, installation, and a separate pruning notice for each old version:

```text
✓ dummy  2ms
✓ tiny   2ms
✓ resolved 2 tools in 2ms
✓ asdf:dummy@1.0.0  2ms
✓ asdf:tiny@1.0.0   2ms
✓ resolved 2 tools in 2ms
✓ dummy@1.1.0  1.1s
✓ tiny@1.1.0   1.1s
✓ installed 2 tools in 1.2s
mise dummy@1.0.0 will be pruned after 24h
mise tiny@1.0.0 will be pruned after 24h

Upgraded 2 tools:
  dummy 1.0.0 → 1.1.0
  tiny 1.0.0 → 1.1.0
```

After the one-time pruning hint has been shown or disabled:

```text
Upgraded 2 tools:
  dummy 1.0.0 → 1.1.0
  tiny 1.0.0 → 1.1.0
```

On the first interactive upgrade that schedules pruning, mise also explains the policy once:

```text
mise hint old tool versions are kept for 24h before automatic pruning. Disable this for future upgrades with mise settings set upgrade.auto_prune false
```

The delay reflects `upgrade.prune_after`. This uses the existing hint system, so subsequent upgrades leave no pruning notice. Suppress just the hint with:

```sh
mise settings add disable_hints upgrade_auto_prune
```

Disabling the hint does not disable pruning. The command shown by the hint disables pruning for future upgrades; existing scheduled removals are unaffected. Individual scheduled versions remain at debug level, and scheduling failures still emit warnings. Captured output does not show the hint.

### `mise install`: retain the installed versions in the summary

For `mise install dummy@1.0.0 tiny@1.0.0`, before:

```text
✓ dummy@1.0.0  1.1s
✓ tiny@1.0.0   1.1s
✓ installed 2 tools in 1.2s
```

After:

```text
✓ installed 2 tools in 1.2s: dummy@1.0.0, tiny@1.0.0
```

Installs triggered by `mise use`, `mise exec` / `mise x`, and tasks use the same summary. For example, when `mise x dummy@1.0.0 -- true` installs a missing tool, it leaves:

```text
✓ installed 1 tool in 1.1s: dummy@1.0.0
```

Already-installed tools no longer leave individual `⇢ … · already installed` lines. In a mixed install, their count remains in the summary, but only newly installed versions are listed:

```text
✓ installed 1 tool · 1 already installed in 1.1s: dummy@1.0.0
```

A session consisting entirely of successful lookups or already-installed checks leaves no progress summary.

### `mise uninstall` / `mise prune`: retain the removed versions

Before:

```text
✓ dummy@1.0.0  5ms
✓ removed 1 tool in 5ms
```

After:

```text
✓ removed 1 tool in 5ms: dummy@1.0.0
```

## Failure handling and other output modes

Failures still print immediately with diagnostics. Partial failures retain a result summary, including successfully changed versions. Upgrade also prints its old → new list when later config saves, pruning preparation, or link rebuilding fail, before returning the error. If installation and post-install work both fail, the final error includes both diagnostics. Captured/CI progress and explicit quiet, verbose, and raw progress modes retain their existing behavior. The pruning explanation follows the existing one-time hint behavior.

The terminal redraw also updates the completed count before publishing a full bar, avoiding a transient `0/1` frame at 100%.

Addresses https://github.com/jdx/mise/discussions/12939.

## Validation

- Six focused progress unit tests.
- Nine focused E2E tests: interactive install/implicit install/removal/failure, captured output, resolution progress, upgrade summary, deferred pruning, post-install config-save failure, parallel installation failure, one-time/disabled pruning hints, and simultaneous installation/config-save errors.
- `mise run lint-fix`.
- Made the existing pruning test's `sed` and `awk` expressions portable to macOS so the full regression runs locally.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core install/upgrade/uninstall UX and changes when upgrade returns errors relative to printing success summaries, though install disk state behavior is intentionally preserved.
> 
> **Overview**
> Interactive TTY install, uninstall, and remove sessions no longer leave a **✓ per-tool line** in scrollback for successes. Finished rows drop out of the live region; the closing line lists **only changed versions** (for example `installed 1 tool in …: dummy@1.0.0`). Failures still print immediately with diagnostics, and partial failures keep a summary that names what succeeded.
> 
> **`mise upgrade`** passes `hide_success_summary` into install so lookup/install progress does not duplicate the final **old → new** list. Post-install config, symlink, and prune work runs in a block that can still fail afterward, but **`Upgraded N tools:`** is printed once installs finish—even when saving config fails afterward. Per-version “will be pruned after …” moves to debug; attended terminals get a **one-time hint** about deferred pruning (with `MISE_DISABLE_HINTS` support).
> 
> The progress header updates **completed count before the bar** so a frame does not show 100% with a stale fraction. E2E and unit tests lock in the new summaries, implicit install, uninstall wording, upgrade output without duplicate ✓ rows, prune hints, and config-save failure behavior; macOS portability fixes for existing prune tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fff0a25f639793a74fcb4d653f0150068f9f710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Install and upgrade progress now use a cleaner live view, keeping successful completions out of terminal scrollback.
  * Upgrade results include a consolidated summary of changed tool versions.
  * Upgrade summaries remain visible even when post-install configuration updates fail.
  * Pruning guidance now uses a retention hint and avoids repeated or unnecessary notices.
  * Failed installations and configuration errors are reported together for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->