### PR TITLE
fix(install): reduce progress output for long CI installs

### DIFF
--- a/src/ui/text_install_progress.rs
+++ b/src/ui/text_install_progress.rs
@@ -10,7 +10,10 @@ use super::multi_progress_report::MultiProgressReport;
 use super::progress_report::{ProgressIcon, SingleReport};
 use super::style;
 
-const INTERVAL: Duration = Duration::from_secs(3);
+/// Keep short installs responsive, then reduce log volume for long builds.
+fn snapshot_interval(elapsed: Duration) -> Duration {
+    (elapsed / 10).clamp(Duration::from_secs(3), Duration::from_secs(60))
+}
 pub(super) const BAR_WIDTH: usize = 16;
 
 #[derive(Debug)]
@@ -755,11 +758,14 @@ impl TextInstallProgress {
             state.action.present(),
             tool_noun(total)
         );
+        let started = state.started;
         let state = Arc::new(Mutex::new(state));
         let (stop, rx) = mpsc::channel();
         let shared = state.clone();
         let thread = thread::spawn(move || {
-            while rx.recv_timeout(INTERVAL) == Err(mpsc::RecvTimeoutError::Timeout) {
+            while rx.recv_timeout(snapshot_interval(started.elapsed()))
+                == Err(mpsc::RecvTimeoutError::Timeout)
+            {
                 let render = || {
                     let state = shared.lock().unwrap();
                     // Completed tools have already printed their individual results.
@@ -933,6 +939,16 @@ impl SingleReport for TextToolProgress {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn snapshots_back_off_for_long_installs() {
+        for (elapsed, interval) in [(0, 3), (30, 3), (60, 6), (300, 30), (600, 60), (3600, 60)] {
+            assert_eq!(
+                snapshot_interval(Duration::from_secs(elapsed)),
+                Duration::from_secs(interval)
+            );
+        }
+    }
 
     fn state(started: Instant) -> State {
         let mut state = State::new((0..3).map(|i| (i.to_string(), format!("tool{i}@1"))));
@@ -1428,7 +1444,7 @@ mod tests {
         ))));
         progress.stop();
         assert!(progress.thread.is_none());
-        assert!(start.elapsed() < INTERVAL);
+        assert!(start.elapsed() < snapshot_interval(Duration::ZERO));
     }
 
     #[test]


### PR DESCRIPTION
Long-running installs currently append a progress snapshot every three seconds throughout the session, filling CI logs with repetitive output.

Scale the non-TTY snapshot interval to 10% of elapsed session time, with a three-second minimum and a one-minute maximum. This reaches roughly 30 seconds between snapshots after five minutes and one minute after ten minutes. Tool results and the final summary still print immediately, and stopping the heartbeat remains interruptible. The shared text renderer also applies this cadence to resolution and removal sessions.

Validation: all 28 text progress tests pass, including backoff coverage; `mise run lint-fix` passes.

*AI-assisted — Tool: Codex; model: openai/gpt-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging cadence only in the text/CI progress path; no install logic or data handling changes.
> 
> **Overview**
> **Non-TTY install progress** no longer logs a snapshot every 3 seconds for the whole session. The heartbeat now uses **`snapshot_interval`**: 10% of elapsed session time, clamped between **3s** and **60s**, so CI logs stay responsive early and quiet during long builds.
> 
> The background thread reads the session’s **`started`** instant and recomputes the timeout on each loop. Per-tool completion lines and the final summary are unchanged; stopping the heartbeat still does not wait for the next tick. Tests cover the backoff curve and update the stop-timing assertion to use the minimum interval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16739ff2e6816c4446e42a8d5816b995825a84a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Installation progress updates now adjust their reporting frequency based on elapsed installation time.
  * Short installations remain responsive, while longer installations reduce update frequency to limit unnecessary logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->