### PR TITLE
feat(lock): trial complete lockfile generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ include = [
   "/LICENSE",
   "/README.md",
   "/build.rs",
+  "/build/lockfile_rollout.rs",
   "/completions/*",
   "/docs/public/apple-touch-icon.png",
   "/docs/public/android-chrome-512x512.png",

--- a/build.rs
+++ b/build.rs
@@ -14,10 +14,18 @@ use aqua_registry::types::{AquaPackage, AquaPackageType, RegistryPackageRow, Reg
 use eyre::{Result, eyre};
 use serde_yaml::Value;
 
+#[path = "build/lockfile_rollout.rs"]
+mod lockfile_rollout;
+
 // cfg_aliases 0.2.1 emits semicolon-terminated helper macros in expression
 // position, which the latest nightly compiler rejects as future-incompatible.
 #[allow(semicolon_in_expressions_from_macros)]
 fn main() -> Result<()> {
+    let release = (
+        env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>()?,
+        env!("CARGO_PKG_VERSION_MINOR").parse::<u32>()?,
+    );
+    lockfile_rollout::check_release(release.0, release.1);
     cfg_aliases::cfg_aliases! {
         asdf: { any(feature = "asdf", not(target_os = "windows")) },
         macos: { target_os = "macos" },

--- a/build/lockfile_rollout.rs
+++ b/build/lockfile_rollout.rs
@@ -1,0 +1,31 @@
+//! Release-version gate, deliberately independent of the wall clock.
+
+pub(crate) fn check_release(year: u32, month: u32) {
+    assert!(
+        (year, month) < (2026, 12),
+        "Review lockfile_mode=generate trial feedback: promote generate to the default or explicitly postpone this December 2026 decision gate"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn releases_before_december_pass() {
+        check_release(2026, 9);
+        check_release(2026, 11);
+    }
+
+    #[test]
+    #[should_panic(expected = "Review lockfile_mode=generate trial feedback")]
+    fn first_december_release_requires_decision() {
+        check_release(2026, 12);
+    }
+
+    #[test]
+    #[should_panic(expected = "explicitly postpone")]
+    fn later_releases_cannot_bypass_decision() {
+        check_release(2027, 1);
+    }
+}

--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -10,6 +10,31 @@ concrete versions those requests resolved to. Supported backends also record
 artifact URLs, checksums, and verification metadata. Commit both files so other
 machines can use the same resolutions.
 
+::: tip Try complete lockfile generation
+
+We recommend trying the new generator to reduce cross-platform lockfile churn:
+
+```toml [mise.toml]
+[settings]
+lockfile_mode = "generate"
+```
+
+`mise lock` rebuilds the complete lockfile from current requests, reusing unchanged
+artifacts. During installation, a dedicated `lock` progress bar tracks background
+metadata downloads, hashing, and verification. The first run can download artifacts
+for other platforms; subsequent runs reuse unchanged entries.
+
+This does not enable automatic lockfile creation: run `mise lock` first or also set
+`lockfile = true`. Set `lockfile_mode = "merge"` to return to the existing behavior,
+or use `MISE_LOCKFILE_MODE=generate` to trial the setting for one command. Switching
+modes requires no format migration.
+
+The initial default remains `merge`. Before releasing mise `2026.12.0`, maintainers
+must review trial feedback and explicitly promote generation or postpone the
+decision. The default does not change based on your computer's date.
+
+:::
+
 ## Overview
 
 A lockfile separates routine installation from intentional updates:
@@ -98,7 +123,7 @@ A platform entry is written under a quoted key such as
 - **`size`** (legacy): File size in bytes; accepted when reading older lockfiles but omitted by the current writer
 - **`url`** (optional): Artifact download URL
 - **`url_api`** (optional): API download URL, for sources that require authenticated asset requests
-- **`provenance`** and **`provenance_verified`**: Available verification method and whether verification succeeded
+- **`provenance`**: Verification method successfully used for the artifact
 - **`signer`** and **`attested_by`**: Packslip identity commitments
 
 ### Tool Entry Fields
@@ -548,14 +573,13 @@ are enabled. Do not pass arbitrary npm range syntax directly to `mise use`.
 
 ## Provenance and Security
 
-For supported backends, `mise lock` records available provenance metadata such
-as SLSA, Cosign, Minisign, or GitHub attestations. Aqua and GitHub can download
-and cryptographically verify the current platform's artifact at lock time.
-A successful check is recorded separately with `provenance_verified`.
-Cross-platform metadata may describe an available verification method without
-having been verified locally.
+For supported backends, `mise lock` records verified provenance such as SLSA,
+Cosign, Minisign, or GitHub attestations. New provenance is cryptographically
+verified against the artifact for each target platform before it is recorded.
+Existing `provenance_verified` values are preserved as inert compatibility
+metadata for unchanged artifacts; mise no longer reads or adds this flag.
 
-During installation, a checksum plus a recorded verified provenance result can
+During installation, a checksum plus recorded provenance can
 allow mise to skip repeating that provenance check. The lockfile is therefore a
 trust input: review it and obtain it from a trusted project source. Artifact
 checksum verification still applies. A provenance field alone is not proof that

--- a/e2e/lockfile/test_lockfile_generate
+++ b/e2e/lockfile/test_lockfile_generate
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+detect_platform
+export MISE_LOCKFILE_MODE=generate
+assert_fail "MISE_LOCKFILE_MODE=invalid mise settings get lockfile_mode"
+
+cat >mise.toml <<'EOF'
+[settings]
+lockfile_platforms = ["linux-x64", "macos-arm64"]
+
+[tools."http:generate-fixture"]
+version = "1.0.0"
+url = "https://mise.jdx.dev/test-fixtures/hello-world-1.0.0.tar.gz"
+bin_path = "hello-world-1.0.0/bin"
+EOF
+
+# Choosing the generator does not opt in to creating a file during install.
+mise install
+assert "test -e mise.lock && echo exists || echo absent" "absent"
+
+mise lock
+assert_contains "cat mise.lock" 'sha256:'
+assert_not_contains "cat mise.lock" 'provenance_verified'
+cp mise.lock expected.lock
+mise lock
+diff -u expected.lock mise.lock
+mise install
+diff -u expected.lock mise.lock
+
+# A filtered update must carry the other target forward.
+mise lock --platform linux-x64
+diff -u expected.lock mise.lock
+
+# Explicit choices override the configured mode, with no format migration.
+mise settings --local set lockfile_mode merge
+assert "mise settings get lockfile_mode" "generate"
+unset MISE_LOCKFILE_MODE
+assert "mise settings get lockfile_mode" "merge"
+mise install
+export MISE_LOCKFILE_MODE=generate
+mise lock
+diff -u expected.lock mise.lock
+
+# Failure cannot publish over an existing lockfile.
+mise settings --local set lockfile_mode generate
+cat >>mise.toml <<'EOF'
+
+[tools."http:generate-broken"]
+version = "1.0.0"
+url = "http://127.0.0.1:1/unavailable.tar.gz"
+EOF
+assert_fail "MISE_HTTP_RETRIES=0 mise lock"
+diff -u expected.lock mise.lock

--- a/e2e/lockfile/test_lockfile_generate
+++ b/e2e/lockfile/test_lockfile_generate
@@ -38,6 +38,7 @@ assert "mise settings get lockfile_mode" "generate"
 unset MISE_LOCKFILE_MODE
 assert "mise settings get lockfile_mode" "merge"
 mise install
+diff -u expected.lock mise.lock
 export MISE_LOCKFILE_MODE=generate
 mise lock
 diff -u expected.lock mise.lock

--- a/e2e/lockfile/test_lockfile_generate_concurrent_edits
+++ b/e2e/lockfile/test_lockfile_generate_concurrent_edits
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export MISE_LOCKFILE_MODE=generate
+export MISE_HTTP_RETRIES=0
+detect_platform
+
+python3 -u - <<'PY' >server.port &
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import threading
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/config":
+            with open("mise.toml", "a") as config:
+                config.write("\n# concurrent config edit\n")
+        elif self.path == "/lock":
+            Path("mise.lock").write_text("# concurrent lock edit\n[tools]\n")
+        elif self.path == "/cancel":
+            Path("started").touch()
+            threading.Event().wait(30)
+        self.send_response(200)
+        self.send_header("Content-Length", "7")
+        self.end_headers()
+        self.wfile.write(b"fixture")
+
+    def log_message(self, *_):
+        pass
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+print(server.server_port, flush=True)
+server.serve_forever()
+PY
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+for _ in {1..100}; do
+  [[ -s server.port ]] && break
+  sleep 0.05
+done
+PORT=$(cat server.port)
+
+configure() {
+  cat >mise.toml <<EOF
+[tools."http:concurrent"]
+version = "1.0"
+url = "http://127.0.0.1:$PORT/$1"
+EOF
+}
+
+printf '[tools]\n' >mise.lock
+cp mise.lock expected.lock
+configure config
+assert_fail "mise lock --platform $MISE_PLATFORM"
+diff -u expected.lock mise.lock
+assert_contains "cat mise.toml" "concurrent config edit"
+
+configure config
+if mise install >install.log 2>&1; then
+  echo "install unexpectedly published after a concurrent config edit" >&2
+  exit 1
+fi
+assert_contains "cat install.log" "changed during installation"
+diff -u expected.lock mise.lock
+
+configure lock
+assert_fail "mise lock --platform $MISE_PLATFORM"
+assert_contains "cat mise.lock" "concurrent lock edit"
+
+cp mise.lock expected.lock
+configure cancel
+mise lock --platform "$MISE_PLATFORM" >cancel.log 2>&1 &
+LOCK_PID=$!
+for _ in {1..100}; do
+  [[ -f started ]] && break
+  sleep 0.05
+done
+test -f started
+kill -TERM "$LOCK_PID"
+if wait "$LOCK_PID"; then
+  echo "cancelled lock unexpectedly succeeded" >&2
+  exit 1
+fi
+diff -u expected.lock mise.lock

--- a/e2e/lockfile/test_lockfile_generate_creation
+++ b/e2e/lockfile/test_lockfile_generate_creation
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE_MODE=generate
+# shellcheck source=e2e/lockfile/test_lockfile_auto_create
+source "${TEST_ROOT}/lockfile/test_lockfile_auto_create"

--- a/e2e/lockfile/test_lockfile_generate_monorepo
+++ b/e2e/lockfile/test_lockfile_generate_monorepo
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE_MODE=generate
+# shellcheck source=e2e/lockfile/test_lockfile_monorepo
+source "${TEST_ROOT}/lockfile/test_lockfile_monorepo"

--- a/e2e/lockfile/test_lockfile_generate_overlap
+++ b/e2e/lockfile/test_lockfile_generate_overlap
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+detect_platform
+OTHER_PLATFORM=linux-x64
+if [[ $MISE_PLATFORM == linux-x64 ]]; then
+  OTHER_PLATFORM=macos-arm64
+fi
+
+# Neither request can finish until both have started. A sequential lock/install
+# implementation fails rather than passing through a timing-sensitive assertion.
+python3 -u - <<'PY' >server.port &
+import io
+import json
+import tarfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+events = {"/host.tar.gz": threading.Event(), "/other.tar.gz": threading.Event()}
+counts = {}
+mutex = threading.Lock()
+payload = io.BytesIO()
+with tarfile.open(fileobj=payload, mode="w:gz") as archive:
+    content = b"#!/bin/sh\necho fixture\n"
+    member = tarfile.TarInfo("bin/generate-overlap")
+    member.mode = 0o755
+    member.size = len(content)
+    archive.addfile(member, io.BytesIO(content))
+body = payload.getvalue()
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path not in events:
+            self.send_error(404)
+            return
+        with mutex:
+            counts[self.path] = counts.get(self.path, 0) + 1
+            with open("requests.json", "w") as output:
+                json.dump(counts, output)
+        events[self.path].set()
+        if not all(event.wait(15) for event in events.values()):
+            self.send_error(500, "installation and generation did not overlap")
+            return
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_):
+        pass
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+print(server.server_port, flush=True)
+server.serve_forever()
+PY
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+for _ in {1..100}; do
+  [[ -s server.port ]] && break
+  sleep 0.05
+done
+PORT=$(cat server.port)
+
+cat >mise.toml <<EOF
+[settings]
+lockfile = true
+lockfile_mode = "generate"
+lockfile_platforms = ["$OTHER_PLATFORM"]
+jobs = 2
+
+[tools."http:generate-overlap"]
+version = "1.0"
+
+[tools."http:generate-overlap".platforms."$MISE_PLATFORM"]
+url = "http://127.0.0.1:$PORT/host.tar.gz"
+
+[tools."http:generate-overlap".platforms."$OTHER_PLATFORM"]
+url = "http://127.0.0.1:$PORT/other.tar.gz"
+EOF
+
+MISE_HTTP_RETRIES=0 mise install 2>progress.log
+assert_contains "cat progress.log" "lock"
+assert "jq '.[\"/host.tar.gz\"]' requests.json" "1"
+assert "jq '.[\"/other.tar.gz\"]' requests.json" "1"
+cp mise.lock expected.lock
+mise lock
+diff -u expected.lock mise.lock
+assert "jq '.[\"/host.tar.gz\"]' requests.json" "1"
+assert "jq '.[\"/other.tar.gz\"]' requests.json" "1"

--- a/e2e/lockfile/test_lockfile_generate_platform_options
+++ b/e2e/lockfile/test_lockfile_generate_platform_options
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE_MODE=generate
+# shellcheck source=e2e/lockfile/test_lockfile_platform_option_variants
+source "${TEST_ROOT}/lockfile/test_lockfile_platform_option_variants"

--- a/e2e/lockfile/test_lockfile_generate_provenance_slow
+++ b/e2e/lockfile/test_lockfile_generate_provenance_slow
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE_MODE=generate
+# shellcheck source=e2e/lockfile/test_lockfile_provenance_determinism_slow
+source "${TEST_ROOT}/lockfile/test_lockfile_provenance_determinism_slow"
+assert_not_contains "cat mise.lock" "provenance_verified"

--- a/e2e/lockfile/test_lockfile_generate_task_tools
+++ b/e2e/lockfile/test_lockfile_generate_task_tools
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE_MODE=generate
+# shellcheck source=e2e/lockfile/test_lockfile_task_tools
+source "${TEST_ROOT}/lockfile/test_lockfile_task_tools"

--- a/e2e/lockfile/test_lockfile_monorepo
+++ b/e2e/lockfile/test_lockfile_monorepo
@@ -203,9 +203,16 @@ EOF
 touch monorepo-bad-roots/mise.lock
 
 rm -rf "$MISE_DATA_DIR/installs/tiny"
-output=$(cd monorepo-bad-roots/packages/a && mise install 2>&1)
-assert_contains "echo '$output'" "lockfile = true is set"
-assert_contains "cat monorepo-bad-roots/mise.lock" 'version = "1.0.0"'
+if [[ ${MISE_LOCKFILE_MODE:-merge} == generate ]]; then
+  # Complete generation cannot prune safely without resolving membership.
+  cp monorepo-bad-roots/mise.lock monorepo-bad-roots/mise.lock.before
+  assert_fail "cd monorepo-bad-roots/packages/a && mise install"
+  assert "cmp monorepo-bad-roots/mise.lock.before monorepo-bad-roots/mise.lock"
+else
+  output=$(cd monorepo-bad-roots/packages/a && mise install 2>&1)
+  assert_contains "echo '$output'" "lockfile = true is set"
+  assert_contains "cat monorepo-bad-roots/mise.lock" 'version = "1.0.0"'
+fi
 assert_fail "test -f monorepo-bad-roots/packages/a/mise.lock"
 
 echo "=== [monorepo] lockfile = false keeps subproject lockfiles ==="

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -1324,6 +1324,11 @@
           "description": "Create and read lockfiles for tool versions.",
           "type": "boolean"
         },
+        "lockfile_mode": {
+          "description": "Choose incremental merging or complete lockfile generation.",
+          "type": "string",
+          "enum": ["merge", "generate"]
+        },
         "lockfile_platforms": {
           "description": "Platforms to target in lockfile operations.",
           "type": "array",

--- a/settings.toml
+++ b/settings.toml
@@ -1753,6 +1753,19 @@ env = "MISE_LOCKFILE"
 optional = true
 type = "Bool"
 
+[lockfile_mode]
+default_docs = "merge"
+description = "Choose incremental merging or complete lockfile generation."
+docs = """
+Set to `generate` to trial complete lockfile generation and concurrent locking during
+installation. The initial default is `merge`. This setting does not enable lockfile
+creation: use `lockfile = true` or `mise lock` for that.
+"""
+enum = ["merge", "generate"]
+env = "MISE_LOCKFILE_MODE"
+optional = true
+type = "String"
+
 [lockfile_platforms]
 description = "Platforms to target in lockfile operations."
 docs = """

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -1438,10 +1438,12 @@ impl AquaBackend {
         {
             crate::hash::ensure_checksum(&artifact_path, expected, None, algorithm)?;
         }
-        *checksum = Some(format!(
-            "sha256:{}",
-            crate::hash::file_hash_sha256(&artifact_path, None)?
-        ));
+        if checksum.is_none() {
+            *checksum = Some(format!(
+                "sha256:{}",
+                crate::hash::file_hash_sha256(&artifact_path, None)?
+            ));
+        }
         let expected_checksum = checksum.as_deref();
 
         match detected {

--- a/src/backend/aqua.rs
+++ b/src/backend/aqua.rs
@@ -51,6 +51,7 @@ pub(crate) struct AquaBackend {
     ba: Arc<BackendArg>,
     id: String,
     version_tags_cache: CacheManager<Vec<(String, String)>>,
+    verification_target: Option<PlatformTarget>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -875,7 +876,7 @@ impl Backend for AquaBackend {
         }
 
         // Try to get checksum from checksum file if not available from GitHub API
-        let checksum = match checksum {
+        let mut checksum = match checksum {
             Some(c) => Some(c),
             None => match self
                 .fetch_checksum_from_file(&pkg, &v, target_os, target_arch, name.as_deref(), target)
@@ -951,20 +952,19 @@ impl Backend for AquaBackend {
             }
         }
 
-        // For the current platform, verify provenance cryptographically at lock time.
-        // This ensures the lockfile's provenance entry is backed by actual verification,
-        // not just registry metadata. Cross-platform entries remain detection-only.
+        // Record only cryptographically verified provenance for the target artifact.
         if provenance.is_some()
-            && target.is_current()
             && let Some(ref artifact_url) = url
         {
-            match self
+            let mut verifier = Self::from_arg(self.ba.as_ref().clone());
+            verifier.verification_target = Some(target.clone());
+            match verifier
                 .verify_provenance_at_lock_time(
                     &pkg,
                     &v,
                     artifact_url,
                     provenance.as_ref().unwrap(),
-                    checksum.as_deref(),
+                    &mut checksum,
                 )
                 .await
             {
@@ -972,16 +972,10 @@ impl Backend for AquaBackend {
                     provenance = verified;
                 }
                 Err(e) => {
-                    // Clear provenance so install-time verification will run.
-                    // If we kept the unverified provenance, has_lockfile_integrity
-                    // would be true and verify_provenance() would be skipped.
-                    warn!(
-                        "lock-time provenance verification failed for {}, \
-                         will be verified at install time: {e}{}",
-                        self.id,
+                    return Err(e.wrap_err(format!(
+                        "lock-time provenance verification failed{}",
                         Self::scratch_length_hint()
-                    );
-                    provenance = None;
+                    )));
                 }
             }
         }
@@ -997,6 +991,25 @@ impl Backend for AquaBackend {
 }
 
 impl AquaBackend {
+    fn verification_target(&self) -> PlatformTarget {
+        self.verification_target
+            .clone()
+            .unwrap_or_else(PlatformTarget::from_current)
+    }
+
+    fn verification_os(&self) -> &str {
+        self.verification_target
+            .as_ref()
+            .map(|target| Self::to_aqua_platform(target).0)
+            .unwrap_or_else(|| os())
+    }
+
+    fn verification_arch(&self) -> &str {
+        self.verification_target
+            .as_ref()
+            .map(|target| Self::to_aqua_platform(target).1)
+            .unwrap_or_else(|| arch())
+    }
     /// Resolve the registry entry for `tv` and decide whether it can be installed here at all.
     ///
     /// Split out of `install_version_` so `verify_install_feasible` can reach `validate` without
@@ -1407,7 +1420,7 @@ impl AquaBackend {
         v: &str,
         artifact_url: &str,
         detected: &ProvenanceType,
-        expected_checksum: Option<&str>,
+        checksum: &mut Option<String>,
     ) -> Result<Option<ProvenanceType>> {
         let tmp_dir = Self::lock_time_download_dir()?;
         let filename = get_filename_from_url(artifact_url);
@@ -1419,6 +1432,17 @@ impl AquaBackend {
         );
         HTTP.download_file(artifact_url, &artifact_path, None)
             .await?;
+        if let Some((algorithm, expected)) = checksum
+            .as_deref()
+            .and_then(|checksum| checksum.split_once(':'))
+        {
+            crate::hash::ensure_checksum(&artifact_path, expected, None, algorithm)?;
+        }
+        *checksum = Some(format!(
+            "sha256:{}",
+            crate::hash::file_hash_sha256(&artifact_path, None)?
+        ));
+        let expected_checksum = checksum.as_deref();
 
         match detected {
             ProvenanceType::GithubAttestations => {
@@ -1677,9 +1701,16 @@ impl AquaBackend {
         download_dir: &Path,
         pr: Option<&dyn SingleReport>,
     ) -> Result<String> {
-        let target = PlatformTarget::from_current();
-        let (provenance_url, url_api) =
-            self.resolve_slsa_url(pkg, v, os(), arch(), &target).await?;
+        let target = self.verification_target();
+        let (provenance_url, url_api) = self
+            .resolve_slsa_url(
+                pkg,
+                v,
+                self.verification_os(),
+                self.verification_arch(),
+                &target,
+            )
+            .await?;
         let download_url =
             select_github_download_url(pkg.private, &provenance_url, url_api.as_deref()).await;
         let provenance_path = download_dir.join(get_filename_from_url(&provenance_url));
@@ -1717,7 +1748,7 @@ impl AquaBackend {
         pkg: &AquaPackage,
         v: &str,
     ) -> Result<bool> {
-        let format = pkg.format(v, os(), arch())?;
+        let format = pkg.format(v, self.verification_os(), self.verification_arch())?;
         let format = Self::effective_extraction_format(pkg, format)?;
         if !format.is_archive() {
             return Err(eyre!(
@@ -1745,7 +1776,14 @@ impl AquaBackend {
     async fn run_minisign_check(&self, check: MinisignCheck<'_>) -> Result<()> {
         let template_ctx = check
             .checksum
-            .map(|checksum| checksum.template_ctx(check.pkg, check.version, os(), arch()))
+            .map(|checksum| {
+                checksum.template_ctx(
+                    check.pkg,
+                    check.version,
+                    self.verification_os(),
+                    self.verification_arch(),
+                )
+            })
             .transpose()?;
         let sig_path = match check.config._type() {
             AquaMinisignType::GithubRelease => {
@@ -1756,16 +1794,16 @@ impl AquaBackend {
                         check.config.asset.as_ref().unwrap(),
                         check.version,
                         &overrides,
-                        os(),
-                        arch(),
+                        self.verification_os(),
+                        self.verification_arch(),
                     )?
                 } else {
                     check.config.asset(
                         check.pkg,
                         check.artifact_filename,
                         check.version,
-                        os(),
-                        arch(),
+                        self.verification_os(),
+                        self.verification_arch(),
                     )?
                 };
                 let asset_strs = IndexSet::from([asset]);
@@ -1791,11 +1829,16 @@ impl AquaBackend {
                         check.config.url.as_ref().unwrap(),
                         check.version,
                         ctx,
-                        os(),
-                        arch(),
+                        self.verification_os(),
+                        self.verification_arch(),
                     )?
                 } else {
-                    check.config.url(check.pkg, check.version, os(), arch())?
+                    check.config.url(
+                        check.pkg,
+                        check.version,
+                        self.verification_os(),
+                        self.verification_arch(),
+                    )?
                 };
                 let path = check
                     .download_dir
@@ -1807,9 +1850,12 @@ impl AquaBackend {
         let data = file::read(check.artifact_path)?;
         let sig = file::read_to_string(&sig_path)?;
         minisign::verify(
-            &check
-                .config
-                .public_key(check.pkg, check.version, os(), arch())?,
+            &check.config.public_key(
+                check.pkg,
+                check.version,
+                self.verification_os(),
+                self.verification_arch(),
+            )?,
             &data,
             &sig,
         )?;
@@ -1833,12 +1879,13 @@ impl AquaBackend {
                 resolve_repo_info(key.repo_owner.as_ref(), key.repo_name.as_ref(), pkg);
             let (key_url, key_download_url) = match key.r#type.as_deref().unwrap_or_default() {
                 "github_release" => {
-                    let asset_strs = key.asset_strs(pkg, v, os(), arch())?;
+                    let asset_strs =
+                        key.asset_strs(pkg, v, self.verification_os(), self.verification_arch())?;
                     self.github_release_asset_urls(&key_pkg, v, asset_strs)
                         .await?
                 }
                 "http" => {
-                    let url = key.url(pkg, v, os(), arch())?;
+                    let url = key.url(pkg, v, self.verification_os(), self.verification_arch())?;
                     (url.clone(), url)
                 }
                 t => return Err(eyre!("unsupported cosign key type: {t}")),
@@ -1856,12 +1903,22 @@ impl AquaBackend {
                 let (sig_url, sig_download_url) =
                     match signature.r#type.as_deref().unwrap_or_default() {
                         "github_release" => {
-                            let asset_strs = signature.asset_strs(pkg, v, os(), arch())?;
+                            let asset_strs = signature.asset_strs(
+                                pkg,
+                                v,
+                                self.verification_os(),
+                                self.verification_arch(),
+                            )?;
                             self.github_release_asset_urls(&sig_pkg, v, asset_strs)
                                 .await?
                         }
                         "http" => {
-                            let url = signature.url(pkg, v, os(), arch())?;
+                            let url = signature.url(
+                                pkg,
+                                v,
+                                self.verification_os(),
+                                self.verification_arch(),
+                            )?;
                             (url.clone(), url)
                         }
                         t => return Err(eyre!("unsupported cosign signature type: {t}")),
@@ -1894,12 +1951,18 @@ impl AquaBackend {
             let (bundle_url, bundle_download_url) =
                 match bundle.r#type.as_deref().unwrap_or_default() {
                     "github_release" => {
-                        let asset_strs = bundle.asset_strs(pkg, v, os(), arch())?;
+                        let asset_strs = bundle.asset_strs(
+                            pkg,
+                            v,
+                            self.verification_os(),
+                            self.verification_arch(),
+                        )?;
                         self.github_release_asset_urls(&bundle_pkg, v, asset_strs)
                             .await?
                     }
                     "http" => {
-                        let url = bundle.url(pkg, v, os(), arch())?;
+                        let url =
+                            bundle.url(pkg, v, self.verification_os(), self.verification_arch())?;
                         (url.clone(), url)
                     }
                     t => return Err(eyre!("unsupported cosign bundle type: {t}")),
@@ -1908,7 +1971,7 @@ impl AquaBackend {
             HTTP.download_file(&bundle_download_url, &bundle_path, pr)
                 .await?;
 
-            let opts = cosign.opts(pkg, v, os(), arch())?;
+            let opts = cosign.opts(pkg, v, self.verification_os(), self.verification_arch())?;
             let result = if let Some(key_url) = cosign_opt_value(&opts, "--key") {
                 let key_path = download_dir.join(get_filename_from_url(key_url));
                 HTTP.download_file(key_url, &key_path, pr).await?;
@@ -1960,11 +2023,16 @@ impl AquaBackend {
     ) -> Result<(String, String)> {
         match checksum._type() {
             AquaChecksumType::GithubRelease => {
-                let asset_strs = checksum.asset_strs(pkg, v, os(), arch())?;
+                let asset_strs = checksum.asset_strs(
+                    pkg,
+                    v,
+                    self.verification_os(),
+                    self.verification_arch(),
+                )?;
                 self.github_release_asset_urls(pkg, v, asset_strs).await
             }
             AquaChecksumType::Http => checksum
-                .url(pkg, v, os(), arch())
+                .url(pkg, v, self.verification_os(), self.verification_arch())
                 .map(|url| (url.clone(), url)),
         }
     }
@@ -2010,6 +2078,7 @@ impl AquaBackend {
         Self {
             id: id.to_string(),
             ba: Arc::new(ba),
+            verification_target: None,
             // Bumped from `version_tags.msgpack.z`: this cache used to be filtered
             // by the inline `prerelease` opt, so previously cached lists could be
             // missing pre-release tags needed at install/lock time. The new cache
@@ -2219,7 +2288,7 @@ impl AquaBackend {
         v: &str,
         asset_strs: IndexSet<String>,
     ) -> Result<(String, String)> {
-        let target = PlatformTarget::from_current();
+        let target = self.verification_target();
         self.github_release_asset_urls_for_target(pkg, v, asset_strs, &target)
             .await
     }
@@ -2517,7 +2586,7 @@ impl AquaBackend {
         let has_lockfile_integrity = tv
             .lock_platforms
             .get(&platform_key)
-            .is_some_and(PlatformInfo::has_checksum_and_verified_provenance);
+            .is_some_and(PlatformInfo::has_checksum_and_provenance);
         let locked_provenance = tv
             .lock_platforms
             .get(&platform_key)
@@ -2777,7 +2846,7 @@ impl AquaBackend {
     /// When skipping full provenance re-verification (lockfile has checksum+provenance),
     /// check that the setting for the recorded provenance type is still enabled.
     /// Disabling a verification setting while the lockfile expects it is a downgrade.
-    fn ensure_provenance_setting_enabled(
+    pub(crate) fn ensure_provenance_setting_enabled(
         &self,
         tv: &ToolVersion,
         platform_key: &str,

--- a/src/backend/asset_matcher.rs
+++ b/src/backend/asset_matcher.rs
@@ -1077,13 +1077,18 @@ impl AssetMatcher {
             } else {
                 format!("\nNote: filtered by {}", active_filters.join(", "))
             };
-            eyre::eyre!(
+            let message = format!(
                 "No matching asset found for platform {}-{}{}\nAvailable assets:\n{}",
                 os,
                 arch,
                 filter_note,
                 assets.join("\n")
-            )
+            );
+            if active_filters.is_empty() {
+                eyre::Report::new(crate::errors::Error::UnsupportedTarget(message))
+            } else {
+                eyre::eyre!(message)
+            }
         })?;
 
         Ok(MatchedAsset { name: best })

--- a/src/backend/github.rs
+++ b/src/backend/github.rs
@@ -1001,7 +1001,7 @@ impl Backend for UnifiedGitBackend {
             .await;
 
         match asset {
-            Ok(asset) => {
+            Ok(mut asset) => {
                 let primary_explicit_pattern = opts.asset_pattern_for_target(target).is_some();
                 // Detect provenance availability from release assets and attestation API
                 let mut provenance = if !self.is_gitlab() && !self.is_forgejo() {
@@ -1010,39 +1010,30 @@ impl Backend for UnifiedGitBackend {
                 } else {
                     None
                 };
-                let mut provenance_verified = false;
-
-                // For the current platform, verify provenance cryptographically at lock time.
-                // This ensures the lockfile's provenance entry is backed by actual verification,
-                // not just an API query. Cross-platform entries remain detection-only.
-                if provenance.is_some() && target.is_current() {
+                // Every recorded provenance claim must be verified, including
+                // artifacts for platforms other than the host running mise lock.
+                if provenance.is_some() {
                     match self
                         .verify_provenance_at_lock_time(
                             tv,
                             &opts,
-                            &asset,
+                            &mut asset,
+                            target,
                             AssetVerification::primary(primary_explicit_pattern),
                         )
                         .await
                     {
                         Ok(verified) => {
                             provenance = verified;
-                            provenance_verified = provenance.is_some();
                         }
                         Err(e) => {
-                            // Clear provenance so install-time verification will run.
-                            warn!(
-                                "lock-time provenance verification failed for {}, \
-                                 will be verified at install time: {e}",
-                                self.ba.full()
-                            );
-                            provenance = None;
+                            return Err(e.wrap_err("lock-time provenance verification failed"));
                         }
                     }
                 }
                 let mut additional_artifacts = Vec::new();
                 for pattern in opts.additional_asset_patterns_for_target(target) {
-                    let additional = self
+                    let mut additional = self
                         .resolve_asset_url_for_target_with_pattern(
                             tv,
                             &opts,
@@ -1057,31 +1048,22 @@ impl Backend for UnifiedGitBackend {
                     } else {
                         None
                     };
-                    let mut additional_provenance_verified = false;
-                    if additional_provenance.is_some() && target.is_current() {
+                    if additional_provenance.is_some() {
                         additional_provenance = self
                             .verify_provenance_at_lock_time(
                                 tv,
                                 &opts,
-                                &additional,
+                                &mut additional,
+                                target,
                                 AssetVerification::ADDITIONAL,
                             )
-                            .await
-                            .unwrap_or_else(|e| {
-                                warn!(
-                                    "lock-time provenance verification failed for additional asset {}: {e}",
-                                    additional.name
-                                );
-                                None
-                            });
-                        additional_provenance_verified = additional_provenance.is_some();
+                            .await?;
                     }
                     additional_artifacts.push(ArtifactInfo {
                         checksum: additional.digest,
                         url: additional.url,
                         url_api: (!additional.url_api.is_empty()).then_some(additional.url_api),
                         provenance: additional_provenance,
-                        provenance_verified: additional_provenance_verified,
                         ..Default::default()
                     });
                 }
@@ -1091,13 +1073,20 @@ impl Backend for UnifiedGitBackend {
                     url_api: (!asset.url_api.is_empty()).then_some(asset.url_api),
                     checksum: asset.digest,
                     provenance,
-                    provenance_verified,
                     github_attestations: None,
                     additional_artifacts,
                     ..Default::default()
                 })
             }
             Err(e) => {
+                if Settings::get().generate_lockfiles()
+                    && !matches!(
+                        e.downcast_ref::<crate::errors::Error>(),
+                        Some(crate::errors::Error::UnsupportedTarget(_))
+                    )
+                {
+                    return Err(e);
+                }
                 debug!(
                     "Failed to resolve asset for {} on {}: {}",
                     self.ba.full(),
@@ -1327,7 +1316,8 @@ impl UnifiedGitBackend {
         &self,
         tv: &ToolVersion,
         opts: &GitBackendOptions<'_>,
-        asset: &ReleaseAsset,
+        asset: &mut ReleaseAsset,
+        target: &PlatformTarget,
         verification: AssetVerification,
     ) -> Result<Option<ProvenanceType>> {
         let repo = self.repo();
@@ -1356,6 +1346,18 @@ impl UnifiedGitBackend {
         };
         HTTP.download_file_with_headers(&download_url, &artifact_path, &headers, None)
             .await?;
+
+        if let Some((algorithm, expected)) = asset
+            .digest
+            .as_deref()
+            .and_then(|digest| digest.split_once(':'))
+        {
+            crate::hash::ensure_checksum(&artifact_path, expected, None, algorithm)?;
+        }
+        asset.digest = Some(format!(
+            "sha256:{}",
+            crate::hash::file_hash_sha256(&artifact_path, None)?
+        ));
 
         let settings = Settings::get();
 
@@ -1421,15 +1423,14 @@ impl UnifiedGitBackend {
                 .await?;
 
             let asset_names: Vec<String> = release.assets.iter().map(|a| a.name.clone()).collect();
-            let current_platform = PlatformTarget::from_current();
             // Keep provenance aligned with the matching-selected binary, unless
             // `asset_pattern` is set (it selects the binary, ignoring `matching`).
             let (matching, matching_regex) =
-                opts.matching_for_provenance(&current_platform, verification.explicit_pattern);
+                opts.matching_for_provenance(target, verification.explicit_pattern);
             let picker = AssetPicker::with_libc(
-                current_platform.os_name().to_string(),
-                current_platform.arch_name().to_string(),
-                current_platform.qualifier().map(|s| s.to_string()),
+                target.os_name().to_string(),
+                target.arch_name().to_string(),
+                target.qualifier().map(|s| s.to_string()),
             )
             .with_matching(matching.unwrap_or_default())
             .with_matching_regex(matching_regex.unwrap_or_default());
@@ -1653,7 +1654,7 @@ impl UnifiedGitBackend {
         let has_lockfile_integrity = tv
             .lock_platforms
             .get(&platform_key)
-            .is_some_and(PlatformInfo::has_checksum_and_verified_provenance);
+            .is_some_and(PlatformInfo::has_checksum_and_provenance);
         let locked_provenance = tv
             .lock_platforms
             .get(&platform_key)
@@ -1692,7 +1693,6 @@ impl UnifiedGitBackend {
             if provenance_result.is_some() {
                 let platform_info = tv.lock_platforms.entry(platform_key).or_default();
                 platform_info.provenance = provenance_result;
-                platform_info.provenance_verified = true;
                 platform_info.github_attestations = None;
             }
         }
@@ -1731,7 +1731,7 @@ impl UnifiedGitBackend {
             .cloned()
             .unwrap_or_default();
         let lockfile_has_checksum = artifact_info.checksum.is_some();
-        let has_lockfile_integrity = artifact_info.has_checksum_and_verified_provenance();
+        let has_lockfile_integrity = artifact_info.has_checksum_and_provenance();
         artifact_info.url = asset.url.clone();
         artifact_info.url_api = (!asset.url_api.is_empty()).then(|| asset.url_api.clone());
         if let Some(digest) = &asset.digest
@@ -1791,7 +1791,6 @@ impl UnifiedGitBackend {
                 .await?;
             if provenance.is_some() {
                 artifact_info.provenance = provenance;
-                artifact_info.provenance_verified = true;
             }
         }
 
@@ -2488,7 +2487,7 @@ impl UnifiedGitBackend {
     /// When skipping full provenance re-verification (lockfile has checksum+provenance),
     /// check that the setting for the recorded provenance type is still enabled.
     /// Disabling a verification setting while the lockfile expects it is a downgrade.
-    fn ensure_provenance_setting_enabled(
+    pub(crate) fn ensure_provenance_setting_enabled(
         &self,
         tv: &ToolVersion,
         platform_key: &str,

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -1154,11 +1154,12 @@ impl Backend for HttpBackend {
         // orchestration reports it as skipped, rather than returning an empty
         // entry that is miscounted as a successful platform (see #7113).
         let Some(url) = self.lock_url_for_target(&opts, tv, target) else {
-            return Err(eyre::eyre!(
+            return Err(crate::errors::Error::UnsupportedTarget(format!(
                 "no URL configured for {} on {}; skipping",
                 self.ba.full(),
                 target.to_key()
-            ));
+            ))
+            .into());
         };
 
         let checksum = self.resolve_lock_checksum(&opts, tv, target, &url).await;
@@ -1168,6 +1169,13 @@ impl Backend for HttpBackend {
         // url-only entry is still written, but surface it so it isn't a silent
         // drop of checksum verification.
         if checksum.is_none() && opts.checksum_url_for_target(target).is_some() {
+            if Settings::get().generate_lockfiles() {
+                eyre::bail!(
+                    "could not resolve the configured checksum for {} on {}",
+                    self.ba.full(),
+                    target.to_key()
+                );
+            }
             warn!(
                 "could not resolve a checksum for {} on {}; locking the URL without checksum verification",
                 self.ba.full(),

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -152,7 +152,7 @@ impl Install {
     #[async_backtrace::framed]
     pub async fn run(self) -> Result<()> {
         let config = Config::get().await?;
-        if !self.is_dry_run() {
+        if !self.is_dry_run() && !Settings::get().generate_lockfiles() {
             crate::lockfile::migrate_monorepo_lockfiles(&config, false)?;
         }
         let task_requests = self.collect_task_tool_requests(&config).await?;

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -204,6 +204,20 @@ struct PreparedLockfileRollback {
     replacement: Option<crate::file::PreparedAtomicWrite>,
 }
 
+fn verify_generation_snapshots<'a>(
+    snapshots: impl Iterator<Item = (&'a PathBuf, &'a Option<Vec<u8>>)>,
+) -> Result<()> {
+    for (path, content) in snapshots {
+        if read_optional_file(path)? != *content {
+            bail!(
+                "file {} changed during lockfile generation; retry the command",
+                display_path(path)
+            );
+        }
+    }
+    Ok(())
+}
+
 fn read_optional_file(path: &Path) -> Result<Option<Vec<u8>>> {
     match fs::read(path) {
         Ok(content) => Ok(Some(content)),
@@ -769,14 +783,7 @@ impl Lock {
         // resolved and bound successfully. This also keeps legacy monorepo
         // lockfiles untouched on failure.
         if !self.dry_run && atomic {
-            for (path, content) in config_snapshots.iter().chain(initial_lockfiles.iter()) {
-                if read_optional_file(path)? != *content {
-                    bail!(
-                        "file {} changed during lockfile generation; retry the command",
-                        display_path(path)
-                    );
-                }
-            }
+            verify_generation_snapshots(config_snapshots.iter().chain(initial_lockfiles.iter()))?;
             let migration_paths = lockfile::monorepo_lockfile_migration_paths(&config);
             let transaction_paths: BTreeSet<PathBuf> = staged_upgrade_writes
                 .iter()
@@ -801,6 +808,9 @@ impl Lock {
                 );
             }
 
+            // Lock acquisition may wait behind another writer. Recheck every input,
+            // including bumped configs and migration sources, under the transaction locks.
+            verify_generation_snapshots(config_snapshots.iter().chain(initial_lockfiles.iter()))?;
             for staged in &staged_upgrade_writes {
                 if read_optional_file(&staged.path)? != staged.original_content {
                     bail!(
@@ -828,6 +838,7 @@ impl Lock {
                 .iter()
                 .map(|staged| staged.lockfile.prepare_write(&staged.path))
                 .collect::<Result<Vec<_>>>()?;
+            verify_generation_snapshots(config_snapshots.iter().chain(initial_lockfiles.iter()))?;
             let commit_result = (|| -> Result<()> {
                 crate::toolset::outdated_info::apply_config_bumps(&config, &deferred_config_bumps)?;
                 for prepared in prepared_writes.into_iter().flatten() {
@@ -1953,6 +1964,21 @@ mod tests {
     use std::fs;
     use std::str::FromStr;
     use std::sync::Arc;
+
+    #[test]
+    fn snapshot_recheck_detects_config_and_migration_edits_after_initial_check() {
+        let dir = tempfile::tempdir().unwrap();
+        for filename in ["mise.toml", "legacy.mise.lock"] {
+            let path = dir.path().join(filename);
+            fs::write(&path, "original").unwrap();
+            let snapshots = BTreeMap::from([(path.clone(), Some(b"original".to_vec()))]);
+            super::verify_generation_snapshots(snapshots.iter()).unwrap();
+            // Simulate a writer completing while publication waits for its lock.
+            fs::write(&path, "concurrent edit").unwrap();
+            assert!(super::verify_generation_snapshots(snapshots.iter()).is_err());
+            assert_eq!(fs::read_to_string(path).unwrap(), "concurrent edit");
+        }
+    }
 
     #[test]
     fn rollback_restores_replaced_files_and_removes_created_files() {

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -40,6 +40,7 @@ fn lock_tool_matches(a: &LockTool, b: &LockTool) -> bool {
         && a.1.version == b.1.version
         && a.1.request.version() == b.1.request.version()
         && a.1.request.options() == b.1.request.options()
+        && a.1.request.source() == b.1.request.source()
 }
 
 fn push_unique_lock_tool(tools: &mut Vec<LockTool>, tool: LockTool) {
@@ -277,12 +278,41 @@ fn classify_lock_result(
 
 impl Lock {
     pub(crate) async fn run(self) -> Result<()> {
+        self.run_with_installed(None, Config::get().await?).await
+    }
+
+    pub(crate) async fn generate_after_install(
+        config: Arc<Config>,
+        installed: &[crate::toolset::ToolVersion],
+    ) -> Result<()> {
+        Self {
+            tool: vec![],
+            global: false,
+            jobs: None,
+            dry_run: false,
+            platform: vec![],
+            bump: false,
+            json: true,
+            local: false,
+            minimum_release_age: None,
+            upgrade: false,
+        }
+        .run_with_installed(Some(installed), config)
+        .await
+    }
+
+    async fn run_with_installed(
+        self,
+        installed: Option<&[crate::toolset::ToolVersion]>,
+        config: Arc<Config>,
+    ) -> Result<()> {
         if self.upgrade && !self.tool.is_empty() {
             bail!("`mise lock --upgrade` cannot be combined with tool arguments");
         }
         let settings = Settings::get();
-        let config = Config::get().await?;
-        if !self.dry_run && !self.upgrade {
+        let generate = settings.generate_lockfiles();
+        let atomic = self.upgrade || generate;
+        if !self.dry_run && !atomic {
             lockfile::migrate_monorepo_lockfiles(&config, self.upgrade)?;
         }
         let before_date = self.get_before_date()?;
@@ -314,6 +344,29 @@ impl Lock {
         let task_load_context = crate::task::TaskLoadContext::all();
         let tasks = config.tasks_with_context(Some(&task_load_context)).await?;
 
+        let config_snapshots = effective_config_files
+            .keys()
+            .chain(tasks.values().filter_map(|task| task.file.as_ref()))
+            .map(|path| Ok((path.clone(), read_optional_file(path)?)))
+            .collect::<Result<BTreeMap<_, _>>>()?;
+        let scoped_config_paths = if installed.is_some() {
+            effective_config_files.keys().cloned().collect()
+        } else {
+            self.config_paths_in_lock_scope(&config, effective_config_files)
+        };
+        let lockfile_targets =
+            self.get_lockfile_targets(&config, effective_config_files, &scoped_config_paths);
+        let migration_inputs = lockfile::monorepo_lockfile_migration_paths(&config);
+        let initial_lockfiles = lockfile_targets
+            .keys()
+            .chain(
+                migration_inputs
+                    .iter()
+                    .flat_map(|(source, target)| [source, target]),
+            )
+            .map(|path| Ok((path.clone(), read_optional_file(path)?)))
+            .collect::<Result<BTreeMap<_, _>>>()?;
+
         let ts_owned;
         let ts = if let Some(monorepo_union) = &monorepo_union {
             let mut monorepo_ts: Toolset = monorepo_union.tool_request_set.clone().into();
@@ -328,9 +381,6 @@ impl Lock {
             &ts_owned
         };
 
-        let scoped_config_paths = self.config_paths_in_lock_scope(&config, effective_config_files);
-        let lockfile_targets =
-            self.get_lockfile_targets(&config, effective_config_files, &scoped_config_paths);
         let mut has_lock_targets = false;
         let mut all_resolution_errors: Vec<String> = Vec::new();
         let mut all_platform_regressions: Vec<String> = Vec::new();
@@ -349,9 +399,41 @@ impl Lock {
         // earlier environment/local/monorepo lockfiles partially updated.
         let mut prepared_targets = Vec::with_capacity(lockfile_targets.len());
         for (lockfile_path, config_paths) in &lockfile_targets {
-            let tools = self
+            if installed.is_some()
+                && !lockfile::generate::has_previous_file(&config, lockfile_path)
+                && (!config.lockfile_creation_enabled()
+                    || installed.is_some_and(|versions| {
+                        !versions.is_empty()
+                            && versions.iter().all(|tv| {
+                                tv.request
+                                    .source()
+                                    .path()
+                                    .is_none_or(crate::config::is_global_config)
+                            })
+                    })
+                    || !config_paths
+                        .iter()
+                        .any(|p| !crate::config::is_global_config(p)))
+            {
+                continue;
+            }
+            let mut tools = self
                 .get_tools_to_lock(&collection_context, lockfile_path, config_paths)
                 .await?;
+            if let Some(installed) = installed {
+                for (_, tv) in &mut tools {
+                    if let Some(actual) = installed.iter().find(|actual| {
+                        actual.ba().full() == tv.ba().full()
+                            && request_matches(&actual.request, &tv.request)
+                            && actual.request.source() == tv.request.source()
+                    }) {
+                        *tv = actual.clone();
+                    }
+                }
+                if tools.is_empty() && !lockfile_path.exists() {
+                    continue;
+                }
+            }
             let configured_selectors = self.configured_tool_selectors_for_target(
                 &config,
                 &tools,
@@ -379,7 +461,11 @@ impl Lock {
                 // `tools` can be empty either because config has no tools, or because a filter excludes all.
                 // For unfiltered runs (`mise lock`), this means "prune all stale lockfile entries".
                 if self.dry_run {
-                    let lockfile = Lockfile::read(&lockfile_path)?;
+                    let lockfile = if generate {
+                        lockfile::generate::read_previous(&config, &lockfile_path, self.upgrade)?
+                    } else {
+                        Lockfile::read(&lockfile_path)?
+                    };
                     self.report_lockfile_format(&lockfile_path, &lockfile, true)?;
                     if self.json {
                         all_changes.extend(self.compute_version_changes(
@@ -399,7 +485,11 @@ impl Lock {
                         .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
                         .lock()?;
                     let original_content = read_optional_file(&lockfile_path)?;
-                    let mut lockfile = Lockfile::read(&lockfile_path)?;
+                    let mut lockfile = if generate {
+                        lockfile::generate::read_previous(&config, &lockfile_path, self.upgrade)?
+                    } else {
+                        Lockfile::read(&lockfile_path)?
+                    };
                     if self.json {
                         all_changes.extend(self.compute_version_changes(
                             &lockfile,
@@ -425,7 +515,7 @@ impl Lock {
                         false
                     };
                     if format_changed || !pruned_tools.is_empty() {
-                        if self.upgrade {
+                        if atomic {
                             staged_upgrade_writes.push(StagedUpgradeWrite {
                                 path: lockfile_path.clone(),
                                 original_content,
@@ -438,7 +528,7 @@ impl Lock {
                         } else {
                             lockfile.write(&lockfile_path)?;
                         }
-                        if !self.upgrade {
+                        if !atomic {
                             self.show_stale_prune_message(&lockfile_path, &pruned_tools, false)?;
                         }
                         has_lock_targets = true;
@@ -477,7 +567,11 @@ impl Lock {
 
             if self.dry_run {
                 self.show_dry_run(&tools, &target_platforms)?;
-                let lockfile = Lockfile::read(&lockfile_path)?;
+                let lockfile = if generate {
+                    lockfile::generate::read_previous(&config, &lockfile_path, self.upgrade)?
+                } else {
+                    Lockfile::read(&lockfile_path)?
+                };
                 self.report_lockfile_format(&lockfile_path, &lockfile, true)?;
                 if self.json {
                     all_changes.extend(self.compute_version_changes(
@@ -501,15 +595,22 @@ impl Lock {
                 .with_callback(|l| debug!("waiting for lock on {}", display_path(l)))
                 .lock()?;
             let original_content = read_optional_file(&lockfile_path)?;
-            let mut lockfile = Lockfile::read(&lockfile_path)?;
+            let mut lockfile = if generate {
+                lockfile::generate::read_previous(&config, &lockfile_path, self.upgrade)?
+            } else {
+                Lockfile::read(&lockfile_path)?
+            };
             if !self.upgrade {
                 self.report_lockfile_format(&lockfile_path, &lockfile, false)?;
             }
             if self.json {
                 all_changes.extend(self.compute_version_changes(&lockfile, &tools, &lockfile_path));
             }
-            let stale_tools =
-                self.prune_stale_entries_if_needed(&mut lockfile, configured_selectors.as_ref());
+            let stale_tools = if generate {
+                self.stale_entries_if_pruned(&lockfile, configured_selectors.as_ref())
+            } else {
+                self.prune_stale_entries_if_needed(&mut lockfile, configured_selectors.as_ref())
+            };
             if !self.upgrade {
                 self.show_stale_prune_message(&lockfile_path, &stale_tools, false)?;
             }
@@ -518,9 +619,22 @@ impl Lock {
             // compare against old version entries. Actual pruning happens after.
             let stale_versions = self.stale_versions_if_pruned(&lockfile, &tools);
 
-            let (results, resolution_errors) = self
-                .process_tools(&settings, &tools, &target_platforms, &mut lockfile)
+            let (results, resolution_errors) = if generate {
+                lockfile = lockfile::generate::generate(
+                    &lockfile,
+                    &tools,
+                    &target_platforms,
+                    !self.tool.is_empty(),
+                    !self.platform.is_empty(),
+                    crate::jobs::resolve(settings.jobs, self.jobs),
+                    installed.unwrap_or_default(),
+                )
                 .await?;
+                (Vec::new(), Vec::new())
+            } else {
+                self.process_tools(&settings, &tools, &target_platforms, &mut lockfile)
+                    .await?
+            };
             let resolution_succeeded = resolution_errors.is_empty();
             all_resolution_errors.extend(resolution_errors);
 
@@ -546,7 +660,9 @@ impl Lock {
             }
 
             // Prune stale versions AFTER provenance checks complete
-            self.prune_stale_versions(&mut lockfile, &tools);
+            if !generate {
+                self.prune_stale_versions(&mut lockfile, &tools);
+            }
             if !self.upgrade {
                 self.show_stale_version_prune_message(&lockfile_path, &stale_versions, false)?;
             }
@@ -556,12 +672,12 @@ impl Lock {
                 .filter(|result| matches!(result.status, LockTaskStatus::Updated))
                 .count();
             let skipped = results.len() - successful;
-            if self.upgrade {
+            if atomic {
                 staged_upgrade_writes.push(StagedUpgradeWrite {
                     path: lockfile_path.clone(),
                     original_content,
                     lockfile,
-                    summary: Some((successful, skipped)),
+                    summary: (!generate).then_some((successful, skipped)),
                     format_changed,
                     stale_tools,
                     stale_versions,
@@ -574,7 +690,7 @@ impl Lock {
 
             // Print summaries for normal writes now. Upgrade summaries are
             // deferred with their writes until every target succeeds.
-            if !self.json && !self.upgrade {
+            if !self.json && !atomic {
                 miseprintln!(
                     "{} Updated {} platform entries ({} skipped)",
                     style("✓").green(),
@@ -606,6 +722,7 @@ impl Lock {
         // Update config files when a specific version is requested that doesn't match
         // the current prefix (e.g., `mise lock tiny@3.0.1` when config has `tiny = "2"`).
         // Never under --bump, which is documented to leave config files untouched.
+        let mut deferred_config_bumps = Vec::new();
         if !self.bump {
             use crate::toolset::outdated_info::{
                 apply_config_bumps, compute_config_bumps_for_paths,
@@ -636,6 +753,8 @@ impl Lock {
                         );
                     }
                 }
+            } else if atomic {
+                deferred_config_bumps = bumps;
             } else {
                 apply_config_bumps(&config, &bumps)?;
             }
@@ -649,11 +768,24 @@ impl Lock {
         // Format upgrades are committed as a batch only after every target has
         // resolved and bound successfully. This also keeps legacy monorepo
         // lockfiles untouched on failure.
-        if !self.dry_run && self.upgrade {
+        if !self.dry_run && atomic {
+            for (path, content) in config_snapshots.iter().chain(initial_lockfiles.iter()) {
+                if read_optional_file(path)? != *content {
+                    bail!(
+                        "file {} changed during lockfile generation; retry the command",
+                        display_path(path)
+                    );
+                }
+            }
             let migration_paths = lockfile::monorepo_lockfile_migration_paths(&config);
             let transaction_paths: BTreeSet<PathBuf> = staged_upgrade_writes
                 .iter()
                 .map(|staged| staged.path.clone())
+                .chain(
+                    deferred_config_bumps
+                        .iter()
+                        .map(|bump| bump.config_path.clone()),
+                )
                 .chain(
                     migration_paths
                         .iter()
@@ -672,7 +804,7 @@ impl Lock {
             for staged in &staged_upgrade_writes {
                 if read_optional_file(&staged.path)? != staged.original_content {
                     bail!(
-                        "lockfile {} changed while the format upgrade was being prepared; retry `mise lock --upgrade`",
+                        "lockfile {} changed while generation was being prepared; retry the command",
                         display_path(&staged.path)
                     );
                 }
@@ -692,11 +824,28 @@ impl Lock {
             // later disk-full failure cannot prevent restoration by requiring
             // more file data to be written.
             let rollbacks = prepare_lockfile_rollback(&snapshots)?;
+            let prepared_writes = staged_upgrade_writes
+                .iter()
+                .map(|staged| staged.lockfile.prepare_write(&staged.path))
+                .collect::<Result<Vec<_>>>()?;
             let commit_result = (|| -> Result<()> {
-                for staged in &staged_upgrade_writes {
-                    staged.lockfile.write(&staged.path)?;
+                crate::toolset::outdated_info::apply_config_bumps(&config, &deferred_config_bumps)?;
+                for prepared in prepared_writes.into_iter().flatten() {
+                    prepared.publish()?;
                 }
-                lockfile::migrate_monorepo_lockfiles_already_locked(&config, true, &migration_paths)
+                lockfile::migrate_monorepo_lockfiles_already_locked(
+                    &config,
+                    self.upgrade,
+                    &migration_paths,
+                    generate
+                        .then(|| {
+                            staged_upgrade_writes
+                                .iter()
+                                .map(|staged| staged.path.clone())
+                                .collect::<BTreeSet<_>>()
+                        })
+                        .as_ref(),
+                )
             })();
             if let Err(err) = commit_result {
                 if let Err(rollback_err) = restore_lockfile_snapshots(rollbacks) {
@@ -709,6 +858,13 @@ impl Lock {
             drop(transaction_locks);
 
             for staged in &staged_upgrade_writes {
+                if generate && !self.json {
+                    miseprintln!(
+                        "{} Lockfile ready at {}",
+                        style("✓").green(),
+                        style(display_path(&staged.path)).cyan()
+                    );
+                }
                 if staged.format_changed {
                     self.show_lockfile_upgrade_message(&staged.path)?;
                 }
@@ -732,7 +888,7 @@ impl Lock {
             }
         }
 
-        if self.json {
+        if self.json && installed.is_none() {
             miseprintln!("{}", serde_json::to_string_pretty(&all_changes)?);
         }
 
@@ -1302,6 +1458,11 @@ impl Lock {
                 // an arbitrary project mise.lock.
                 continue;
             } else {
+                if Settings::get().generate_lockfiles() {
+                    // Complete generation is owned by configuration, not temporary
+                    // CLI/environment overrides. Explicit lock selectors are applied below.
+                    continue;
+                }
                 // Tools without a source path (env vars, CLI args) go to mise.lock only
                 let is_base_lockfile = target_lockfile_path
                     .file_name()
@@ -1335,9 +1496,16 @@ impl Lock {
             {
                 continue;
             }
-            if let Ok(trs) = cf.to_tool_request_set() {
+            let requests = match cf.to_tool_request_set() {
+                Err(error) if Settings::get().generate_lockfiles() => return Err(error),
+                result => result,
+            };
+            if let Ok(trs) = requests {
                 for (ba, requests, source) in trs.iter() {
                     for request in requests {
+                        if Settings::get().generate_lockfiles() {
+                            ba.backend()?;
+                        }
                         if ba.backend().is_ok() {
                             // Check if the resolved toolset has a matching request.
                             let mut matched_resolved = false;
@@ -1350,9 +1518,11 @@ impl Lock {
                                         })
                                     {
                                         matched_resolved = true;
+                                        let mut tv = tv.clone();
+                                        tv.request.set_source(source.clone());
                                         push_unique_lock_tool(
                                             &mut all_tools,
-                                            (ba.as_ref().clone(), tv.clone()),
+                                            (ba.as_ref().clone(), tv),
                                         );
                                     }
                                 }
@@ -1370,6 +1540,7 @@ impl Lock {
                             // toolset. Keep this broad only for idiomatic version files;
                             // other sources preserve the previous latest-only behavior.
                             let should_resolve_overridden = active_unresolved
+                                || Settings::get().generate_lockfiles()
                                 || request.version() == "latest"
                                 || source.is_idiomatic_version_file();
                             if !matched_resolved && should_resolve_overridden {
@@ -1378,7 +1549,8 @@ impl Lock {
                                 {
                                     Ok(opts) => opts,
                                     Err(err) => {
-                                        if active_unresolved {
+                                        if active_unresolved || Settings::get().generate_lockfiles()
+                                        {
                                             return Err(err.wrap_err(format!(
                                                     "failed to resolve options for {request} for lockfile {}",
                                                     display_path(target_lockfile_path)
@@ -1391,7 +1563,9 @@ impl Lock {
                                         }
                                     }
                                 };
-                                resolve_options.use_locked_version = false;
+                                if !Settings::get().generate_lockfiles() {
+                                    resolve_options.use_locked_version = false;
+                                }
                                 if resolve_options.before_date.is_some() {
                                     resolve_options.latest_versions = true;
                                 }
@@ -1403,7 +1577,8 @@ impl Lock {
                                         );
                                     }
                                     Err(err) => {
-                                        if active_unresolved {
+                                        if active_unresolved || Settings::get().generate_lockfiles()
+                                        {
                                             return Err(err.wrap_err(format!(
                                                 "failed to resolve {request} for lockfile {}",
                                                 display_path(target_lockfile_path)
@@ -1715,7 +1890,8 @@ impl Lock {
                     if let Some(msg) = &resolution_error {
                         debug!("{msg}");
                     }
-                    let error_is_fatal = resolution.8;
+                    let error_is_fatal =
+                        resolution.8 == crate::lockfile::LockResolutionStatus::Required;
                     pr.set_message(format!("{}@{} {}", short, version, platform_key));
                     pr.set_position(completed);
                     match lockfile::apply_lock_result(lockfile, resolution) {
@@ -1881,11 +2057,11 @@ mod tests {
             BTreeMap::new(),
             BTreeMap::new(),
             BTreeMap::new(),
-            true,
+            crate::lockfile::LockResolutionStatus::Required,
         );
         let mut lockfile = Lockfile::default();
         let resolution_error = resolution.4.as_ref().err().cloned();
-        let error_is_fatal = resolution.8;
+        let error_is_fatal = resolution.8 == crate::lockfile::LockResolutionStatus::Required;
 
         let applied = apply_lock_result(&mut lockfile, resolution).unwrap();
         let (status, returned_error) =
@@ -2195,7 +2371,7 @@ mod tests {
             BTreeMap::new(),
             BTreeMap::new(),
             BTreeMap::new(),
-            false,
+            crate::lockfile::LockResolutionStatus::Optional,
         );
 
         let applied = apply_lock_result(&mut lockfile, resolution).unwrap();

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -204,6 +204,19 @@ struct PreparedLockfileRollback {
     replacement: Option<crate::file::PreparedAtomicWrite>,
 }
 
+fn publication_lock_paths(
+    mutations: &BTreeSet<PathBuf>,
+    configs: &BTreeMap<PathBuf, Option<Vec<u8>>>,
+    lockfiles: &BTreeMap<PathBuf, Option<Vec<u8>>>,
+) -> BTreeSet<PathBuf> {
+    mutations
+        .iter()
+        .chain(configs.keys())
+        .chain(lockfiles.keys())
+        .cloned()
+        .collect()
+}
+
 fn verify_generation_snapshots<'a>(
     snapshots: impl Iterator<Item = (&'a PathBuf, &'a Option<Vec<u8>>)>,
 ) -> Result<()> {
@@ -785,7 +798,7 @@ impl Lock {
         if !self.dry_run && atomic {
             verify_generation_snapshots(config_snapshots.iter().chain(initial_lockfiles.iter()))?;
             let migration_paths = lockfile::monorepo_lockfile_migration_paths(&config);
-            let transaction_paths: BTreeSet<PathBuf> = staged_upgrade_writes
+            let mutation_paths: BTreeSet<PathBuf> = staged_upgrade_writes
                 .iter()
                 .map(|staged| staged.path.clone())
                 .chain(
@@ -799,6 +812,8 @@ impl Lock {
                         .flat_map(|(source, target)| [source.clone(), target.clone()]),
                 )
                 .collect();
+            let transaction_paths =
+                publication_lock_paths(&mutation_paths, &config_snapshots, &initial_lockfiles);
             let mut transaction_locks = Vec::with_capacity(transaction_paths.len());
             for path in &transaction_paths {
                 transaction_locks.push(
@@ -820,7 +835,8 @@ impl Lock {
                 }
             }
 
-            let snapshots = transaction_paths
+            // Read-only inputs need locks, but must never become rollback writes.
+            let snapshots = mutation_paths
                 .iter()
                 .map(|path| {
                     Ok(LockfileSnapshot {
@@ -1964,6 +1980,21 @@ mod tests {
     use std::fs;
     use std::str::FromStr;
     use std::sync::Arc;
+
+    #[test]
+    fn publication_locks_read_only_inputs_without_adding_rollback_targets() {
+        let mutations = std::collections::BTreeSet::from([std::path::PathBuf::from("mise.lock")]);
+        let configs = BTreeMap::from([
+            (std::path::PathBuf::from("mise.toml"), None),
+            (std::path::PathBuf::from("tasks/build"), None),
+        ]);
+        let lockfiles = BTreeMap::from([(std::path::PathBuf::from("legacy.lock"), None)]);
+        let locked = super::publication_lock_paths(&mutations, &configs, &lockfiles);
+        for path in ["mise.lock", "mise.toml", "tasks/build", "legacy.lock"] {
+            assert!(locked.contains(std::path::Path::new(path)));
+        }
+        assert_eq!(mutations.len(), 1);
+    }
 
     #[test]
     fn snapshot_recheck_detects_config_and_migration_edits_after_initial_check() {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -44,7 +44,7 @@ mod install_into;
 mod latest;
 mod link;
 mod local;
-mod lock;
+pub(crate) mod lock;
 mod ls;
 mod ls_remote;
 mod mcp;

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -191,7 +191,7 @@ impl Upgrade {
             unimplemented!("mise upgrade --monorepo is not implemented yet");
         }
         let mut config = Config::get().await?;
-        if !self.is_dry_run() {
+        if !self.is_dry_run() && !Settings::get().generate_lockfiles() {
             crate::lockfile::migrate_monorepo_lockfiles(&config, false)?;
         }
         let ts = ToolsetBuilder::new()

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -302,6 +302,9 @@ impl Use {
                             resolve_options.use_locked_version = false;
                         }
                         let mut tvr = tvr;
+                        if Settings::get().generate_lockfiles() {
+                            tvr.set_source(cf.source());
+                        }
                         if target.has_options() {
                             tvr.set_options(request_options);
                         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3866,7 +3866,20 @@ pub(crate) async fn rebuild_shims_and_runtime_symlinks(
         &changed_install_paths,
         lockfile_update_mode,
     )
-    .await
+    .await?;
+    if Settings::get().generate_lockfiles()
+        && Settings::get().lockfile_enabled()
+        && (!Settings::get().locked
+            || lockfile_update_mode == lockfile::LockfileUpdateMode::AllowLocked)
+    {
+        lockfile::generate::ensure_install_succeeded()?;
+        Box::pin(crate::cli::lock::Lock::generate_after_install(
+            config.clone(),
+            new_versions,
+        ))
+        .await?;
+    }
+    Ok(())
 }
 
 /// Reconcile runtime links and shim farms after versions have been removed.
@@ -3945,6 +3958,9 @@ async fn rebuild_shims_and_runtime_symlinks_for_changes(
                 .wrap_err("failed to rebuild system shims")?;
         }
     });
+    if Settings::get().generate_lockfiles() {
+        return Ok(());
+    }
     lockfile::migrate_monorepo_lockfiles(config, false)?;
     // Snapshot the lockfiles' platform keys BEFORE update_lockfiles writes
     // current-platform entries — auto-lock uses this to tell a curated lockfile

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -995,6 +995,7 @@ impl Settings {
         let mut settings = builder.load()?;
         normalize_storage_dirs(&mut settings)?;
         validate_settings_enum_values(&settings)?;
+        settings.validate_lockfile_mode()?;
         Ok(settings)
     }
 
@@ -1389,6 +1390,18 @@ impl Settings {
 
     pub(crate) fn lockfile_enabled(&self) -> bool {
         self.lockfile.unwrap_or(true)
+    }
+
+    pub(crate) fn generate_lockfiles(&self) -> bool {
+        self.lockfile_mode.as_deref() == Some("generate")
+    }
+
+    fn validate_lockfile_mode(&self) -> Result<()> {
+        validate_setting_enum_values(
+            "lockfile_mode",
+            self.lockfile_mode.as_deref(),
+            &["merge", "generate"],
+        )
     }
 
     pub(crate) fn lockfile_creation_enabled(&self) -> bool {
@@ -2015,6 +2028,19 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lockfile_mode_defaults_and_explicit_choices() {
+        let mut settings = Settings::default();
+        assert!(!settings.generate_lockfiles());
+        settings.lockfile_mode = Some("generate".into());
+        assert!(settings.generate_lockfiles());
+        settings.lockfile_mode = Some("merge".into());
+        assert!(!settings.generate_lockfiles());
+        assert!(settings.validate_lockfile_mode().is_ok());
+        settings.lockfile_mode = Some("invalid".into());
+        assert!(settings.validate_lockfile_mode().is_err());
+    }
 
     /// File-backed exclusions are inherited in low-to-high precedence order and deduplicated.
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,6 +9,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub(crate) enum Error {
+    #[error("{0}")]
+    UnsupportedTarget(String),
     #[error("[{ts}] {tr}: {source:#}")]
     FailedToResolveVersion {
         tr: Box<ToolRequest>,

--- a/src/github/sigstore.rs
+++ b/src/github/sigstore.rs
@@ -36,6 +36,28 @@ pub(crate) use mise_sigstore::{AttestationError, SlsaArtifact};
 /// Result alias that matches `mise_sigstore`'s internal convention.
 type AttestationResult<T> = std::result::Result<T, AttestationError>;
 
+type VerificationCell = std::sync::Arc<tokio::sync::OnceCell<bool>>;
+static INVOCATION_VERIFICATIONS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, VerificationCell>>,
+> = std::sync::LazyLock::new(Default::default);
+
+async fn shared_verification(
+    key: String,
+    verification: impl std::future::Future<Output = AttestationResult<bool>>,
+) -> AttestationResult<bool> {
+    let settings = crate::config::Settings::get();
+    if !settings.generate_lockfiles() || settings.force_provenance_verify() {
+        return verification.await;
+    }
+    let cell = INVOCATION_VERIFICATIONS
+        .lock()
+        .unwrap()
+        .entry(key)
+        .or_default()
+        .clone();
+    cell.get_or_try_init(|| verification).await.copied()
+}
+
 #[derive(Debug)]
 enum CachedAttestationVerification {
     Verified,
@@ -126,6 +148,43 @@ fn attestation_client(api_url: &str) -> AttestationResult<AttestationClient> {
 /// Applies configured URL replacements to the API base URL before dispatching to
 /// [`mise_sigstore::verify_github_attestation_with_base_url`].
 pub(crate) async fn verify_attestation(
+    artifact_path: &Path,
+    owner: &str,
+    repo: &str,
+    expected_workflow: Option<&str>,
+    api_url: Option<&str>,
+    use_versions_host: bool,
+) -> AttestationResult<bool> {
+    if !crate::config::Settings::get().generate_lockfiles() {
+        return verify_attestation_uncached(
+            artifact_path,
+            owner,
+            repo,
+            expected_workflow,
+            api_url,
+            use_versions_host,
+        )
+        .await;
+    }
+    let digest = mise_sigstore::calculate_file_digest(artifact_path).await?;
+    let key = format!(
+        "github:{owner}/{repo}:{digest}:{expected_workflow:?}:{api_url:?}:{use_versions_host}"
+    );
+    shared_verification(
+        key,
+        verify_attestation_uncached(
+            artifact_path,
+            owner,
+            repo,
+            expected_workflow,
+            api_url,
+            use_versions_host,
+        ),
+    )
+    .await
+}
+
+async fn verify_attestation_uncached(
     artifact_path: &Path,
     owner: &str,
     repo: &str,
@@ -381,7 +440,18 @@ pub(crate) async fn verify_slsa_provenance(
     min_level: u8,
 ) -> AttestationResult<bool> {
     mise_sigstore::set_tuf_url(routed_tuf_url());
-    mise_sigstore::verify_slsa_provenance(artifact_path, provenance_path, min_level).await
+    if !crate::config::Settings::get().generate_lockfiles() {
+        return mise_sigstore::verify_slsa_provenance(artifact_path, provenance_path, min_level)
+            .await;
+    }
+    let artifact_digest = mise_sigstore::calculate_file_digest(artifact_path).await?;
+    let provenance_digest = mise_sigstore::calculate_file_digest(provenance_path).await?;
+    let key = format!("slsa:{artifact_digest}:{provenance_digest}:{min_level}");
+    shared_verification(
+        key,
+        mise_sigstore::verify_slsa_provenance(artifact_path, provenance_path, min_level),
+    )
+    .await
 }
 
 pub(crate) async fn verify_slsa_provenance_artifacts(
@@ -407,7 +477,17 @@ pub(crate) async fn verify_cosign_signature(
     sig_or_bundle_path: &Path,
 ) -> AttestationResult<bool> {
     mise_sigstore::set_tuf_url(routed_tuf_url());
-    mise_sigstore::verify_cosign_signature(artifact_path, sig_or_bundle_path).await
+    if !crate::config::Settings::get().generate_lockfiles() {
+        return mise_sigstore::verify_cosign_signature(artifact_path, sig_or_bundle_path).await;
+    }
+    let artifact_digest = mise_sigstore::calculate_file_digest(artifact_path).await?;
+    let signature_digest = mise_sigstore::calculate_file_digest(sig_or_bundle_path).await?;
+    let key = format!("cosign:{artifact_digest}:{signature_digest}");
+    shared_verification(
+        key,
+        mise_sigstore::verify_cosign_signature(artifact_path, sig_or_bundle_path),
+    )
+    .await
 }
 
 /// Verify a Cosign signature against a public key. Passthrough — no token needed.

--- a/src/http.rs
+++ b/src/http.rs
@@ -208,6 +208,36 @@ static INVOCATION_DOWNLOADS: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<String, SharedDownload>>,
 > = std::sync::LazyLock::new(Default::default);
 
+// Bound retained scratch space, excluding transfers still borrowed by callers.
+// Active transfers are bounded by their callers' jobs limit and remain shared.
+fn prune_shared_downloads(
+    downloads: &mut std::collections::HashMap<String, SharedDownload>,
+    max_bytes: u64,
+    max_entries: usize,
+) {
+    let size = |entry: &SharedDownload| {
+        entry
+            .get()
+            .and_then(|(directory, _)| {
+                std::fs::metadata(directory.path().join("artifact"))
+                    .ok()
+                    .map(|m| m.len())
+            })
+            .unwrap_or(0)
+    };
+    let mut bytes: u64 = downloads.values().map(size).sum();
+    let mut count = downloads.len();
+    downloads.retain(|_, entry| {
+        if (bytes > max_bytes || count > max_entries) && Arc::strong_count(entry) == 1 {
+            bytes = bytes.saturating_sub(size(entry));
+            count -= 1;
+            false
+        } else {
+            true
+        }
+    });
+}
+
 /// Own temporary shared artifacts for this command, including cancellation paths.
 pub(crate) struct InvocationDownloads;
 
@@ -900,8 +930,23 @@ impl Client {
             if let Some(parent) = path.parent() {
                 file::create_dir_all(parent)?;
             }
-            file::copy(directory.path().join("artifact"), path)?;
-            return Ok(metadata.clone());
+            let partial = PartialDownload::new(path, download_request_hash(&url, headers))?;
+            let lock_path = partial.path.clone();
+            let _download_lock = tokio::task::spawn_blocking(move || {
+                crate::lock_file::LockFile::new(&lock_path).lock()
+            })
+            .await??;
+            partial.clear()?;
+            file::copy(directory.path().join("artifact"), &partial.path)?;
+            partial.persist(path)?;
+            let metadata = metadata.clone();
+            drop(shared);
+            prune_shared_downloads(
+                &mut INVOCATION_DOWNLOADS.lock().unwrap(),
+                512 * 1024 * 1024,
+                64,
+            );
+            return Ok(metadata);
         }
         self.download_file_with_headers_timeout(
             url,
@@ -2558,10 +2603,48 @@ mod tests {
         a.unwrap();
         b.unwrap();
         assert_eq!(
+            std::fs::read(&first).unwrap(),
+            std::fs::read(&second).unwrap()
+        );
+        let (a, b) = tokio::join!(
+            client.download_file(&url, &first, None),
+            client.download_file(&url, &first, None)
+        );
+        a.unwrap();
+        b.unwrap();
+        assert_eq!(
             std::fs::read(first).unwrap(),
             std::fs::read(second).unwrap()
         );
         assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn shared_download_retention_evicts_idle_bytes_but_never_active_callers() {
+        let make_entry = || {
+            let directory = tempfile::tempdir().unwrap();
+            std::fs::write(directory.path().join("artifact"), b"1234").unwrap();
+            Arc::new(tokio::sync::OnceCell::new_with(Some((
+                directory,
+                DownloadFileMetadata::default(),
+            ))))
+        };
+        let active = make_entry();
+        let idle = make_entry();
+        let idle_path = idle.get().unwrap().0.path().to_path_buf();
+        let mut downloads = std::collections::HashMap::from([
+            ("active".into(), active.clone()),
+            ("idle".into(), idle),
+        ]);
+        prune_shared_downloads(&mut downloads, 4, 64);
+        assert_eq!(downloads.len(), 1);
+        assert!(downloads.contains_key("active"));
+        assert!(!idle_path.exists());
+        prune_shared_downloads(&mut downloads, 0, 0);
+        assert_eq!(downloads.len(), 1);
+        drop(active);
+        prune_shared_downloads(&mut downloads, 0, 0);
+        assert!(downloads.is_empty());
     }
 
     struct AtomicBoolGuard {

--- a/src/http.rs
+++ b/src/http.rs
@@ -202,6 +202,21 @@ pub(crate) struct DownloadFileMetadata {
     pub(crate) effective_filename: Option<String>,
 }
 
+type SharedDownload =
+    std::sync::Arc<tokio::sync::OnceCell<(tempfile::TempDir, DownloadFileMetadata)>>;
+static INVOCATION_DOWNLOADS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, SharedDownload>>,
+> = std::sync::LazyLock::new(Default::default);
+
+/// Own temporary shared artifacts for this command, including cancellation paths.
+pub(crate) struct InvocationDownloads;
+
+impl Drop for InvocationDownloads {
+    fn drop(&mut self) {
+        INVOCATION_DOWNLOADS.lock().unwrap().clear();
+    }
+}
+
 fn download_filename_hint(url: &Url) -> Option<String> {
     let segment = url.path_segments()?.next_back()?;
     let filename = urlencoding::decode(segment).ok()?.into_owned();
@@ -858,6 +873,36 @@ impl Client {
         headers: &HeaderMap,
         pr: Option<&dyn SingleReport>,
     ) -> Result<DownloadFileMetadata> {
+        let url = url.into_url()?;
+        if Settings::get().generate_lockfiles() {
+            let key = format!("{:p}:{}", self, download_request_hash(&url, headers));
+            let shared = INVOCATION_DOWNLOADS
+                .lock()
+                .unwrap()
+                .entry(key)
+                .or_default()
+                .clone();
+            let (directory, metadata) = shared
+                .get_or_try_init(|| async {
+                    let directory = tempfile::tempdir()?;
+                    let metadata = self
+                        .download_file_with_headers_timeout(
+                            url.clone(),
+                            &directory.path().join("artifact"),
+                            headers,
+                            pr,
+                            Settings::get().http_download_timeout(),
+                        )
+                        .await?;
+                    Ok::<_, eyre::Report>((directory, metadata))
+                })
+                .await?;
+            if let Some(parent) = path.parent() {
+                file::create_dir_all(parent)?;
+            }
+            file::copy(directory.path().join("artifact"), path)?;
+            return Ok(metadata.clone());
+        }
         self.download_file_with_headers_timeout(
             url,
             path,
@@ -2490,6 +2535,33 @@ mod tests {
         settings.offline = Some(true);
         crate::config::Settings::reset(Some(settings));
         SettingsGuard { _lock: lock }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_generation_shares_concurrent_artifact_downloads() {
+        let lock = crate::test::lock_ignoring_poison(&TEST_SETTINGS_LOCK);
+        let mut settings = crate::config::settings::SettingsPartial::empty();
+        settings.lockfile_mode = Some("generate".into());
+        crate::config::Settings::reset(Some(settings));
+        let _settings = SettingsGuard { _lock: lock };
+        let _downloads = InvocationDownloads;
+        let (port, count) = spawn_canned_server(vec![ok_response()]).await;
+        let url = format!("http://127.0.0.1:{port}/artifact");
+        let client = Client::new(Duration::from_secs(2), ClientKind::Http).unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("first");
+        let second = temp.path().join("second");
+        let (a, b) = tokio::join!(
+            client.download_file(&url, &first, None),
+            client.download_file(&url, &second, None)
+        );
+        a.unwrap();
+        b.unwrap();
+        assert_eq!(
+            std::fs::read(first).unwrap(),
+            std::fs::read(second).unwrap()
+        );
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 
     struct AtomicBoolGuard {

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,3 +1,5 @@
+pub(crate) mod generate;
+
 use crate::backend::Backend;
 use crate::backend::backend_type::BackendType;
 use crate::backend::conda::CondaBackend;
@@ -268,26 +270,20 @@ pub(crate) enum GithubAttestationsStatus {
     Unavailable,
 }
 
-fn is_false(value: &bool) -> bool {
-    !*value
-}
-
 fn merge_provenance_state(
     current: Option<ProvenanceType>,
-    current_verified: bool,
+    current_verified: Option<bool>,
     other: Option<ProvenanceType>,
-    other_verified: bool,
-) -> (Option<ProvenanceType>, bool) {
+    other_verified: Option<bool>,
+) -> (Option<ProvenanceType>, Option<bool>) {
     match (current, other) {
-        (Some(current), Some(_)) if current_verified && !other_verified => (Some(current), true),
-        (Some(_), Some(other)) if !current_verified && other_verified => (Some(other), true),
         (Some(current), Some(other)) => (
             Some(current.merge(other)),
-            current_verified && other_verified,
+            current_verified.or(other_verified),
         ),
         (Some(current), None) => (Some(current), current_verified),
         (None, Some(other)) => (Some(other), other_verified),
-        (None, None) => (None, false),
+        (None, None) => (None, current_verified.or(other_verified)),
     }
 }
 
@@ -303,14 +299,14 @@ pub(crate) struct ArtifactInfo {
     pub url_api: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provenance: Option<ProvenanceType>,
-    /// Whether `provenance` was cryptographically verified for this artifact.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub provenance_verified: bool,
+    /// Opaque legacy metadata, preserved only to avoid churn with older clients.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance_verified: Option<bool>,
 }
 
 impl ArtifactInfo {
-    pub(crate) fn has_checksum_and_verified_provenance(&self) -> bool {
-        self.checksum.is_some() && self.provenance.is_some() && self.provenance_verified
+    pub(crate) fn has_checksum_and_provenance(&self) -> bool {
+        self.checksum.is_some() && self.provenance.is_some()
     }
 
     fn merge_with(&self, other: &ArtifactInfo) -> ArtifactInfo {
@@ -391,9 +387,9 @@ pub(crate) struct PlatformInfo {
     /// Type of provenance detected or verified (SLSA carries its URL).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provenance: Option<ProvenanceType>,
-    /// Whether `provenance` was cryptographically verified for this platform.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub provenance_verified: bool,
+    /// Opaque legacy metadata, preserved only to avoid churn with older clients.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance_verified: Option<bool>,
     /// GitHub attestation probe status when no provenance was verified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub github_attestations: Option<GithubAttestationsStatus>,
@@ -436,7 +432,7 @@ impl PlatformInfo {
             && self.pkgx_provides.is_none()
             && self.pkgx_runtime_env.is_none()
             && self.provenance.is_none()
-            && !self.provenance_verified
+            && self.provenance_verified.is_none()
             && self.signer.is_none()
             && self.attested_by.is_none()
             && self.additional_artifacts.is_empty()
@@ -458,7 +454,7 @@ impl PlatformInfo {
             url: None,
             url_api: None,
             provenance: None,
-            provenance_verified: false,
+            provenance_verified: None,
             github_attestations: None,
             // The signer describes the release, not the artifact, so it stays.
             signer: self.signer.clone(),
@@ -468,8 +464,8 @@ impl PlatformInfo {
     }
 
     /// True when the lockfile has checksum-backed, successfully verified provenance.
-    pub(crate) fn has_checksum_and_verified_provenance(&self) -> bool {
-        self.checksum.is_some() && self.provenance.is_some() && self.provenance_verified
+    pub(crate) fn has_checksum_and_provenance(&self) -> bool {
+        self.checksum.is_some() && self.provenance.is_some()
     }
 
     /// Merge this PlatformInfo with another, preserving important data.
@@ -684,11 +680,9 @@ impl TryFrom<toml::Value> for PlatformInfo {
                     }
                     _ => None,
                 };
-                let provenance_verified = provenance.is_some()
-                    && matches!(
-                        t.remove("provenance_verified"),
-                        Some(toml::Value::Boolean(true))
-                    );
+                let provenance_verified = t
+                    .remove("provenance_verified")
+                    .and_then(|value| value.as_bool());
                 let github_attestations = if provenance.is_some() {
                     None
                 } else {
@@ -810,8 +804,8 @@ impl From<PlatformInfo> for toml::Value {
                 }
             }
         }
-        if platform_info.provenance_verified {
-            table.insert("provenance_verified".to_string(), true.into());
+        if let Some(value) = platform_info.provenance_verified {
+            table.insert("provenance_verified".to_string(), value.into());
         }
         if let Some(signer) = platform_info.signer {
             table.insert("signer".to_string(), signer.into());
@@ -1079,7 +1073,13 @@ impl Lockfile {
     }
 
     fn save<P: AsRef<Path>>(&self, path: P) -> Result<()> {
-        let path = path.as_ref();
+        if let Some(prepared) = self.prepare_write(path.as_ref())? {
+            prepared.publish()?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn prepare_write(&self, path: &Path) -> Result<Option<PreparedWrite>> {
         let mut lockfile = toml::Table::new();
 
         if self.lockfile_version > 0 {
@@ -1163,6 +1163,9 @@ impl Lockfile {
             .or_else(|| existing_lockfile_doc_url_from_path(path))
             .unwrap_or_else(|| DEFAULT_LOCKFILE_DOC_URL.to_string());
         let content = format!("{LOCKFILE_HEADER_PREFIX}{doc_url}\n\n{content}");
+        if fs::read(path).ok().as_deref() == Some(content.as_bytes()) {
+            return Ok(None);
+        }
 
         // Resolve the symlink target first, before writing the temp file
         let target = if path.is_symlink() {
@@ -1210,10 +1213,8 @@ impl Lockfile {
         let mut tmp = tempfile::NamedTempFile::with_prefix_in(".mise.lock.", parent)?;
         tmp.as_file_mut().write_all(content.as_bytes())?;
         apply_lockfile_permissions(&tmp, &target)?;
-        persist_lockfile_tmp(tmp, &target)?;
-
-        invalidate_caches();
-        Ok(())
+        tmp.as_file().sync_all()?;
+        Ok(Some(PreparedWrite { tmp, target }))
     }
 
     /// Add or update a conda package in the shared section
@@ -1543,6 +1544,19 @@ impl Lockfile {
     }
 }
 
+pub(crate) struct PreparedWrite {
+    tmp: tempfile::NamedTempFile,
+    target: PathBuf,
+}
+
+impl PreparedWrite {
+    pub(crate) fn publish(self) -> Result<()> {
+        persist_lockfile_tmp(self.tmp, &self.target)?;
+        invalidate_caches();
+        Ok(())
+    }
+}
+
 /// Determines the lockfile path for a given config file path
 /// Returns (lockfile_path, is_local)
 ///
@@ -1685,7 +1699,7 @@ pub(crate) fn migrate_monorepo_lockfiles(
     config: &Config,
     allow_format_upgrade: bool,
 ) -> Result<()> {
-    migrate_monorepo_lockfiles_inner(config, allow_format_upgrade, true, None)
+    migrate_monorepo_lockfiles_inner(config, allow_format_upgrade, true, None, None)
 }
 
 pub(crate) fn monorepo_lockfile_migration_paths(config: &Config) -> Vec<(PathBuf, PathBuf)> {
@@ -1706,8 +1720,15 @@ pub(crate) fn migrate_monorepo_lockfiles_already_locked(
     config: &Config,
     allow_format_upgrade: bool,
     migration_paths: &[(PathBuf, PathBuf)],
+    generated_targets: Option<&BTreeSet<PathBuf>>,
 ) -> Result<()> {
-    migrate_monorepo_lockfiles_inner(config, allow_format_upgrade, false, Some(migration_paths))
+    migrate_monorepo_lockfiles_inner(
+        config,
+        allow_format_upgrade,
+        false,
+        Some(migration_paths),
+        generated_targets,
+    )
 }
 
 fn migrate_monorepo_lockfiles_inner(
@@ -1715,6 +1736,7 @@ fn migrate_monorepo_lockfiles_inner(
     allow_format_upgrade: bool,
     acquire_target_locks: bool,
     migration_paths: Option<&[(PathBuf, PathBuf)]>,
+    generated_targets: Option<&BTreeSet<PathBuf>>,
 ) -> Result<()> {
     if !Settings::get().lockfile_enabled() {
         return Ok(());
@@ -1734,6 +1756,11 @@ fn migrate_monorepo_lockfiles_inner(
     };
     for (source, target) in migration_paths {
         if !source.exists() {
+            continue;
+        }
+        if generated_targets.is_some_and(|targets| targets.contains(target)) {
+            fs::remove_file(source)?;
+            migrated += 1;
             continue;
         }
         let _lock = acquire_target_locks
@@ -2408,7 +2435,7 @@ fn prune_verified_provenance_baselines(
         let verified_here = |tool: &LockfileTool| {
             tool.platforms
                 .get(platform_key)
-                .is_some_and(|info| info.provenance.is_some() && info.provenance_verified)
+                .is_some_and(|info| info.provenance.is_some())
         };
         // The baseline the deferred regression check for `tool` compares against, as
         // `check_provenance_regression` computes it for a not-yet-verified entry.
@@ -2999,6 +3026,13 @@ fn deferred_provenance_resolution_error(
 /// The `info_or_error` field is `Ok(info)` on success or `Err(message)` on failure,
 /// allowing callers to log at the appropriate level. `error_is_fatal` distinguishes
 /// genuine conda solve failures from backends that use errors to skip unsupported targets.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LockResolutionStatus {
+    Optional,
+    Required,
+    Unsupported,
+}
+
 pub(crate) type LockResolutionResult = (
     String,
     String,
@@ -3008,7 +3042,7 @@ pub(crate) type LockResolutionResult = (
     BTreeMap<String, String>,
     BTreeMap<String, CondaPackageInfo>,
     BTreeMap<String, PkgxPackageInfo>,
-    bool,
+    LockResolutionStatus,
 );
 
 /// Resolve lock info for a single tool/platform combination.
@@ -3023,9 +3057,14 @@ pub(crate) async fn resolve_tool_lock_info(
     backend: Option<crate::backend::ABackend>,
 ) -> LockResolutionResult {
     let target = PlatformTarget::new(platform.clone());
-    let error_is_fatal = backend
+    let mut error_is_fatal = if backend
         .as_ref()
-        .is_some_and(|backend| backend.get_type() == BackendType::Conda);
+        .is_some_and(|backend| backend.get_type() == BackendType::Conda)
+    {
+        LockResolutionStatus::Required
+    } else {
+        LockResolutionStatus::Optional
+    };
 
     let (info, options, conda_packages, pkgx_packages) = if let Some(backend) = backend {
         let options = match backend.resolve_lockfile_options(&tv.request, &target) {
@@ -3104,6 +3143,20 @@ pub(crate) async fn resolve_tool_lock_info(
                     BTreeMap::new()
                 };
                 (Ok(info), options, conda_packages, pkgx_packages)
+            }
+            Err(e)
+                if matches!(
+                    e.downcast_ref::<crate::errors::Error>(),
+                    Some(crate::errors::Error::UnsupportedTarget(_))
+                ) =>
+            {
+                error_is_fatal = LockResolutionStatus::Unsupported;
+                (
+                    Err(e.to_string()),
+                    options,
+                    BTreeMap::new(),
+                    BTreeMap::new(),
+                )
             }
             Err(e) => (
                 Err(format!(
@@ -4431,7 +4484,7 @@ mod tests {
             BTreeMap::new(),
             BTreeMap::new(),
             BTreeMap::new(),
-            false,
+            crate::lockfile::LockResolutionStatus::Optional,
         );
 
         assert!(!apply_lock_result(&mut lockfile, result).unwrap());
@@ -4461,7 +4514,7 @@ mod tests {
             BTreeMap::new(),
             BTreeMap::new(),
             BTreeMap::new(),
-            false,
+            crate::lockfile::LockResolutionStatus::Optional,
         );
 
         assert!(!apply_lock_result(&mut lockfile, result).unwrap());
@@ -4991,7 +5044,7 @@ options = { exe = "rg" }
             PlatformInfo {
                 url: Some(format!("https://example.com/repo-{version}.tar.gz")),
                 provenance: Some(ProvenanceType::GithubAttestations),
-                provenance_verified: true,
+                provenance_verified: Some(true),
                 ..Default::default()
             },
         );
@@ -5052,17 +5105,19 @@ options = { exe = "rg" }
         assert!(prune_verified_provenance_baselines(&mut tools, &requested, &platform).is_empty());
         assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0", "0.11.0"]);
 
-        // Provenance detected but never cryptographically verified on this platform, as
-        // when another platform's `mise lock` populated the entry: not good enough.
+        // Recorded provenance is authoritative regardless of the legacy bit.
         let mut detected_only = verified_github_tool("0.12.0", &platform);
         detected_only
             .platforms
             .get_mut(&platform)
             .unwrap()
-            .provenance_verified = false;
+            .provenance_verified = None;
         let mut tools = vec![detected_only, verified_github_tool("0.11.0", &platform)];
-        assert!(prune_verified_provenance_baselines(&mut tools, &requested, &platform).is_empty());
-        assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0", "0.11.0"]);
+        assert_eq!(
+            prune_verified_provenance_baselines(&mut tools, &requested, &platform),
+            vec!["0.11.0"]
+        );
+        assert_eq!(lockfile_tool_versions(&tools), vec!["0.12.0"]);
 
         // Two option variants of the requested version, only one verified: the other
         // still relies on the baseline for its deferred check.
@@ -6244,7 +6299,7 @@ backend = "conda:jq"
             provenance: Some(ProvenanceType::Slsa {
                 url: Some("https://example.com/tool.intoto.jsonl".to_string()),
             }),
-            provenance_verified: true,
+            provenance_verified: Some(true),
             ..Default::default()
         };
 
@@ -6263,7 +6318,7 @@ backend = "conda:jq"
         );
         let parsed: PlatformInfo = toml_val.try_into().unwrap();
         assert!(parsed.provenance.as_ref().unwrap().is_slsa());
-        assert!(parsed.provenance_verified);
+        assert_eq!(parsed.provenance_verified, Some(true));
         match &parsed.provenance {
             Some(ProvenanceType::Slsa { url }) => {
                 assert_eq!(
@@ -6285,7 +6340,7 @@ backend = "conda:jq"
                     checksum: Some("sha256:rocm".to_string()),
                     url: "https://example.com/tool-rocm.tar.gz".to_string(),
                     provenance: Some(ProvenanceType::GithubAttestations),
-                    provenance_verified: true,
+                    provenance_verified: Some(true),
                     ..Default::default()
                 },
                 ArtifactInfo {
@@ -6430,7 +6485,7 @@ backend = "conda:jq"
             Some(GithubAttestationsStatus::Unavailable)
         );
         assert!(parsed.provenance.is_none());
-        assert!(!parsed.has_checksum_and_verified_provenance());
+        assert!(!parsed.has_checksum_and_provenance());
     }
 
     #[test]
@@ -6443,16 +6498,16 @@ backend = "conda:jq"
         let parsed: PlatformInfo = toml::Value::Table(table.clone()).try_into().unwrap();
         assert!(parsed.provenance.as_ref().unwrap().is_slsa());
         assert!(parsed.github_attestations.is_none());
-        assert!(!parsed.has_checksum_and_verified_provenance());
+        assert!(parsed.has_checksum_and_provenance());
 
         table.insert("provenance_verified".to_string(), true.into());
         let parsed: PlatformInfo = toml::Value::Table(table).try_into().unwrap();
-        assert!(parsed.has_checksum_and_verified_provenance());
+        assert!(parsed.has_checksum_and_provenance());
 
         let serialized: toml::Value = PlatformInfo {
             checksum: Some("sha256:abc123".to_string()),
             provenance: Some(ProvenanceType::GithubAttestations),
-            provenance_verified: true,
+            provenance_verified: Some(true),
             github_attestations: Some(GithubAttestationsStatus::Unavailable),
             ..Default::default()
         }
@@ -6467,19 +6522,19 @@ backend = "conda:jq"
     }
 
     #[test]
-    fn test_detected_cross_platform_provenance_is_not_verified() {
+    fn test_recorded_provenance_trust_ignores_legacy_bit() {
         let detected = PlatformInfo {
             checksum: Some("sha256:detected".to_string()),
             provenance: Some(ProvenanceType::GithubAttestations),
             ..Default::default()
         };
-        assert!(!detected.has_checksum_and_verified_provenance());
+        assert!(detected.has_checksum_and_provenance());
 
         let verified = PlatformInfo {
-            provenance_verified: true,
+            provenance_verified: Some(false),
             ..detected.clone()
         };
-        assert!(verified.has_checksum_and_verified_provenance());
+        assert!(verified.has_checksum_and_provenance());
 
         let detected_artifact = ArtifactInfo {
             checksum: detected.checksum,
@@ -6487,13 +6542,13 @@ backend = "conda:jq"
             provenance: detected.provenance,
             ..Default::default()
         };
-        assert!(!detected_artifact.has_checksum_and_verified_provenance());
+        assert!(detected_artifact.has_checksum_and_provenance());
 
         let verified_artifact = ArtifactInfo {
-            provenance_verified: true,
+            provenance_verified: Some(false),
             ..detected_artifact
         };
-        assert!(verified_artifact.has_checksum_and_verified_provenance());
+        assert!(verified_artifact.has_checksum_and_provenance());
     }
 
     #[test]
@@ -6502,12 +6557,12 @@ backend = "conda:jq"
         let detected = Some(ProvenanceType::Slsa { url: None });
 
         assert_eq!(
-            merge_provenance_state(verified.clone(), true, detected.clone(), false),
-            (verified.clone(), true)
+            merge_provenance_state(verified.clone(), Some(true), detected.clone(), None),
+            (verified.clone(), Some(true))
         );
         assert_eq!(
-            merge_provenance_state(detected, false, verified.clone(), true),
-            (verified, true)
+            merge_provenance_state(detected, None, verified.clone(), Some(true)),
+            (verified, Some(true))
         );
     }
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -3182,7 +3182,7 @@ pub(crate) async fn resolve_tool_lock_info(
     (
         ba.short.clone(),
         tv.version.clone(),
-        ba.full(),
+        ba.stored_full(),
         platform,
         info,
         options,

--- a/src/lockfile/generate.rs
+++ b/src/lockfile/generate.rs
@@ -195,24 +195,43 @@ pub(crate) async fn prepare_install(config: &Config, tv: &ToolVersion) -> Result
     Ok(())
 }
 
+fn resolution_key(
+    ba: &crate::cli::args::BackendArg,
+    tv: &ToolVersion,
+    platform: &Platform,
+) -> String {
+    let mut options = tv.request.options().clone();
+    options.opts.values.sort_keys();
+    options.core.install_env.sort_keys();
+    let mut install_env = tv.install_env();
+    install_env.sort_keys();
+    format!(
+        "{}\n{}\n{:?}\n{:?}\n{}",
+        ba.full(),
+        tv.version,
+        options,
+        install_env,
+        platform.to_key()
+    )
+}
+
 async fn resolve(
     ba: crate::cli::args::BackendArg,
     tv: ToolVersion,
     platform: Platform,
 ) -> Result<LockResolutionResult> {
-    let key = format!(
-        "{}\n{}\n{:?}\n{:?}\n{}",
-        ba.full(),
-        tv.version,
-        tv.request.options(),
-        tv.install_env(),
-        platform.to_key()
-    );
+    let key = resolution_key(&ba, &tv, &platform);
     let cell = RESOLUTIONS.lock().unwrap().entry(key).or_default().clone();
     Ok(cell
         .get_or_init(|| async {
             let backend = tv.backend().ok();
-            resolve_tool_lock_info(ba, tv, platform, backend).await
+            let mut resolution = resolve_tool_lock_info(ba, tv, platform, backend).await;
+            if let Ok(info) = &mut resolution.4
+                && let Err(error) = complete_artifact_checksums(info).await
+            {
+                resolution.4 = Err(error.to_string());
+            }
+            resolution
         })
         .await
         .clone())
@@ -348,18 +367,7 @@ pub(crate) async fn generate(
                 resolve(ba, tv.clone(), platform).await?
             };
             if let Ok(info) = &mut resolution.4 {
-                if info.checksum.is_none()
-                    && let Some(url) = &info.url
-                {
-                    info.checksum = Some(artifact_checksum(url, info.url_api.as_deref()).await?);
-                }
-                for artifact in &mut info.additional_artifacts {
-                    if artifact.checksum.is_none() {
-                        artifact.checksum = Some(
-                            artifact_checksum(&artifact.url, artifact.url_api.as_deref()).await?,
-                        );
-                    }
-                }
+                complete_artifact_checksums(info).await?;
                 if let Some(old) = previous_info {
                     preserve_legacy_metadata(&old, info);
                 }
@@ -532,6 +540,21 @@ impl Drop for ProgressGuard<'_> {
     }
 }
 
+async fn complete_artifact_checksums(info: &mut PlatformInfo) -> Result<()> {
+    if info.checksum.is_none()
+        && let Some(url) = &info.url
+    {
+        info.checksum = Some(artifact_checksum(url, info.url_api.as_deref()).await?);
+    }
+    for artifact in &mut info.additional_artifacts {
+        if artifact.checksum.is_none() {
+            artifact.checksum =
+                Some(artifact_checksum(&artifact.url, artifact.url_api.as_deref()).await?);
+        }
+    }
+    Ok(())
+}
+
 async fn artifact_checksum(url: &str, api_url: Option<&str>) -> Result<String> {
     let temp = tempfile::tempdir()?;
     let path = temp.path().join("artifact");
@@ -634,6 +657,35 @@ mod tests {
         let tv = ToolVersion::new(request, "1.0".into());
         let result = resolve_tool_lock_info(ba.clone(), tv, Platform::current(), None).await;
         assert_eq!(result.2, ba.stored_full());
+    }
+
+    #[test]
+    fn resolution_keys_ignore_option_and_environment_insertion_order() {
+        let ba = BackendArg::new("fixture".into(), Some("http:fixture".into()));
+        let version = |keys: [&str; 2]| {
+            let mut options = ToolVersionOptions::default();
+            for key in keys {
+                options
+                    .opts
+                    .insert(key.into(), toml::Value::String(key.into()));
+                options.core.install_env.insert(
+                    key.into(),
+                    crate::config::env_directive::EnvValue::String(key.into()),
+                );
+            }
+            let request = ToolRequest::new_with_options(
+                Arc::new(ba.clone()),
+                "1",
+                options,
+                ToolSource::Argument,
+            )
+            .unwrap();
+            ToolVersion::new(request, "1.0".into())
+        };
+        assert_eq!(
+            resolution_key(&ba, &version(["a", "b"]), &Platform::current()),
+            resolution_key(&ba, &version(["b", "a"]), &Platform::current()),
+        );
     }
 
     #[tokio::test]

--- a/src/lockfile/generate.rs
+++ b/src/lockfile/generate.rs
@@ -465,13 +465,20 @@ fn ensure_no_downgrade(old: &PlatformInfo, new: &PlatformInfo) -> Result<()> {
             "lockfile generation would change the recorded signer; previous files were preserved"
         );
     }
-    for (index, artifact) in old.additional_artifacts.iter().enumerate() {
-        if new
+    // Preserve identities across reordering, then pair replaced URLs in their
+    // configured order so version upgrades retain the previous trust baseline.
+    let mut replacements = new.additional_artifacts.iter().filter(|artifact| {
+        !old.additional_artifacts
+            .iter()
+            .any(|old| old.url == artifact.url)
+    });
+    for artifact in &old.additional_artifacts {
+        let replacement = new
             .additional_artifacts
-            .get(index)
-            .and_then(|a| a.provenance.as_ref())
-            < artifact.provenance.as_ref()
-        {
+            .iter()
+            .find(|new| new.url == artifact.url)
+            .or_else(|| replacements.next());
+        if replacement.and_then(|a| a.provenance.as_ref()) < artifact.provenance.as_ref() {
             bail!(
                 "lockfile generation would downgrade additional artifact provenance; previous files were preserved"
             );
@@ -870,5 +877,32 @@ mod tests {
             ..Default::default()
         };
         assert!(ensure_no_downgrade(&old, &PlatformInfo::default()).is_err());
+    }
+
+    #[test]
+    fn additional_artifact_reordering_preserves_identity_and_upgrade_policy() {
+        let old = PlatformInfo {
+            additional_artifacts: vec![
+                ArtifactInfo {
+                    url: "https://example.com/verified-v1".into(),
+                    provenance: Some(ProvenanceType::GithubAttestations),
+                    ..Default::default()
+                },
+                ArtifactInfo {
+                    url: "https://example.com/checksum-only".into(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let mut new = old.clone();
+        new.additional_artifacts.reverse();
+        assert!(ensure_no_downgrade(&old, &new).is_ok());
+        new.additional_artifacts[1].url = "https://example.com/verified-v2".into();
+        assert!(ensure_no_downgrade(&old, &new).is_ok());
+        new.additional_artifacts[1].provenance = None;
+        assert!(ensure_no_downgrade(&old, &new).is_err());
+        new.additional_artifacts.pop();
+        assert!(ensure_no_downgrade(&old, &new).is_err());
     }
 }

--- a/src/lockfile/generate.rs
+++ b/src/lockfile/generate.rs
@@ -623,7 +623,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fresh_resolution_uses_the_same_backend_identity_as_reuse() {
+        crate::backend::load_tools().await.unwrap();
+        let ba = BackendArg::new(
+            "fixture".into(),
+            Some("http:fixture[rename_exe=fixture]".into()),
+        );
+        assert_ne!(ba.full(), ba.stored_full());
+        let request = ToolRequest::new(Arc::new(ba.clone()), "1.0", ToolSource::Argument).unwrap();
+        let tv = ToolVersion::new(request, "1.0".into());
+        let result = resolve_tool_lock_info(ba.clone(), tv, Platform::current(), None).await;
+        assert_eq!(result.2, ba.stored_full());
+    }
+
+    #[tokio::test]
     async fn actual_source_fallback_wins_over_reusable_binary_metadata() {
+        crate::backend::load_tools().await.unwrap();
         let (ba, mut actual) = tool();
         let platform = Platform::current();
         actual.lock_platforms.insert(
@@ -652,6 +667,7 @@ mod tests {
 
     #[tokio::test]
     async fn unsupported_target_is_skipped_without_an_empty_entry() {
+        crate::backend::load_tools().await.unwrap();
         let generated = generate(
             &Lockfile::default(),
             &[tool()],
@@ -668,6 +684,7 @@ mod tests {
 
     #[tokio::test]
     async fn unchanged_entries_reuse_metadata_without_network_and_are_stable() {
+        crate::backend::load_tools().await.unwrap();
         let old = previous();
         let platforms = vec![
             Platform::parse("linux-x64").unwrap(),
@@ -685,6 +702,7 @@ mod tests {
 
     #[tokio::test]
     async fn filtered_platform_carries_other_platform_forward() {
+        crate::backend::load_tools().await.unwrap();
         let old = previous();
         let generated = generate(
             &old,
@@ -702,6 +720,7 @@ mod tests {
 
     #[tokio::test]
     async fn fresh_generation_drops_obsolete_tools_but_filter_keeps_them() {
+        crate::backend::load_tools().await.unwrap();
         let old = previous();
         let empty = generate(&old, &[], &[], false, false, 1, &[])
             .await
@@ -736,6 +755,7 @@ mod tests {
 
     #[tokio::test]
     async fn erlang_keeps_distinct_linux_and_macos_options() {
+        crate::backend::load_tools().await.unwrap();
         let ba = BackendArg::new("erlang".into(), Some("core:erlang".into()));
         let request = ToolRequest::new_with_options(
             Arc::new(ba.clone()),

--- a/src/lockfile/generate.rs
+++ b/src/lockfile/generate.rs
@@ -1,0 +1,802 @@
+//! Generate selected scope from requests with an immutable previous lockfile.
+use super::*;
+use crate::ui::multi_progress_report::MultiProgressReport;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static INSTALL_FAILED: AtomicBool = AtomicBool::new(false);
+static INSTALL_FAILURE_DETAIL: Lazy<Mutex<Option<String>>> = Lazy::new(Default::default);
+type ResolutionCell = Arc<tokio::sync::OnceCell<LockResolutionResult>>;
+static RESOLUTIONS: Lazy<Mutex<HashMap<String, ResolutionCell>>> = Lazy::new(Default::default);
+static PREPARE_SLOTS: Lazy<Semaphore> = Lazy::new(|| Semaphore::new(1));
+
+#[derive(Default)]
+pub(crate) struct PreparationBatch {
+    tasks: Mutex<JoinSet<(crate::toolset::ToolRequest, Result<()>)>>,
+    pending: Mutex<Vec<(Arc<Config>, ToolVersion)>>,
+    requests: Mutex<HashMap<tokio::task::Id, crate::toolset::ToolRequest>>,
+    snapshots: Mutex<BTreeMap<PathBuf, InstallSnapshot>>,
+}
+
+struct InstallSnapshot {
+    request: crate::toolset::ToolRequest,
+    content: Option<Vec<u8>>,
+}
+
+fn snapshot(path: &Path) -> Result<Option<Vec<u8>>> {
+    match std::fs::read(path) {
+        Ok(content) => Ok(Some(content)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+impl PreparationBatch {
+    pub(crate) fn start(
+        &self,
+        config: Arc<Config>,
+        tv: ToolVersion,
+        concurrent: bool,
+    ) -> Result<()> {
+        {
+            let mut snapshots = self.snapshots.lock().unwrap();
+            let lock_path =
+                lockfile_path_for_tool_source(&config, tv.request.source()).map(|(path, _)| path);
+            for path in config.config_files.keys().cloned().chain(lock_path) {
+                if let std::collections::btree_map::Entry::Vacant(entry) = snapshots.entry(path) {
+                    let content = snapshot(entry.key())?;
+                    entry.insert(InstallSnapshot {
+                        request: tv.request.clone(),
+                        content,
+                    });
+                }
+            }
+        }
+        if !concurrent {
+            self.pending.lock().unwrap().push((config, tv));
+            return Ok(());
+        }
+        let request = tv.request.clone();
+        let handle = self.tasks.lock().unwrap().spawn(async move {
+            let result = prepare_install(&config, &tv).await;
+            (tv.request, result)
+        });
+        self.requests.lock().unwrap().insert(handle.id(), request);
+        Ok(())
+    }
+
+    pub(crate) async fn finish(&self) -> Vec<(crate::toolset::ToolRequest, eyre::Report)> {
+        let mut tasks = std::mem::take(&mut *self.tasks.lock().unwrap());
+        let mut errors = Vec::new();
+        let mut requests = std::mem::take(&mut *self.requests.lock().unwrap());
+        let pending = std::mem::take(&mut *self.pending.lock().unwrap());
+        for (config, tv) in pending {
+            if let Err(error) = prepare_install(&config, &tv).await {
+                errors.push((tv.request, error));
+            }
+        }
+        while let Some(result) = tasks.join_next().await {
+            match result {
+                Ok((request, Err(error))) => errors.push((request, error)),
+                Err(error) => {
+                    record_install_failure();
+                    if let Some(request) = requests.remove(&error.id()) {
+                        errors.push((request, eyre!("lockfile preparation failed: {error}")));
+                    }
+                }
+                Ok((_, Ok(()))) => {}
+            }
+        }
+        for (path, previous) in std::mem::take(&mut *self.snapshots.lock().unwrap()) {
+            match snapshot(&path) {
+                Ok(content) if content == previous.content => {}
+                result => errors.push((
+                    previous.request,
+                    match result {
+                        Err(error) => error,
+                        _ => eyre!(
+                            "{} changed during installation; retry to regenerate the lockfile",
+                            path.display()
+                        ),
+                    },
+                )),
+            }
+        }
+        if !errors.is_empty() {
+            *INSTALL_FAILURE_DETAIL.lock().unwrap() = Some(
+                errors
+                    .iter()
+                    .map(|(_, error)| error.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            );
+            record_install_failure();
+        }
+        errors
+    }
+}
+
+pub(crate) fn record_install_failure() {
+    INSTALL_FAILED.store(true, Ordering::Relaxed);
+}
+
+pub(crate) fn ensure_install_succeeded() -> Result<()> {
+    if INSTALL_FAILED.load(Ordering::Relaxed) {
+        if let Some(detail) = INSTALL_FAILURE_DETAIL.lock().unwrap().as_ref() {
+            bail!("{detail}\nprevious lockfiles were preserved");
+        }
+        bail!("installation failed; previous lockfiles were preserved");
+    }
+    Ok(())
+}
+
+pub(crate) fn has_previous_file(config: &Config, path: &Path) -> bool {
+    path.exists()
+        || monorepo_lockfile_migration_paths(config)
+            .iter()
+            .any(|(source, target)| target == path && source.exists())
+}
+
+pub(crate) fn read_previous(config: &Config, path: &Path, upgrade: bool) -> Result<Lockfile> {
+    let mut previous = Lockfile::read(path)?;
+    let mut exists = path.exists();
+    for (source, target) in monorepo_lockfile_migration_paths(config) {
+        if target != path || !source.exists() {
+            continue;
+        }
+        let legacy = Lockfile::read(&source)?;
+        if !exists {
+            previous.lockfile_version = legacy.lockfile_version;
+            previous
+                .generated_header_url
+                .clone_from(&legacy.generated_header_url);
+            exists = true;
+        } else if previous.lockfile_version != legacy.lockfile_version {
+            if !upgrade {
+                bail!("incompatible monorepo lockfile formats; run `mise lock --upgrade`");
+            }
+            previous.lockfile_version = previous.lockfile_version.max(legacy.lockfile_version);
+        }
+        merge_lockfile_preserving_root(&mut previous, legacy);
+    }
+    Ok(previous)
+}
+
+pub(crate) async fn prepare_install(config: &Config, tv: &ToolVersion) -> Result<()> {
+    let Some((path, _)) = lockfile_path_for_tool_source(config, tv.request.source()) else {
+        return Ok(());
+    };
+    if !has_previous_file(config, &path)
+        && (!config.lockfile_creation_enabled()
+            || tv
+                .request
+                .source()
+                .path()
+                .is_some_and(crate::config::is_global_config))
+    {
+        return Ok(());
+    }
+    let previous = read_previous(config, &path, false)?;
+    let mut platforms = determine_target_platforms_from_lockfile(&previous.all_platform_keys())?;
+    // The installer owns the host artifact (and may fall back to a source build).
+    // Start foreign artifacts first instead of contending with that download.
+    platforms.retain(|platform| platform.to_key() != Platform::current().to_key());
+    // Reserve at most one background worker, leaving the remaining workers for installs.
+    let _permit = PREPARE_SLOTS.acquire().await?;
+    generate(
+        &previous,
+        &[(tv.ba().clone(), tv.clone())],
+        &platforms,
+        true,
+        false,
+        1,
+        &[],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn resolve(
+    ba: crate::cli::args::BackendArg,
+    tv: ToolVersion,
+    platform: Platform,
+) -> Result<LockResolutionResult> {
+    let key = format!(
+        "{}\n{}\n{:?}\n{:?}\n{}",
+        ba.full(),
+        tv.version,
+        tv.request.options(),
+        tv.install_env(),
+        platform.to_key()
+    );
+    let cell = RESOLUTIONS.lock().unwrap().entry(key).or_default().clone();
+    Ok(cell
+        .get_or_init(|| async {
+            let backend = tv.backend().ok();
+            resolve_tool_lock_info(ba, tv, platform, backend).await
+        })
+        .await
+        .clone())
+}
+
+pub(crate) type Tool = (crate::cli::args::BackendArg, ToolVersion);
+
+pub(crate) async fn generate(
+    previous: &Lockfile,
+    tools: &[Tool],
+    platforms: &[Platform],
+    filtered_tools: bool,
+    filtered_platforms: bool,
+    jobs: usize,
+    installed: &[ToolVersion],
+) -> Result<Lockfile> {
+    let mut candidate = Lockfile {
+        lockfile_version: previous.lockfile_version,
+        generated_header_url: previous.generated_header_url.clone(),
+        ..Default::default()
+    };
+    let selected: BTreeSet<_> = tools.iter().map(|(ba, _)| ba.short.as_str()).collect();
+    let mut targets = Vec::new();
+    let mut keys = BTreeSet::new();
+    for (ba, tv) in tools {
+        let backend = tv.backend()?;
+        for platform in platforms {
+            for platform in backend.platform_variants(platform) {
+                let options = backend.resolve_lockfile_options(
+                    &tv.request,
+                    &PlatformTarget::new(platform.clone()),
+                )?;
+                keys.insert((ba.short.clone(), platform.to_key()));
+                targets.push((ba.clone(), tv.clone(), platform, options));
+            }
+        }
+    }
+    for (short, entries) in &previous.tools {
+        for entry in entries {
+            let mut untouched = entry.clone();
+            if selected.contains(short.as_str()) {
+                if !filtered_platforms {
+                    continue;
+                }
+                untouched
+                    .platforms
+                    .retain(|platform, _| !keys.contains(&(short.clone(), platform.clone())));
+                if untouched.platforms.is_empty() {
+                    continue;
+                }
+            } else if !filtered_tools {
+                continue;
+            }
+            candidate
+                .tools
+                .entry(short.clone())
+                .or_default()
+                .push(untouched);
+        }
+    }
+    candidate.conda_packages = previous.conda_packages.clone();
+    candidate.pkgx_packages = previous.pkgx_packages.clone();
+    let report = MultiProgressReport::get().add("lock");
+    let mut progress = ProgressGuard {
+        report: report.as_ref(),
+        finished: false,
+    };
+    report.set_length(targets.len() as u64);
+    let semaphore = Arc::new(Semaphore::new(crate::jobs::normalize(jobs)));
+    let mut tasks = JoinSet::new();
+    for (ordinal, (ba, tv, platform, options)) in targets.into_iter().enumerate() {
+        let actual = installed
+            .iter()
+            .find(|actual| {
+                actual.ba().full() == ba.full()
+                    && actual.version == tv.version
+                    && actual.request.options() == tv.request.options()
+                    && actual.request.source() == tv.request.source()
+            })
+            .and_then(|actual| {
+                let backend = actual.backend().ok()?;
+                (platform.to_key() == backend.get_platform_key())
+                    .then(|| actual.lock_platforms.get(&platform.to_key()).cloned())
+                    .flatten()
+            })
+            .filter(|info| {
+                info.url.is_some()
+                    || info.install.is_some()
+                    || info.conda_deps.is_some()
+                    || info.pkgx_deps.is_some()
+            });
+        let previous_info = previous.tools.get(&ba.short).and_then(|entries| {
+            entries
+                .iter()
+                .find(|entry| {
+                    entry.version == tv.version
+                        && entry.options == options
+                        && entry.backend.as_deref() == Some(ba.stored_full().as_str())
+                })
+                .and_then(|entry| entry.platforms.get(&platform.to_key()))
+                .cloned()
+        });
+        let semaphore = semaphore.clone();
+        tasks.spawn(async move {
+            let _permit = semaphore.acquire().await?;
+            if let Some(info) = &previous_info {
+                validate_provenance_settings(&ba, &tv, &platform.to_key(), info)?;
+            }
+            let mut resolution = if let Some(info) = actual.or_else(|| {
+                previous_info.clone().filter(|info| {
+                    info.checksum.is_some()
+                        && info.url.is_some()
+                        && info.signer.is_none()
+                        && info
+                            .additional_artifacts
+                            .iter()
+                            .all(|artifact| artifact.checksum.is_some())
+                        && !Settings::get().force_provenance_verify()
+                })
+            }) {
+                (
+                    ba.short.clone(),
+                    tv.version.clone(),
+                    ba.stored_full(),
+                    platform,
+                    Ok(info),
+                    options,
+                    BTreeMap::new(),
+                    BTreeMap::new(),
+                    LockResolutionStatus::Optional,
+                )
+            } else {
+                resolve(ba, tv.clone(), platform).await?
+            };
+            if let Ok(info) = &mut resolution.4 {
+                if info.checksum.is_none()
+                    && let Some(url) = &info.url
+                {
+                    info.checksum = Some(artifact_checksum(url, info.url_api.as_deref()).await?);
+                }
+                for artifact in &mut info.additional_artifacts {
+                    if artifact.checksum.is_none() {
+                        artifact.checksum = Some(
+                            artifact_checksum(&artifact.url, artifact.url_api.as_deref()).await?,
+                        );
+                    }
+                }
+                if let Some(old) = previous_info {
+                    preserve_legacy_metadata(&old, info);
+                }
+            }
+            Ok::<_, eyre::Report>((ordinal, tv.request.version(), resolution))
+        });
+    }
+    let mut completed = 0;
+    let mut resolved = Vec::new();
+    while let Some(result) = tasks.join_next().await {
+        let (ordinal, specifier, resolution) =
+            match result.map_err(eyre::Report::from).and_then(|r| r) {
+                Ok(result) => result,
+                Err(error) => {
+                    tasks.shutdown().await;
+                    return Err(error);
+                }
+            };
+        completed += 1;
+        report.set_position(completed);
+        report.set_message(format!(
+            "{}@{} {}",
+            resolution.0,
+            resolution.1,
+            resolution.3.to_key()
+        ));
+        resolved.push((ordinal, specifier, resolution));
+    }
+    resolved.sort_by_key(|(ordinal, _, _)| *ordinal);
+    for (_, specifier, resolution) in resolved {
+        let (short, version, backend, platform, info, options, conda, pkgx, status) = resolution;
+        if status == LockResolutionStatus::Unsupported {
+            continue;
+        }
+        let info = info.map_err(|error| eyre!(error))?;
+        if let Some(entries) = previous.tools.get(&short) {
+            for old in entries
+                .iter()
+                .filter(|old| {
+                    old.backend.as_deref() == Some(backend.as_str())
+                        && old.options == options
+                        && (old.specifiers.contains(&specifier)
+                            || old.version == version
+                            || old.specifiers.is_empty())
+                })
+                .filter_map(|old| old.platforms.get(&platform.to_key()))
+            {
+                ensure_no_downgrade(old, &info)?;
+            }
+        }
+        if let Some(error) = check_single_tool_provenance(
+            previous.tools.get(&short).map(Vec::as_slice),
+            &short,
+            &version,
+            &backend,
+            &platform.to_key(),
+            info.provenance.as_ref(),
+        ) {
+            report.abandon();
+            bail!("{error}");
+        }
+        candidate.set_platform_info(
+            &short,
+            &version,
+            Some(&backend),
+            &options,
+            &platform.to_key(),
+            info,
+        );
+        candidate.bind_request(&short, &specifier, &version, &options);
+        for (key, value) in conda {
+            candidate.set_conda_package(&platform.to_key(), &key, value);
+        }
+        for (key, value) in pkgx {
+            candidate.set_pkgx_package(&platform.to_key(), &key, value);
+        }
+    }
+    candidate.cleanup_unreferenced_conda_packages();
+    candidate.cleanup_unreferenced_pkgx_packages();
+    report.finish_with_message(format!("{completed} targets checked"));
+    progress.finished = true;
+    Ok(candidate)
+}
+
+fn ensure_no_downgrade(old: &PlatformInfo, new: &PlatformInfo) -> Result<()> {
+    if new.provenance < old.provenance {
+        bail!(
+            "lockfile generation would downgrade recorded provenance; previous files were preserved"
+        );
+    }
+    if let Some(signer) = &old.signer
+        && (new.signer.as_ref() != Some(signer) || new.attested_by != old.attested_by)
+    {
+        bail!(
+            "lockfile generation would change the recorded signer; previous files were preserved"
+        );
+    }
+    for (index, artifact) in old.additional_artifacts.iter().enumerate() {
+        if new
+            .additional_artifacts
+            .get(index)
+            .and_then(|a| a.provenance.as_ref())
+            < artifact.provenance.as_ref()
+        {
+            bail!(
+                "lockfile generation would downgrade additional artifact provenance; previous files were preserved"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_provenance_settings(
+    ba: &crate::cli::args::BackendArg,
+    tv: &ToolVersion,
+    platform: &str,
+    info: &PlatformInfo,
+) -> Result<()> {
+    let mut tv = tv.clone();
+    tv.lock_platforms.insert(platform.to_owned(), info.clone());
+    let validate = |tv: &ToolVersion| -> Result<()> {
+        match tv.backend()?.get_type() {
+            BackendType::Aqua => crate::backend::aqua::AquaBackend::from_arg(ba.clone())
+                .ensure_provenance_setting_enabled(tv, platform),
+            BackendType::Github => crate::backend::github::UnifiedGitBackend::from_arg(ba.clone())
+                .ensure_provenance_setting_enabled(tv, platform),
+            BackendType::Core
+                if matches!(ba.full_without_opts().as_str(), "core:python" | "core:ruby") =>
+            {
+                crate::backend::ensure_provenance_setting_enabled(tv, platform, |provenance| {
+                    let settings = Settings::get();
+                    let enabled = if ba.full_without_opts() == "core:python" {
+                        settings
+                            .python
+                            .github_attestations
+                            .unwrap_or(settings.github_attestations)
+                    } else {
+                        settings
+                            .ruby
+                            .github_attestations
+                            .unwrap_or(settings.github_attestations)
+                    };
+                    if !provenance.is_github_attestations() {
+                        bail!("unexpected provenance for {tv}");
+                    }
+                    Ok(!enabled)
+                })
+            }
+            _ => Ok(()),
+        }
+    };
+    validate(&tv)?;
+    for artifact in &info.additional_artifacts {
+        tv.lock_platforms.get_mut(platform).unwrap().provenance = artifact.provenance.clone();
+        validate(&tv)?;
+    }
+    Ok(())
+}
+
+struct ProgressGuard<'a> {
+    report: &'a dyn crate::ui::progress_report::SingleReport,
+    finished: bool,
+}
+
+impl Drop for ProgressGuard<'_> {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.report.abandon();
+        }
+    }
+}
+
+async fn artifact_checksum(url: &str, api_url: Option<&str>) -> Result<String> {
+    let temp = tempfile::tempdir()?;
+    let path = temp.path().join("artifact");
+    let url = if let Some(api_url) = api_url {
+        crate::github::pick_reachable_asset_url(url, api_url).await
+    } else {
+        url.to_owned()
+    };
+    crate::http::HTTP.download_file(&url, &path, None).await?;
+    Ok(format!(
+        "sha256:{}",
+        crate::hash::file_hash_sha256(&path, None)?
+    ))
+}
+
+pub(crate) async fn download_for_verification(
+    url: &str,
+    checksum: &mut Option<String>,
+) -> Result<tempfile::TempDir> {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("artifact");
+    crate::http::HTTP.download_file(url, &path, None).await?;
+    if let Some((algorithm, expected)) = checksum.as_deref().and_then(|value| value.split_once(':'))
+    {
+        crate::hash::ensure_checksum(&path, expected, None, algorithm)?;
+    } else {
+        *checksum = Some(format!(
+            "sha256:{}",
+            crate::hash::file_hash_sha256(&path, None)?
+        ));
+    }
+    Ok(directory)
+}
+
+fn preserve_legacy_metadata(old: &PlatformInfo, new: &mut PlatformInfo) {
+    new.provenance_verified = None;
+    if old.url == new.url && old.checksum == new.checksum {
+        new.provenance_verified = old.provenance_verified;
+    }
+    for artifact in &mut new.additional_artifacts {
+        artifact.provenance_verified = None;
+        if let Some(old) = old
+            .additional_artifacts
+            .iter()
+            .find(|old| old.url == artifact.url && old.checksum == artifact.checksum)
+        {
+            artifact.provenance_verified = old.provenance_verified;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::args::BackendArg;
+    use crate::toolset::ToolRequest;
+
+    fn tool() -> Tool {
+        let ba = BackendArg::new("fixture".into(), Some("http:fixture".into()));
+        let request = ToolRequest::new_with_options(
+            Arc::new(ba.clone()),
+            "1",
+            ToolVersionOptions::default(),
+            ToolSource::Argument,
+        )
+        .unwrap();
+        (ba, ToolVersion::new(request, "1.0".into()))
+    }
+
+    fn previous() -> Lockfile {
+        let mut previous = Lockfile::default();
+        for platform in ["linux-x64", "macos-arm64"] {
+            previous.set_platform_info(
+                "fixture",
+                "1.0",
+                Some("http:fixture"),
+                &BTreeMap::new(),
+                platform,
+                PlatformInfo {
+                    url: Some("https://example.invalid/never-download".into()),
+                    checksum: Some("sha256:unchanged".into()),
+                    provenance_verified: Some(false),
+                    ..Default::default()
+                },
+            );
+        }
+        previous.bind_request("fixture", "1", "1.0", &BTreeMap::new());
+        previous
+    }
+
+    #[tokio::test]
+    async fn actual_source_fallback_wins_over_reusable_binary_metadata() {
+        let (ba, mut actual) = tool();
+        let platform = Platform::current();
+        actual.lock_platforms.insert(
+            platform.to_key(),
+            PlatformInfo {
+                install: Some("source".into()),
+                ..Default::default()
+            },
+        );
+        let generated = generate(
+            &previous(),
+            &[(ba, actual.clone())],
+            std::slice::from_ref(&platform),
+            false,
+            false,
+            1,
+            &[actual],
+        )
+        .await
+        .unwrap();
+        let info = &generated.tools["fixture"][0].platforms[&platform.to_key()];
+        assert_eq!(info.install.as_deref(), Some("source"));
+        assert!(info.url.is_none());
+        assert!(info.provenance_verified.is_none());
+    }
+
+    #[tokio::test]
+    async fn unsupported_target_is_skipped_without_an_empty_entry() {
+        let generated = generate(
+            &Lockfile::default(),
+            &[tool()],
+            &[Platform::parse("windows-arm64").unwrap()],
+            false,
+            false,
+            1,
+            &[],
+        )
+        .await
+        .unwrap();
+        assert!(generated.tools.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unchanged_entries_reuse_metadata_without_network_and_are_stable() {
+        let old = previous();
+        let platforms = vec![
+            Platform::parse("linux-x64").unwrap(),
+            Platform::parse("macos-arm64").unwrap(),
+        ];
+        let generated = generate(&old, &[tool()], &platforms, false, false, 2, &[])
+            .await
+            .unwrap();
+        assert_eq!(old.tools, generated.tools);
+        let again = generate(&generated, &[tool()], &platforms, false, false, 2, &[])
+            .await
+            .unwrap();
+        assert_eq!(generated.tools, again.tools);
+    }
+
+    #[tokio::test]
+    async fn filtered_platform_carries_other_platform_forward() {
+        let old = previous();
+        let generated = generate(
+            &old,
+            &[tool()],
+            &[Platform::parse("linux-x64").unwrap()],
+            false,
+            true,
+            2,
+            &[],
+        )
+        .await
+        .unwrap();
+        assert_eq!(old.tools, generated.tools);
+    }
+
+    #[tokio::test]
+    async fn fresh_generation_drops_obsolete_tools_but_filter_keeps_them() {
+        let old = previous();
+        let empty = generate(&old, &[], &[], false, false, 1, &[])
+            .await
+            .unwrap();
+        assert!(empty.tools.is_empty());
+        let retained = generate(&old, &[], &[], true, false, 1, &[]).await.unwrap();
+        assert_eq!(old.tools, retained.tools);
+    }
+
+    #[test]
+    fn legacy_bits_only_follow_unchanged_artifacts() {
+        let old = PlatformInfo {
+            url: Some("one".into()),
+            checksum: Some("sha256:one".into()),
+            provenance_verified: Some(false),
+            ..Default::default()
+        };
+        let mut same = PlatformInfo {
+            provenance_verified: None,
+            ..old.clone()
+        };
+        preserve_legacy_metadata(&old, &mut same);
+        assert_eq!(same.provenance_verified, Some(false));
+        let mut changed = PlatformInfo {
+            checksum: Some("sha256:two".into()),
+            provenance_verified: None,
+            ..old.clone()
+        };
+        preserve_legacy_metadata(&old, &mut changed);
+        assert_eq!(changed.provenance_verified, None);
+    }
+
+    #[tokio::test]
+    async fn erlang_keeps_distinct_linux_and_macos_options() {
+        let ba = BackendArg::new("erlang".into(), Some("core:erlang".into()));
+        let request = ToolRequest::new_with_options(
+            Arc::new(ba.clone()),
+            "28",
+            ToolVersionOptions::default(),
+            ToolSource::Argument,
+        )
+        .unwrap();
+        let tv = ToolVersion::new(request, "28.0".into());
+        let backend = tv.backend().unwrap();
+        let platforms = vec![
+            Platform::parse("linux-x64").unwrap(),
+            Platform::parse("macos-arm64").unwrap(),
+        ];
+        let mut old = Lockfile::default();
+        for platform in &platforms {
+            let options = backend
+                .resolve_lockfile_options(&tv.request, &PlatformTarget::new(platform.clone()))
+                .unwrap();
+            old.set_platform_info(
+                "erlang",
+                "28.0",
+                Some(&ba.stored_full()),
+                &options,
+                &platform.to_key(),
+                PlatformInfo {
+                    url: Some(format!("https://example.invalid/{}", platform.to_key())),
+                    checksum: Some("sha256:reused".into()),
+                    ..Default::default()
+                },
+            );
+            old.bind_request("erlang", "28", "28.0", &options);
+        }
+        let generated = generate(&old, &[(ba, tv)], &platforms, false, false, 2, &[])
+            .await
+            .unwrap();
+        assert_eq!(old.tools, generated.tools);
+    }
+
+    #[test]
+    fn legacy_false_does_not_allow_provenance_downgrade() {
+        let old = PlatformInfo {
+            provenance: Some(ProvenanceType::GithubAttestations),
+            provenance_verified: Some(false),
+            ..Default::default()
+        };
+        assert!(ensure_no_downgrade(&old, &PlatformInfo::default()).is_err());
+        let mut new = old.clone();
+        new.provenance_verified = None;
+        assert!(ensure_no_downgrade(&old, &new).is_ok());
+    }
+
+    #[test]
+    fn additional_artifact_downgrade_is_rejected() {
+        let old = PlatformInfo {
+            additional_artifacts: vec![ArtifactInfo {
+                provenance: Some(ProvenanceType::GithubAttestations),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(ensure_no_downgrade(&old, &PlatformInfo::default()).is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,10 @@ use indoc::indoc;
 #[macro_use]
 mod test;
 
+#[cfg(test)]
+#[path = "../build/lockfile_rollout.rs"]
+mod lockfile_rollout;
+
 #[macro_use]
 mod output;
 
@@ -183,6 +187,7 @@ fn main() -> ExitCode {
 }
 
 async fn main_() -> eyre::Result<()> {
+    let _downloads = http::InvocationDownloads;
     // Configure color-eyre based on color preferences
     let hook_builder = if *env::CLICOLOR == Some(false) {
         // Use blank theme (no colors) when colors are disabled

--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -890,7 +890,7 @@ impl PythonPlugin {
         // Verify GitHub artifact attestations for precompiled binaries
         // Returns Ok(true) if verified, Ok(false) if skipped, Err if failed
         let verified = self
-            .verify_github_artifact_attestations(ctx, tarball_path, &tv.version)
+            .verify_github_artifact_attestations(ctx.pr.as_ref(), tarball_path, &tv.version)
             .await?;
 
         // Record provenance only if verification actually succeeded (not skipped)
@@ -925,7 +925,7 @@ impl PythonPlugin {
 
     async fn verify_github_artifact_attestations(
         &self,
-        ctx: &InstallContext,
+        pr: &dyn SingleReport,
         tarball_path: &std::path::Path,
         version: &str,
     ) -> Result<bool> {
@@ -934,8 +934,7 @@ impl PythonPlugin {
             return Ok(false);
         }
 
-        ctx.pr
-            .set_message("verify GitHub artifact attestations".to_string());
+        pr.set_message("verify GitHub artifact attestations".to_string());
 
         match crate::github::sigstore::verify_attestation(
             tarball_path,
@@ -948,8 +947,7 @@ impl PythonPlugin {
         .await
         {
             Ok(true) => {
-                ctx.pr
-                    .set_message("✓ GitHub artifact attestations verified".to_string());
+                pr.set_message("✓ GitHub artifact attestations verified".to_string());
                 debug!(
                     "GitHub artifact attestations verified successfully for python@{}",
                     version
@@ -1224,10 +1222,24 @@ impl Backend for PythonPlugin {
         let shasums_url = format!(
             "https://github.com/astral-sh/python-build-standalone/releases/download/{tag}/SHA256SUMS"
         );
-        let checksum = fetch_checksum_from_shasums(&shasums_url, &filename).await;
+        let mut checksum = fetch_checksum_from_shasums(&shasums_url, &filename).await;
 
         // Detect provenance for precompiled binaries
-        let provenance = self.detect_precompiled_provenance();
+        let mut provenance = self.detect_precompiled_provenance();
+        if provenance.is_some() {
+            let artifact =
+                crate::lockfile::generate::download_for_verification(&url, &mut checksum).await?;
+            if !self
+                .verify_github_artifact_attestations(
+                    &crate::ui::progress_report::QuietReport::new(),
+                    &artifact.path().join("artifact"),
+                    version,
+                )
+                .await?
+            {
+                provenance = None;
+            }
+        }
 
         Ok(PlatformInfo {
             url: Some(url),

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -841,13 +841,10 @@ impl RubyPlugin {
         // Verify GitHub artifact attestations for precompiled binaries
         // Returns Ok(true) if verified, Ok(false) if skipped, Err if failed
         let verified = if reuse_provenance {
-            let settings = Settings::get();
-            if !settings
-                .ruby
-                .github_attestations
-                .unwrap_or(settings.github_attestations)
-            {
-                bail!("lockfile requires Ruby provenance but GitHub attestations are disabled");
+            if self.detect_precompiled_provenance().is_none() {
+                bail!(
+                    "lockfile requires Ruby provenance but GitHub attestations are disabled or the precompiled source is not a GitHub repository"
+                );
             }
             true
         } else {

--- a/src/plugins/core/ruby.rs
+++ b/src/plugins/core/ruby.rs
@@ -819,8 +819,20 @@ impl RubyPlugin {
             hash::ensure_checksum(&tarball_path, hash_str, Some(ctx.pr.as_ref()), "sha256")?;
         }
 
-        // Check lockfile provenance expectation before verification
+        // Locked bytes remain checked even when provenance verification is reused.
         let platform_key = PlatformTarget::from_current().to_key();
+        let locked_info = tv
+            .lock_platforms
+            .get(&platform_key)
+            .filter(|info| info.url.as_deref() == Some(url.as_str()));
+        let reuse_provenance = locked_info.is_some_and(|info| info.has_checksum_and_provenance())
+            && !Settings::get().force_provenance_verify();
+        if let Some((algorithm, expected)) = locked_info
+            .and_then(|info| info.checksum.as_deref())
+            .and_then(|checksum| checksum.split_once(':'))
+        {
+            hash::ensure_checksum(&tarball_path, expected, Some(ctx.pr.as_ref()), algorithm)?;
+        }
         let locked_provenance = tv
             .lock_platforms
             .get_mut(&platform_key)
@@ -828,9 +840,20 @@ impl RubyPlugin {
 
         // Verify GitHub artifact attestations for precompiled binaries
         // Returns Ok(true) if verified, Ok(false) if skipped, Err if failed
-        let verified = self
-            .verify_github_artifact_attestations(ctx, &tarball_path, &tv.version)
-            .await?;
+        let verified = if reuse_provenance {
+            let settings = Settings::get();
+            if !settings
+                .ruby
+                .github_attestations
+                .unwrap_or(settings.github_attestations)
+            {
+                bail!("lockfile requires Ruby provenance but GitHub attestations are disabled");
+            }
+            true
+        } else {
+            self.verify_github_artifact_attestations(ctx.pr.as_ref(), &tarball_path, &tv.version)
+                .await?
+        };
 
         // Record provenance only if verification actually succeeded (not skipped)
         if verified {
@@ -879,7 +902,7 @@ impl RubyPlugin {
     /// Returns Err if verification is enabled and fails
     async fn verify_github_artifact_attestations(
         &self,
-        ctx: &InstallContext,
+        pr: &dyn crate::ui::progress_report::SingleReport,
         tarball_path: &std::path::Path,
         version: &str,
     ) -> Result<bool> {
@@ -911,8 +934,7 @@ impl RubyPlugin {
             }
         };
 
-        ctx.pr
-            .set_message("verify GitHub artifact attestations".to_string());
+        pr.set_message("verify GitHub artifact attestations".to_string());
 
         match crate::github::sigstore::verify_attestation(
             tarball_path,
@@ -925,8 +947,7 @@ impl RubyPlugin {
         .await
         {
             Ok(true) => {
-                ctx.pr
-                    .set_message("✓ GitHub artifact attestations verified".to_string());
+                pr.set_message("✓ GitHub artifact attestations verified".to_string());
                 debug!(
                     "GitHub artifact attestations verified successfully for ruby@{}",
                     version
@@ -1182,7 +1203,7 @@ impl Backend for RubyPlugin {
         // Precompiled binary info if enabled
         if self.should_try_precompiled()
             && let Some(platform) = self.precompiled_platform_for_target(target)
-            && let Some((url, checksum)) = {
+            && let Some((url, mut checksum)) = {
                 let locked_build_revision =
                     Self::extract_build_revision_from_lock_platforms(tv, &tv.version);
                 self.resolve_precompiled_url(
@@ -1194,7 +1215,22 @@ impl Backend for RubyPlugin {
             }
         {
             // Detect provenance for precompiled binaries
-            let provenance = self.detect_precompiled_provenance();
+            let mut provenance = self.detect_precompiled_provenance();
+            if provenance.is_some() {
+                let artifact =
+                    crate::lockfile::generate::download_for_verification(&url, &mut checksum)
+                        .await?;
+                if !self
+                    .verify_github_artifact_attestations(
+                        &crate::ui::progress_report::QuietReport::new(),
+                        &artifact.path().join("artifact"),
+                        &tv.version,
+                    )
+                    .await?
+                {
+                    provenance = None;
+                }
+            }
             return Ok(PlatformInfo {
                 url: Some(url),
                 checksum,

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -480,6 +480,7 @@ impl Toolset {
         if all_failed.is_empty() {
             Ok(installed)
         } else {
+            crate::lockfile::generate::record_install_failure();
             Err(Error::InstallFailed {
                 successful_installations: installed,
                 failed_installations: all_failed,
@@ -594,6 +595,11 @@ impl Toolset {
             true => 1,
             false => crate::jobs::resolve(Settings::get().jobs, opts.jobs),
         };
+        let jobs = if Settings::get().generate_lockfiles() {
+            jobs.saturating_sub(1).max(1)
+        } else {
+            jobs
+        };
         let semaphore = Arc::new(Semaphore::new(jobs));
         let ts = Arc::new(self.clone());
         let opts = Arc::new(opts.clone());
@@ -602,6 +608,7 @@ impl Toolset {
         let mut failed = vec![];
         let mut attempted_failures = vec![];
         let mut jset: JoinSet<(ToolRequest, Result<ToolVersion>)> = JoinSet::new();
+        let preparations = Arc::new(crate::lockfile::generate::PreparationBatch::default());
         // Track in-flight tools to recover from task panics
         let mut in_flight: HashMap<tokio::task::Id, ToolRequest> = HashMap::new();
 
@@ -663,9 +670,10 @@ impl Toolset {
                             let tr_clone = tr.clone();
 
                             let progress = install_progress.and_then(|p| p.start_tool(&tool_key(&tr)));
+                            let preparations = preparations.clone();
                             let handle = jset.spawn(async move {
                                 let _permit = permit;
-                                let result = Self::install_single_tool(&config, &ts, &tr, &opts, progress.as_deref()).await;
+                                let result = Self::install_single_tool(&config, &ts, &tr, &opts, progress.as_deref(), &preparations).await;
                                 if let Some(progress) = progress {
                                     let error = result.as_ref().err().map(|e| e.to_string());
                                     progress.complete(error.as_deref());
@@ -714,6 +722,7 @@ impl Toolset {
         }
 
         // Add blocked tools to failures
+        failed.extend(preparations.finish().await);
         let blocked = tool_deps.lock().await.blocked_tools();
         for tr in blocked {
             failed.push((tr.clone(), eyre::eyre!("Skipped due to failed dependency")));
@@ -736,6 +745,7 @@ impl Toolset {
         tr: &ToolRequest,
         opts: &Arc<InstallOptions>,
         tool_progress: Option<&dyn ToolProgress>,
+        preparations: &crate::lockfile::generate::PreparationBatch,
     ) -> Result<ToolVersion> {
         let mpr = MultiProgressReport::get();
         let pre_resolve_backend = tr.backend()?;
@@ -780,6 +790,17 @@ impl Toolset {
             dependency_context: OnceCell::new(),
         };
 
+        let generate = Settings::get().generate_lockfiles()
+            && Settings::get().lockfile_enabled()
+            && !ctx.locked
+            && !opts.dry_run;
+        if !generate {
+            return backend.install_version(ctx, tv).await;
+        }
+        let concurrent = crate::jobs::resolve(Settings::get().jobs, opts.jobs) > 1
+            && !opts.raw
+            && !Settings::get().raw;
+        preparations.start(config.clone(), tv.clone(), concurrent)?;
         backend.install_version(ctx, tv).await
     }
 


### PR DESCRIPTION
## Summary

Trial complete lockfile generation behind `lockfile_mode = "generate"` / `MISE_LOCKFILE_MODE=generate`. The unset default remains `merge`; selecting an engine does not enable automatic lockfile creation or change formats.

This addresses the broader cause of cross-platform churn in Discussion #13018: host-scoped incremental updates can discard another platform's option variant before auto-locking recreates it. The generator starts from current requests and uses previous files as immutable inputs for pinned versions, target platforms, reusable artifact metadata, and provenance baselines.

## Implementation

- Collect configuration, task, and monorepo requests with their ownership and bindings. Regenerate selected scope and carry untouched filtered scope forward.
- Prepare foreign-platform metadata while tools install, reserve bounded worker capacity for installation, share invocation downloads and common verification results, and report progress under `lock`.
- Reconcile actual installed metadata, including source fallback, before publication. Reuse unchanged artifacts and avoid rewriting identical files.
- Stage affected writes, check for concurrent edits, and preserve previous lockfiles on required resolution, verification, or installation failure. Completed installations remain available. Unsupported targets are distinct from genuine failures.
- Retire `provenance_verified` as a trust signal in both modes. Preserve existing values as inert metadata for unchanged artifacts; new provenance is cryptographically verified for each target, including additional artifacts. Keep checksum checks and provenance policy enforcement.
- Recommend the trial near the beginning of the lockfile guide and generate the setting schema/documentation.
- Add a package-version build gate at **2026.12.0**. The first December release requires reviewing feedback and explicitly promoting generation or postponing the gate; no wall-clock default switch.

## Validation

- 153 focused lockfile/release-gate unit tests, including Erlang's Linux/macOS option split, reuse, filters, unsupported targets, source fallback, legacy metadata, downgrade protection, and settings validation.
- Controlled HTTP overlap/reuse test and end-to-end coverage for creation eligibility, mode switching, concurrent edits, cancellation, monorepos, task tools, and platform options.
- Cross-platform SOPS provenance verification and repeated-run determinism.
- Release-gate tests before, at, and after the December threshold.
- All-features build; workspace/all-features/all-targets Clippy with warnings denied; scoped hk formatting/checks; schema validation; documentation build.

Refs https://github.com/jdx/mise/discussions/13018

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes lockfile trust semantics, install/lock orchestration, and atomic publication paths across backends—security-sensitive provenance handling with broad behavioral impact when `generate` is enabled.
> 
> **Overview**
> Adds **`lockfile_mode = "generate"`** (via settings or `MISE_LOCKFILE_MODE`) as a trial alternative to incremental **`merge`**. In generate mode, **`mise lock`** and eligible **`mise install`** runs rebuild lockfiles from current config/task requests while treating the previous file as an immutable baseline—reusing unchanged artifacts, carrying forward filtered scope, and publishing through **staged atomic writes** with snapshot rechecks so failures or concurrent edits do not overwrite good lockfiles.
> 
> **Provenance and backends** now record only cryptographically verified provenance per target platform (including cross-platform lock resolution); failed lock-time verification fails the command instead of deferring. **`provenance_verified`** is no longer a trust signal (preserved only as legacy metadata on unchanged entries). Aqua/GitHub/Python lock paths gain per-target verification, stricter checksum handling, and **`UnsupportedTarget`** semantics that generate mode treats differently from hard failures. **HTTP** deduplicates downloads and attestation checks within a command when generating.
> 
> **Install/upgrade** can trigger background lock preparation during install, skip legacy monorepo migration in generate mode, and run **`Lock::generate_after_install`** when lockfiles are enabled. A **build-time release gate** (`build/lockfile_rollout.rs`) forces an explicit maintainer decision before shipping **2026.12.0**. Docs, schema, and e2e tests cover mode switching, overlap, monorepos, and concurrent edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5fecffce7a0375447e74d8d2997ebf73eae1dbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `lockfile_mode` options (`merge` and `generate`) through settings or `MISE_LOCKFILE_MODE`.
  * Added complete lockfile generation via `mise lock`, including platform filtering, checksums, progress reporting, and reuse of existing data.
  * Concurrent operations now avoid duplicate downloads.

* **Bug Fixes**
  * Improved unsupported-target and invalid-setting errors.
  * Protected lockfiles from concurrent edits, cancellation, partial writes, and failed installations.
  * Standardized provenance and checksum verification across target platforms.

* **Documentation**
  * Documented lockfile generation, configuration, platform handling, and provenance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->