### PR TITLE
feat(bootstrap): extend friendly macos preferences

### DIFF
--- a/docs/bootstrap/macos-defaults.md
+++ b/docs/bootstrap/macos-defaults.md
@@ -59,38 +59,50 @@ same file.
 
 `[bootstrap.macos.dock]` supports:
 
-| Key             | Raw default                    |
-| --------------- | ------------------------------ |
-| `autohide`      | `com.apple.dock.autohide`      |
-| `orientation`   | `com.apple.dock.orientation`   |
-| `tilesize`      | `com.apple.dock.tilesize`      |
-| `magnification` | `com.apple.dock.magnification` |
-| `largesize`     | `com.apple.dock.largesize`     |
-| `show_recents`  | `com.apple.dock.show-recents`  |
-| `mru_spaces`    | `com.apple.dock.mru-spaces`    |
+| Key                      | Raw default                             |
+| ------------------------ | --------------------------------------- |
+| `autohide_delay`         | `com.apple.dock.autohide-delay`         |
+| `autohide_time_modifier` | `com.apple.dock.autohide-time-modifier` |
+| `autohide`               | `com.apple.dock.autohide`               |
+| `orientation`            | `com.apple.dock.orientation`            |
+| `tilesize`               | `com.apple.dock.tilesize`               |
+| `magnification`          | `com.apple.dock.magnification`          |
+| `largesize`              | `com.apple.dock.largesize`              |
+| `show_recents`           | `com.apple.dock.show-recents`           |
+| `mru_spaces`             | `com.apple.dock.mru-spaces`             |
+
+`autohide_delay` and `autohide_time_modifier` accept integers or floats, such as
+`0` and `0.5`.
 
 `orientation` must be `bottom`, `left`, or `right`.
 
 `[bootstrap.macos.finder]` supports:
 
-| Key                       | Raw default                                       |
-| ------------------------- | ------------------------------------------------- |
-| `show_all_files`          | `com.apple.finder.AppleShowAllFiles`              |
-| `show_pathbar`            | `com.apple.finder.ShowPathbar`                    |
-| `show_status_bar`         | `com.apple.finder.ShowStatusBar`                  |
-| `show_extensions_warning` | `com.apple.finder.FXEnableExtensionChangeWarning` |
-| `preferred_view_style`    | `com.apple.finder.FXPreferredViewStyle`           |
+| Key                           | Raw default                                        |
+| ----------------------------- | -------------------------------------------------- |
+| `sort_folders_first`          | `com.apple.finder._FXSortFoldersFirst`             |
+| `save_new_documents_to_cloud` | `NSGlobalDomain.NSDocumentSaveNewDocumentsToCloud` |
+| `show_all_files`              | `com.apple.finder.AppleShowAllFiles`               |
+| `show_pathbar`                | `com.apple.finder.ShowPathbar`                     |
+| `show_status_bar`             | `com.apple.finder.ShowStatusBar`                   |
+| `show_extensions_warning`     | `com.apple.finder.FXEnableExtensionChangeWarning`  |
+| `preferred_view_style`        | `com.apple.finder.FXPreferredViewStyle`            |
+
+`save_new_documents_to_cloud` controls the default save location globally for
+application save dialogs, even though it is grouped under `finder`.
 
 `preferred_view_style` must be `icon`, `list`, `column`, or `gallery`.
 
 `[bootstrap.macos.keyboard]` supports:
 
