### PR TITLE
fix(bootstrap): render vars in file templates

### DIFF
--- a/docs/bootstrap/files.md
+++ b/docs/bootstrap/files.md
@@ -46,7 +46,9 @@ an empty directory; recursive destruction still requires an explicit
 
 Set `template = true` to render file content with mise's template engine. This
 is explicit so literal <span v-pre>`{{ ... }}`</span> content remains untouched
-by default. A template can consume a declared
+by default. Templates can use configured `vars`, the declaring configuration's
+directory as <span v-pre>`{{ config_root }}`</span>, and the destination as
+<span v-pre>`{{ target }}`</span>. A template can consume a declared
 [bootstrap secret input](/bootstrap/secrets.html) with
 <span v-pre>`{{ secret(name="logical_name") }}`</span>. Secret values are never
 included in plans, dry-run descriptions, status output, or privileged helper

--- a/e2e/cli/test_bootstrap_system_files
+++ b/e2e/cli/test_bootstrap_system_files
@@ -23,6 +23,9 @@ assert_fail "mise bootstrap plan" "user '$missing_owner' does not exist"
 assert_fail "test -e $PWD/missing-owner"
 
 cat <<EOF >mise.toml
+[vars]
+managed_content = "first"
+
 [bootstrap.directories."$managed_dir"]
 owner = "$managed_owner"
 group = "$managed_group"
@@ -34,7 +37,8 @@ group = "$managed_group"
 mode = "0750"
 
 [bootstrap.files."$managed_file"]
-content = "first"
+content = '{{ vars.managed_content }}'
+template = true
 owner = "$managed_owner"
 group = "$managed_group"
 mode = "0640"

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -562,7 +562,7 @@ impl ManagedFileRequest {
         if config.template {
             let rendered = content
                 .as_deref()
-                .map(|content| secrets.render(root_config, content, base, &path))
+                .map(|content| secrets.render(root_config, content, base, &path, &origin.config))
                 .transpose()
                 .wrap_err_with(|| {
                     format!(

--- a/src/system/secrets.rs
+++ b/src/system/secrets.rs
@@ -159,13 +159,14 @@ impl SecretValues {
         input: &str,
         base: &Path,
         target: &Path,
+        config_path: &Path,
     ) -> Result<String> {
-        self.render_inner(Some(config), input, base, target)
+        self.render_inner(Some((config, config_path)), input, base, target)
     }
 
     fn render_inner(
         &self,
-        config: Option<&Config>,
+        config: Option<(&Config, &Path)>,
         input: &str,
         base: &Path,
         target: &Path,
@@ -213,6 +214,15 @@ impl SecretValues {
             },
         );
         let mut context = BASE_CONTEXT.clone();
+        // Independently selected bootstrap roots keep their legacy template
+        // context until scoped composition and execution semantics are defined.
+        if let Some((config, config_path)) = config
+            && !config
+                .selected_bootstrap_config_maps()
+                .any(|(_, files)| files.contains_key(config_path))
+        {
+            context.insert("vars", &config.vars);
+        }
         context.insert("config_root", base);
         context.insert("target", target);
         let rendered = render_str_v2(&mut tera, input, &context);
@@ -220,7 +230,7 @@ impl SecretValues {
             .resolution
             .lock()
             .map_err(|_| eyre::eyre!("bootstrap secret resolver is unavailable"))?;
-        if let Some(config) = config {
+        if let Some((config, _)) = config {
             config.add_redactions_excluding(
                 resolution.redaction_env.keys().cloned(),
                 &resolution.redaction_env,


### PR DESCRIPTION
## Summary
- expose resolved `[vars]` to opt-in ordinary `[bootstrap.files]` templates
- retain each declaration path so deprecated independently selected bootstrap roots keep their prior no-`vars` context and cannot receive another root’s values
- preserve the existing `config_root`, `target`, and `secret()` template behavior
- document and cover ordinary `[bootstrap.files]` variable rendering

## Testing
- `mise exec -- cargo test --all-features system::secrets`
- scoped `hk run check --safe` for the four changed files
- `mise run test:e2e e2e/cli/test_bootstrap_system_files` (skipped by its Linux/passwordless-sudo guard on macOS)
- `mise run lint-fix` (Cargo check passed; the repository-wide run stopped at pre-existing repository lint failures)

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*