-| Key                  | Raw default                                 |
-| -------------------- | ------------------------------------------- |
-| `key_repeat`         | `NSGlobalDomain.KeyRepeat`                  |
-| `initial_key_repeat` | `NSGlobalDomain.InitialKeyRepeat`           |
-| `press_and_hold`     | `NSGlobalDomain.ApplePressAndHoldEnabled`   |
-| `fn_state`           | `NSGlobalDomain.com.apple.keyboard.fnState` |
+| Key                             | Raw default                                           |
+| ------------------------------- | ----------------------------------------------------- |
+| `automatic_capitalization`      | `NSGlobalDomain.NSAutomaticCapitalizationEnabled`     |
+| `automatic_spelling_correction` | `NSGlobalDomain.NSAutomaticSpellingCorrectionEnabled` |
+| `key_repeat`                    | `NSGlobalDomain.KeyRepeat`                            |
+| `initial_key_repeat`            | `NSGlobalDomain.InitialKeyRepeat`                     |
+| `press_and_hold`                | `NSGlobalDomain.ApplePressAndHoldEnabled`             |
+| `fn_state`                      | `NSGlobalDomain.com.apple.keyboard.fnState`           |
 
 `[bootstrap.macos.trackpad]` supports:
 

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4572,6 +4572,14 @@
               "type": "object",
               "description": "curated Dock preferences that compile into macOS defaults",
               "properties": {
+                "autohide_delay": {
+                  "type": "number",
+                  "description": "delay before showing the Dock"
+                },
+                "autohide_time_modifier": {
+                  "type": "number",
+                  "description": "Dock autohide animation time modifier"
+                },
                 "autohide": {
                   "type": "boolean",
                   "description": "hide and show the Dock automatically"
@@ -4608,6 +4616,14 @@
               "type": "object",
               "description": "curated Finder preferences that compile into macOS defaults",
               "properties": {
+                "sort_folders_first": {
+                  "type": "boolean",
+                  "description": "keep folders first when sorting by name"
+                },
+                "save_new_documents_to_cloud": {
+                  "type": "boolean",
+                  "description": "save new documents to iCloud by default (applies globally to application save dialogs)"
+                },
                 "show_all_files": {
                   "type": "boolean",
                   "description": "show hidden files in Finder"
@@ -4636,6 +4652,14 @@
               "type": "object",
               "description": "curated keyboard preferences that compile into macOS defaults",
               "properties": {
+                "automatic_capitalization": {
+                  "type": "boolean",
+                  "description": "automatically capitalize words"
+                },
+                "automatic_spelling_correction": {
+                  "type": "boolean",
+                  "description": "automatically correct spelling"
+                },
                 "key_repeat": {
                   "type": "integer",
                   "description": "keyboard repeat interval"

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -944,6 +944,10 @@ fn is_bool(value: &toml::Value) -> bool {
     matches!(value, toml::Value::Boolean(_))
 }
 
+fn is_number(value: &toml::Value) -> bool {
+    matches!(value, toml::Value::Integer(_) | toml::Value::Float(_))
+}
+
 fn is_integer(value: &toml::Value) -> bool {
     matches!(value, toml::Value::Integer(_))
 }
@@ -954,6 +958,30 @@ fn merge_dock_defaults(
 ) {
     for (key, value) in entries {
         match key.as_str() {
+            "autohide_delay" => insert_friendly_default(
+                out,
+                "com.apple.dock",
+                FriendlyDefaultSpec {
+                    section: "dock",
+                    key,
+                    defaults_key: "autohide-delay",
+                    expected: is_number,
+                    expected_type: "number",
+                },
+                value.clone(),
+            ),
+            "autohide_time_modifier" => insert_friendly_default(
+                out,
+                "com.apple.dock",
+                FriendlyDefaultSpec {
+                    section: "dock",
+                    key,
+                    defaults_key: "autohide-time-modifier",
+                    expected: is_number,
+                    expected_type: "number",
+                },
+                value.clone(),
+            ),
             "autohide" => insert_friendly_default(
                 out,
                 "com.apple.dock",
@@ -1052,6 +1080,30 @@ fn merge_finder_defaults(
 ) {
     for (key, value) in entries {
         match key.as_str() {
+            "sort_folders_first" => insert_friendly_default(
+                out,
+                "com.apple.finder",
+                FriendlyDefaultSpec {
+                    section: "finder",
+                    key,
+                    defaults_key: "_FXSortFoldersFirst",
+                    expected: is_bool,
+                    expected_type: "bool",
+                },
+                value.clone(),
+            ),
+            "save_new_documents_to_cloud" => insert_friendly_default(
+                out,
+                "NSGlobalDomain",
+                FriendlyDefaultSpec {
+                    section: "finder",
+                    key,
+                    defaults_key: "NSDocumentSaveNewDocumentsToCloud",
+                    expected: is_bool,
+                    expected_type: "bool",
+                },
+                value.clone(),
+            ),
             "show_all_files" => insert_friendly_default(
                 out,
                 "com.apple.finder",
@@ -1140,6 +1192,30 @@ fn merge_keyboard_defaults(
 ) {
     for (key, value) in entries {
         match key.as_str() {
+            "automatic_capitalization" => insert_friendly_default(
+                out,
+                "NSGlobalDomain",
+                FriendlyDefaultSpec {
+                    section: "keyboard",
+                    key,
+                    defaults_key: "NSAutomaticCapitalizationEnabled",
+                    expected: is_bool,
+                    expected_type: "bool",
+                },
+                value.clone(),
+            ),
+            "automatic_spelling_correction" => insert_friendly_default(
+                out,
+                "NSGlobalDomain",
+                FriendlyDefaultSpec {
+                    section: "keyboard",
+                    key,
+                    defaults_key: "NSAutomaticSpellingCorrectionEnabled",
+                    expected: is_bool,
+                    expected_type: "bool",
+                },
+                value.clone(),
+            ),
             "key_repeat" => insert_friendly_default(
                 out,
                 "NSGlobalDomain",
@@ -2205,6 +2281,119 @@ mod tests {
             )),
             Some(&tv("true"))
         );
+    }
+
+    #[test]
+    fn test_extended_friendly_macos_defaults() {
+        let cases = [
+            (
+                "dock",
+                "autohide_delay",
+                "com.apple.dock",
+                "autohide-delay",
+                "0",
+            ),
+            (
+                "dock",
+                "autohide_delay",
+                "com.apple.dock",
+                "autohide-delay",
+                "0.5",
+            ),
+            (
+                "dock",
+                "autohide_time_modifier",
+                "com.apple.dock",
+                "autohide-time-modifier",
+                "0",
+            ),
+            (
+                "dock",
+                "autohide_time_modifier",
+                "com.apple.dock",
+                "autohide-time-modifier",
+                "0.5",
+            ),
+            (
+                "finder",
+                "sort_folders_first",
+                "com.apple.finder",
+                "_FXSortFoldersFirst",
+                "true",
+            ),
+            (
+                "finder",
+                "sort_folders_first",
+                "com.apple.finder",
+                "_FXSortFoldersFirst",
+                "false",
+            ),
+            (
+                "finder",
+                "save_new_documents_to_cloud",
+                "NSGlobalDomain",
+                "NSDocumentSaveNewDocumentsToCloud",
+                "true",
+            ),
+            (
+                "finder",
+                "save_new_documents_to_cloud",
+                "NSGlobalDomain",
+                "NSDocumentSaveNewDocumentsToCloud",
+                "false",
+            ),
+            (
+                "keyboard",
+                "automatic_capitalization",
+                "NSGlobalDomain",
+                "NSAutomaticCapitalizationEnabled",
+                "true",
+            ),
+            (
+                "keyboard",
+                "automatic_capitalization",
+                "NSGlobalDomain",
+                "NSAutomaticCapitalizationEnabled",
+                "false",
+            ),
+            (
+                "keyboard",
+                "automatic_spelling_correction",
+                "NSGlobalDomain",
+                "NSAutomaticSpellingCorrectionEnabled",
+                "true",
+            ),
+            (
+                "keyboard",
+                "automatic_spelling_correction",
+                "NSGlobalDomain",
+                "NSAutomaticSpellingCorrectionEnabled",
+                "false",
+            ),
+        ];
+        for (section, key, domain, raw, value) in cases {
+            for valid in [true, false] {
+                let mut macos = BootstrapMacosTomlConfig::default();
+                let entries = match section {
+                    "dock" => &mut macos.dock,
+                    "finder" => &mut macos.finder,
+                    "keyboard" => &mut macos.keyboard,
+                    _ => unreachable!(),
+                };
+                entries.insert(
+                    key.into(),
+                    if valid { tv(value) } else { tv(r#""invalid""#) },
+                );
+                let mut out = IndexMap::new();
+                merge_friendly_macos_defaults(&mut out, &macos);
+                if valid {
+                    assert_eq!(out.len(), 1);
+                    assert_eq!(out.get(&(domain.into(), raw.into())), Some(&tv(value)));
+                } else {
+                    assert!(out.is_empty(), "{section}.{key} accepted a string");
+                }
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Add friendly bootstrap options for folder sorting, the default document save location, automatic capitalization and spelling correction, and Dock autohide timing. These map to the same preferences already available through raw defaults, using snake_case names consistent with the existing sections.

Dock timings accept integers and floats, including `0` and `0.5`. Document that `finder.save_new_documents_to_cloud` applies globally to application save dialogs. Include schema entries and tests for each mapping and invalid value types.

Related: https://github.com/jdx/mise/discussions/13029

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*

Validation: all four focused friendly-defaults tests passed; `mise run lint-fix` (including all-features Cargo check and schema validation) and `mise run docs:build` passed. No machine preferences were changed during testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive bootstrap config mappings and documentation only; applies only when users opt in via `mise bootstrap macos defaults apply`.
> 
> **Overview**
> Extends **bootstrap macOS friendly defaults** with more curated keys that compile into `defaults write` pairs, alongside schema and docs updates.
> 
> **Dock** gains `autohide_delay` and `autohide_time_modifier` (integer or float via a new `is_number` validator). **Finder** adds `sort_folders_first` and `save_new_documents_to_cloud` (the latter maps to `NSGlobalDomain.NSDocumentSaveNewDocumentsToCloud` and is documented as global for save dialogs). **Keyboard** adds `automatic_capitalization` and `automatic_spelling_correction` under `NSGlobalDomain`.
> 
> `schema/mise.json` documents the new keys; `docs/bootstrap/macos-defaults.md` lists mappings and notes for numeric dock timings and the cloud-save setting. `src/system/mod.rs` implements the merges and adds `test_extended_friendly_macos_defaults` for valid mappings and rejection of wrong types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0bba184308b17c669858afb399a01f647a6ea9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added six macOS bootstrap preferences:
    - Dock auto-hide delay and timing controls
    - Finder folder sorting and cloud-saving options
    - Keyboard automatic capitalization and spelling correction
  - Added validation for numeric Dock preference values.

- **Documentation**
  - Documented the new preferences, supported value types, and applicable settings.

- **Tests**
  - Added coverage for valid and invalid values across the new preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->