### PR TITLE
fix(bootstrap): detect the origin default branch when connecting dotfiles

### DIFF
--- a/docs/cli/bootstrap/dotfiles/origin/set.md
+++ b/docs/cli/bootstrap/dotfiles/origin/set.md
@@ -15,9 +15,7 @@ Connect a setup repository
 - **`<URL>`** — The repository url (any git url; a private repository is recommended)
 
 ## Flags
-- **`--branch <BRANCH>`** — The setup branch
-
-  **Default:** `main`
+- **`--branch <BRANCH>`** — The setup branch (default: the repository's own default branch)
 - **`--sync <MODE>`** — How the repository is used: sync, fetch-only, or manual
 
   Prompts when omitted. With --yes, accepts the configured mode (default: sync), including automatic publication and incoming writes. Use --sync manual to keep automatic local history without automatic network activity.

--- a/docs/cli/bootstrap/dotfiles/origin/set.md
+++ b/docs/cli/bootstrap/dotfiles/origin/set.md
@@ -16,6 +16,8 @@ Connect a setup repository
 
 ## Flags
 - **`--branch <BRANCH>`** — The setup branch (default: the repository's own default branch)
+
+  Reconnecting a repository this machine already follows keeps that connection's branch. A repository with no branches at all takes `main`, which the first publication creates.
 - **`--sync <MODE>`** — How the repository is used: sync, fetch-only, or manual
 
   Prompts when omitted. With --yes, accepts the configured mode (default: sync), including automatic publication and incoming writes. Use --sync manual to keep automatic local history without automatic network activity.

--- a/e2e/cli/test_dotfiles_origin_default_branch
+++ b/e2e/cli/test_dotfiles_origin_default_branch
@@ -16,8 +16,8 @@ assert_succeed "mise bootstrap dotfiles origin --remove"
 # Reconnecting without --branch follows `master`: the repository is never
 # described as empty, and no unrelated `main` is created beside its history.
 connected="$(mise bootstrap dotfiles origin set "file://$origin" --sync manual --yes 2>&1)" || {
-	echo "connecting failed: $connected" >&2
-	exit 1
+  echo "connecting failed: $connected" >&2
+  exit 1
 }
 assert_contains_text "$connected" "branch master"
 assert_not_contains_text "$connected" "repository is empty"

--- a/e2e/cli/test_dotfiles_origin_default_branch
+++ b/e2e/cli/test_dotfiles_origin_default_branch
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Connecting takes the repository's own default branch, and never mistakes a
+# missing branch for an empty repository.
+require_cmd git
+
+# A setup repository whose default branch is `master`, not `main`.
+origin="$PWD/master-origin.git"
+git init -q --bare -b master "$origin"
+echo local >~/.native
+assert_succeed "mise bootstrap dotfiles track ~/.native"
+assert_succeed "mise bootstrap dotfiles origin set file://$origin --branch master --sync manual --yes"
+assert_succeed "mise bootstrap dotfiles sync"
+assert "git --git-dir=$origin for-each-ref --format='%(refname)' refs/heads" "refs/heads/master"
+assert_succeed "mise bootstrap dotfiles origin --remove"
+
+# Reconnecting without --branch follows `master`: the repository is never
+# described as empty, and no unrelated `main` is created beside its history.
+connected="$(mise bootstrap dotfiles origin set "file://$origin" --sync manual --yes 2>&1)" || {
+	echo "connecting failed: $connected" >&2
+	exit 1
+}
+assert_contains_text "$connected" "branch master"
+assert_not_contains_text "$connected" "repository is empty"
+assert_contains "mise bootstrap dotfiles origin" "branch master"
+assert "git --git-dir=$origin for-each-ref --format='%(refname)' refs/heads" "refs/heads/master"
+
+# An explicitly requested branch the repository does not have is refused, and
+# names the branches it has rather than connecting to a branch that is not there.
+assert_fail "mise bootstrap dotfiles origin set file://$origin --branch main --sync manual --yes" 'no branch `main`'
+assert_contains "mise bootstrap dotfiles origin" "branch master"

--- a/e2e/cli/test_dotfiles_origin_default_branch
+++ b/e2e/cli/test_dotfiles_origin_default_branch
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016
 # Connecting takes the repository's own default branch, and never mistakes a
 # missing branch for an empty repository.
 require_cmd git

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1759,10 +1759,7 @@ Connect a setup repository
 .PP
 .TP
 \fB\-\-branch\fR \fI<BRANCH>\fR
-The setup branch
-.RS
-\fIDefault: \fRmain
-.RE
+The setup branch (default: the repository's own default branch)
 .TP
 \fB\-\-sync\fR \fI<MODE>\fR
 How the repository is used: sync, fetch\-only, or manual

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1760,6 +1760,8 @@ Connect a setup repository
 .TP
 \fB\-\-branch\fR \fI<BRANCH>\fR
 The setup branch (default: the repository's own default branch)
+
+Reconnecting a repository this machine already follows keeps that connection's branch. A repository with no branches at all takes `main`, which the first publication creates.
 .TP
 \fB\-\-sync\fR \fI<MODE>\fR
 How the repository is used: sync, fetch\-only, or manual

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -845,7 +845,7 @@ the mode is `settings.history.sync`.
             flag --remove help="Disconnect: remove `[history.origin]` (local checkpoints and fetched refs stay)" effect=destructive
             flag "-h --help" help="Print help" action=help builtin=#true
             cmd set help="Connect a setup repository" effect=write {
-                flag --branch help="The setup branch" default=main {
+                flag --branch help="The setup branch (default: the repository's own default branch)" {
                     arg <BRANCH>
                 }
                 flag --sync help="How the repository is used: sync, fetch-only, or manual" {

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -846,6 +846,11 @@ the mode is `settings.history.sync`.
             flag "-h --help" help="Print help" action=help builtin=#true
             cmd set help="Connect a setup repository" effect=write {
                 flag --branch help="The setup branch (default: the repository's own default branch)" {
+                    long_help #"""
+The setup branch (default: the repository's own default branch)
+
+Reconnecting a repository this machine already follows keeps that connection's branch. A repository with no branches at all takes `main`, which the first publication creates.
+"""#
                     arg <BRANCH>
                 }
                 flag --sync help="How the repository is used: sync, fetch-only, or manual" {

--- a/src/cli/dotfiles/origin.rs
+++ b/src/cli/dotfiles/origin.rs
@@ -35,6 +35,10 @@ pub(crate) struct DotfilesOriginSet {
     url: String,
 
     /// The setup branch (default: the repository's own default branch)
+    ///
+    /// Reconnecting a repository this machine already follows keeps that
+    /// connection's branch. A repository with no branches at all takes `main`,
+    /// which the first publication creates.
     #[usage(long, value_name = "BRANCH")]
     branch: Option<String>,
 

--- a/src/cli/dotfiles/origin.rs
+++ b/src/cli/dotfiles/origin.rs
@@ -34,9 +34,9 @@ pub(crate) struct DotfilesOriginSet {
     /// The repository url (any git url; a private repository is recommended)
     url: String,
 
-    /// The setup branch
-    #[usage(long, value_name = "BRANCH", default = "main")]
-    branch: String,
+    /// The setup branch (default: the repository's own default branch)
+    #[usage(long, value_name = "BRANCH")]
+    branch: Option<String>,
 
     /// How the repository is used: sync, fetch-only, or manual
     ///

--- a/src/system/history/sync/onboard.rs
+++ b/src/system/history/sync/onboard.rs
@@ -175,7 +175,7 @@ pub(crate) async fn from_git(url: &str, yes: bool, dry_run: bool) -> Result<Opti
 /// The branch a fresh machine takes: the repository's default branch (its
 /// `HEAD`), else `main`, else `master`, else the first head; `None` when the
 /// repository lists none (unreachable, empty).
-fn default_branch(remote: &Remote<'_>) -> Result<Option<String>> {
+pub(super) fn default_branch(remote: &Remote<'_>) -> Result<Option<String>> {
     if let Ok(Some(head)) = remote.symbolic_head() {
         return Ok(Some(head));
     }

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -92,7 +92,7 @@ async fn set_inner(
     // repository's default branch is not the one this machine follows
     let connected = (!status_before.disconnected
         && status_before.origin_url.as_deref() == Some(opts.url.as_str()))
-    .then(|| status_before.origin_branch.as_deref())
+    .then_some(status_before.origin_branch.as_deref())
     .flatten();
     let branch = resolve_branch(&remote, opts.branch.as_deref(), connected)?;
     if !remote.fetch(&branch)? {

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -81,10 +81,20 @@ async fn set_inner(
         .repo()
         .ok_or_else(|| eyre::eyre!("connecting a setup repository requires git"))?;
     let state_dir = store.state_dir();
+    // the connection as it was: another repository or branch starts from a
+    // clean slate, and a scheme change on the same one replaces its refs
+    let status_before = run::read_status(state_dir)?;
     // This is the disposable preview repository. The connected repository's
     // remote-tracking ref remains untouched unless the connection is confirmed.
     let remote = Remote::new(repo, &opts.url);
-    let branch = resolve_branch(&remote, opts.branch.as_deref())?;
+    // re-running the same connection keeps the branch it already has, so an
+    // unattended `origin set <url> --yes` stays idempotent when the
+    // repository's default branch is not the one this machine follows
+    let connected = (!status_before.disconnected
+        && status_before.origin_url.as_deref() == Some(opts.url.as_str()))
+    .then(|| status_before.origin_branch.as_deref())
+    .flatten();
+    let branch = resolve_branch(&remote, opts.branch.as_deref(), connected)?;
     if !remote.fetch(&branch)? {
         refuse_missing_branch(&remote, &branch, &opts.url)?;
         if repo.ref_oid(UPSTREAM_REF)?.is_some() {
@@ -97,9 +107,6 @@ async fn set_inner(
 
     run::capture_now(store, tracked);
     let shared = share::current(repo, tracked)?;
-    // the connection as it was: another repository or branch starts from a
-    // clean slate, and a scheme change on the same one replaces its refs
-    let status_before = run::read_status(state_dir)?;
     let connected_before = status_before.origin_url.is_some();
     let same_origin = status_before.origin_url.as_deref() == Some(opts.url.as_str())
         && status_before.origin_branch.as_deref() == Some(branch.as_str());
@@ -225,14 +232,23 @@ async fn set_inner(
     Ok(())
 }
 
-/// The setup branch: the one asked for, else the repository's own default
-/// branch. Assuming `main` reads a repository that does not have it as empty,
-/// and publishes an unrelated root branch beside its real history.
-fn resolve_branch(remote: &Remote<'_>, requested: Option<&str>) -> Result<String> {
+/// The setup branch: the one asked for, else the branch this machine already
+/// follows on the same repository, else the repository's own default branch.
+/// Assuming `main` reads a repository that does not have it as empty, and
+/// publishes an unrelated root branch beside its real history.
+fn resolve_branch(
+    remote: &Remote<'_>,
+    requested: Option<&str>,
+    connected: Option<&str>,
+) -> Result<String> {
     if let Some(branch) = requested {
-        if branch.trim().is_empty() {
+        let branch = branch.trim();
+        if branch.is_empty() {
             bail!("a branch name is required");
         }
+        return Ok(branch.to_string());
+    }
+    if let Some(branch) = connected {
         return Ok(branch.to_string());
     }
     // an unreachable repository is reported by the fetch that follows
@@ -242,10 +258,10 @@ fn resolve_branch(remote: &Remote<'_>, requested: Option<&str>) -> Result<String
 /// A missing branch is only an empty repository when the repository has no
 /// branches at all; otherwise connecting would publish an unrelated root
 /// branch beside the history that is already there.
-fn refuse_missing_branch(remote: &Remote<'_>, branch: &str, url: &str) -> Result<()> {
-    let Ok(refs) = remote.ls_remote() else {
-        return Ok(());
-    };
+pub(super) fn refuse_missing_branch(remote: &Remote<'_>, branch: &str, url: &str) -> Result<()> {
+    // a listing that fails must not read as an empty repository: that is the
+    // path this check exists to prevent
+    let refs = remote.ls_remote()?;
     let heads: Vec<&str> = refs
         .iter()
         .filter_map(|(_, name)| name.strip_prefix("refs/heads/"))
@@ -488,7 +504,7 @@ mod tests {
             let (_origin, url) = origin_with_branch(&temp.path().join(name), name);
             let local = local_repo(&temp.path().join(format!("{name}-local")));
             let remote = Remote::new(&local, &url);
-            assert_eq!(resolve_branch(&remote, None).unwrap(), name);
+            assert_eq!(resolve_branch(&remote, None, None).unwrap(), name);
         }
     }
 
@@ -501,8 +517,35 @@ mod tests {
         let (_origin, url) = origin_with_branch(&temp.path().join("origin"), "master");
         let local = local_repo(&temp.path().join("local"));
         let remote = Remote::new(&local, &url);
-        assert_eq!(resolve_branch(&remote, Some("release")).unwrap(), "release");
-        assert!(resolve_branch(&remote, Some("  ")).is_err());
+        assert_eq!(
+            resolve_branch(&remote, Some("release"), None).unwrap(),
+            "release"
+        );
+        assert_eq!(
+            resolve_branch(&remote, Some(" release "), None).unwrap(),
+            "release"
+        );
+        assert!(resolve_branch(&remote, Some("  "), None).is_err());
+        // an explicit branch still wins over the one already followed
+        assert_eq!(
+            resolve_branch(&remote, Some("release"), Some("main")).unwrap(),
+            "release"
+        );
+    }
+
+    #[test]
+    fn a_live_connection_keeps_the_branch_it_follows() {
+        if crate::git::plumbing_binary().is_none() {
+            return;
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let (_origin, url) = origin_with_branch(&temp.path().join("origin"), "master");
+        let local = local_repo(&temp.path().join("local"));
+        let remote = Remote::new(&local, &url);
+        // re-running the connection does not move it to the default branch
+        assert_eq!(resolve_branch(&remote, None, Some("main")).unwrap(), "main");
+        // a connection that was removed detects again
+        assert_eq!(resolve_branch(&remote, None, None).unwrap(), "master");
     }
 
     #[test]
@@ -515,7 +558,7 @@ mod tests {
         let url = url::Url::from_file_path(empty.dir()).unwrap().to_string();
         let local = local_repo(&temp.path().join("local"));
         let remote = Remote::new(&local, &url);
-        assert_eq!(resolve_branch(&remote, None).unwrap(), DEFAULT_BRANCH);
+        assert_eq!(resolve_branch(&remote, None, None).unwrap(), DEFAULT_BRANCH);
     }
 
     #[test]

--- a/src/system/history/sync/origin.rs
+++ b/src/system/history/sync/origin.rs
@@ -21,10 +21,14 @@ use crate::ui::prompt;
 
 pub(crate) struct SetOptions {
     pub url: String,
-    pub branch: String,
+    /// The branch asked for; `None` takes the repository's own default branch.
+    pub branch: Option<String>,
     pub mode: SyncMode,
     pub yes: bool,
 }
+
+/// Only for a repository that lists no branches at all.
+const DEFAULT_BRANCH: &str = "main";
 
 /// Connects the setup repository.
 pub(crate) async fn set(store: &Store, tracked: &TrackedSet, opts: &SetOptions) -> Result<()> {
@@ -80,8 +84,12 @@ async fn set_inner(
     // This is the disposable preview repository. The connected repository's
     // remote-tracking ref remains untouched unless the connection is confirmed.
     let remote = Remote::new(repo, &opts.url);
-    if !remote.fetch(&opts.branch)? && repo.ref_oid(UPSTREAM_REF)?.is_some() {
-        repo.delete_ref(UPSTREAM_REF)?;
+    let branch = resolve_branch(&remote, opts.branch.as_deref())?;
+    if !remote.fetch(&branch)? {
+        refuse_missing_branch(&remote, &branch, &opts.url)?;
+        if repo.ref_oid(UPSTREAM_REF)?.is_some() {
+            repo.delete_ref(UPSTREAM_REF)?;
+        }
     }
     let upstream = repo.ref_oid(UPSTREAM_REF)?;
     let repo_state = format::detect(repo, upstream.as_deref())?;
@@ -94,16 +102,15 @@ async fn set_inner(
     let status_before = run::read_status(state_dir)?;
     let connected_before = status_before.origin_url.is_some();
     let same_origin = status_before.origin_url.as_deref() == Some(opts.url.as_str())
-        && status_before.origin_branch.as_deref() == Some(opts.branch.as_str());
+        && status_before.origin_branch.as_deref() == Some(branch.as_str());
     miseprintln!("Every committed tracked-file version is eligible for origin synchronization.");
     // disclosure
-    miseprintln!("Setup repository: {} (branch {})", opts.url, opts.branch);
+    miseprintln!("Setup repository: {} (branch {})", opts.url, branch);
     miseprintln!("Sync mode {}", opts.mode.disclosure());
     crate::system::history::notify::warn_if_release_signing_unavailable();
     match &repo_state {
         RepoState::Empty => miseprintln!(
-            "The repository is empty: the first publication creates `{}` with the mise marker.",
-            opts.branch
+            "The repository is empty: the first publication creates `{branch}` with the mise marker."
         ),
         RepoState::Marked(_) => {
             miseprintln!("The repository is a mise setup repository; continuing.")
@@ -183,7 +190,7 @@ async fn set_inner(
     // say, so `mise settings set history.sync …` keeps working afterwards
     let mode =
         (opts.mode.as_str() != crate::config::Settings::get().history.sync).then_some(opts.mode);
-    write_config(&opts.url, &opts.branch, mode)?;
+    write_config(&opts.url, &branch, mode)?;
     // another repository or branch starts from a clean slate: the previous
     // one's per-path state, pending changes, and conflicts would read its
     // absence of a file as a deletion
@@ -195,7 +202,7 @@ async fn set_inner(
         );
     }
     status.origin_url = Some(opts.url.clone());
-    status.origin_branch = Some(opts.branch.clone());
+    status.origin_branch = Some(branch.clone());
     status.disconnected = false;
     status.adopted = repo_state == RepoState::Unmarked || status.adopted;
     run::write_status(state_dir, &status)?;
@@ -216,6 +223,48 @@ async fn set_inner(
     let outcome = run::sync(&store, &tracked, &SyncRequest::new(!opts.mode.publishes()))?;
     report(&outcome);
     Ok(())
+}
+
+/// The setup branch: the one asked for, else the repository's own default
+/// branch. Assuming `main` reads a repository that does not have it as empty,
+/// and publishes an unrelated root branch beside its real history.
+fn resolve_branch(remote: &Remote<'_>, requested: Option<&str>) -> Result<String> {
+    if let Some(branch) = requested {
+        if branch.trim().is_empty() {
+            bail!("a branch name is required");
+        }
+        return Ok(branch.to_string());
+    }
+    // an unreachable repository is reported by the fetch that follows
+    Ok(super::onboard::default_branch(remote)?.unwrap_or_else(|| DEFAULT_BRANCH.to_string()))
+}
+
+/// A missing branch is only an empty repository when the repository has no
+/// branches at all; otherwise connecting would publish an unrelated root
+/// branch beside the history that is already there.
+fn refuse_missing_branch(remote: &Remote<'_>, branch: &str, url: &str) -> Result<()> {
+    let Ok(refs) = remote.ls_remote() else {
+        return Ok(());
+    };
+    let heads: Vec<&str> = refs
+        .iter()
+        .filter_map(|(_, name)| name.strip_prefix("refs/heads/"))
+        .collect();
+    if heads.is_empty() || heads.contains(&branch) {
+        return Ok(());
+    }
+    let mut listed: Vec<&str> = heads.iter().copied().take(10).collect();
+    listed.sort_unstable();
+    let more = heads.len().saturating_sub(listed.len());
+    let suffix = if more > 0 {
+        format!(" (and {more} more)")
+    } else {
+        String::new()
+    };
+    bail!(
+        "{url} has no branch `{branch}`; it has: {}{suffix}. Connect with `--branch <name>`, or push `{branch}` there first.",
+        listed.join(", ")
+    );
 }
 
 pub(crate) fn report(outcome: &run::SyncOutcome) {
@@ -405,4 +454,101 @@ fn remove_locked(state_dir: &std::path::Path, status: &mut run::SyncStatus) -> R
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::system::history::shadow::HistoryRepo;
+
+    /// A bare repository whose only branch is `name`, advertised through
+    /// `HEAD` the way a hosted repository advertises its default branch.
+    fn origin_with_branch(dir: &std::path::Path, name: &str) -> (HistoryRepo, String) {
+        let repo = HistoryRepo::open_or_init_in(dir).unwrap().unwrap();
+        let tree = repo.empty_object("tree").unwrap();
+        let commit = repo.commit_tree(&tree, vec![], "setup").unwrap();
+        repo.update_ref(&format!("refs/heads/{name}"), &commit, None)
+            .unwrap();
+        std::fs::write(repo.dir().join("HEAD"), format!("ref: refs/heads/{name}\n")).unwrap();
+        let url = url::Url::from_file_path(repo.dir()).unwrap().to_string();
+        (repo, url)
+    }
+
+    fn local_repo(dir: &std::path::Path) -> HistoryRepo {
+        HistoryRepo::open_or_init_in(dir).unwrap().unwrap()
+    }
+
+    #[test]
+    fn an_unrequested_branch_follows_the_repository_default() {
+        if crate::git::plumbing_binary().is_none() {
+            return;
+        }
+        let temp = tempfile::tempdir().unwrap();
+        for name in ["master", "main", "trunk"] {
+            let (_origin, url) = origin_with_branch(&temp.path().join(name), name);
+            let local = local_repo(&temp.path().join(format!("{name}-local")));
+            let remote = Remote::new(&local, &url);
+            assert_eq!(resolve_branch(&remote, None).unwrap(), name);
+        }
+    }
+
+    #[test]
+    fn a_requested_branch_is_taken_as_given() {
+        if crate::git::plumbing_binary().is_none() {
+            return;
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let (_origin, url) = origin_with_branch(&temp.path().join("origin"), "master");
+        let local = local_repo(&temp.path().join("local"));
+        let remote = Remote::new(&local, &url);
+        assert_eq!(resolve_branch(&remote, Some("release")).unwrap(), "release");
+        assert!(resolve_branch(&remote, Some("  ")).is_err());
+    }
+
+    #[test]
+    fn a_repository_without_branches_takes_the_default_name() {
+        if crate::git::plumbing_binary().is_none() {
+            return;
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let empty = local_repo(&temp.path().join("empty"));
+        let url = url::Url::from_file_path(empty.dir()).unwrap().to_string();
+        let local = local_repo(&temp.path().join("local"));
+        let remote = Remote::new(&local, &url);
+        assert_eq!(resolve_branch(&remote, None).unwrap(), DEFAULT_BRANCH);
+    }
+
+    #[test]
+    fn a_missing_branch_is_not_reported_as_an_empty_repository() {
+        if crate::git::plumbing_binary().is_none() {
+            return;
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let (_origin, url) = origin_with_branch(&temp.path().join("origin"), "master");
+        let local = local_repo(&temp.path().join("local"));
+        let remote = Remote::new(&local, &url);
+        assert!(!remote.fetch("main").unwrap());
+        let error = refuse_missing_branch(&remote, "main", &url)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("no branch `main`"), "{error}");
+        assert!(error.contains("master"), "{error}");
+        // the repository's own default branch connects without complaint
+        assert!(remote.fetch("master").unwrap());
+        assert!(refuse_missing_branch(&remote, "master", &url).is_ok());
+    }
+
+    #[test]
+    fn an_empty_repository_still_reads_as_empty() {
+        if crate::git::plumbing_binary().is_none() {
+            return;
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let empty = local_repo(&temp.path().join("empty"));
+        let url = url::Url::from_file_path(empty.dir()).unwrap().to_string();
+        let local = local_repo(&temp.path().join("local"));
+        let remote = Remote::new(&local, &url);
+        assert!(!remote.fetch(DEFAULT_BRANCH).unwrap());
+        assert!(refuse_missing_branch(&remote, DEFAULT_BRANCH, &url).is_ok());
+    }
 }

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -260,6 +260,13 @@ pub(crate) fn sync(
                     origin.url
                 );
             }
+            // a machine that has never synced has no vanished-branch signal,
+            // so a branch this repository does not have (a declaration that
+            // named the wrong one, or omitted it and took the default) must
+            // not read as an empty upstream either
+            if !found {
+                super::origin::refuse_missing_branch(&remote, &origin.branch, &origin.url)?;
+            }
             if !found && repo.ref_oid(UPSTREAM_REF)?.is_some() {
                 repo.delete_ref(UPSTREAM_REF)?;
             }


### PR DESCRIPTION
`mise bootstrap dotfiles origin set <url>` defaulted `--branch` to `main`. A repository whose default branch is `master` has no `main` to fetch, and a missing branch is indistinguishable from an empty one at that point: connecting announced "The repository is empty: the first publication creates `main` with the mise marker", compared nothing against the history that was actually there, and published an unrelated root branch beside it.

Take the repository's own default branch when `--branch` is not given. The `HEAD` symref detection that `mise bootstrap --adopt <url>` already uses is reused rather than duplicated, so both commands resolve the same branch for the same url — which also keeps the url+branch comparison that refuses to move a connected machine consistent between them. A repository that lists no branches at all still falls back to `main`, since the first publication creates it.

A missing branch is also no longer reported as an empty repository. When the requested branch is absent but the repository has other heads, connecting fails and names them, so an explicit `--branch main` against a `master` repository stops instead of creating a second root branch. Bailing rather than warning matches how a setup branch that disappears is already treated during sync.

`--branch` keeps its meaning when passed; only the default changes.

## Validation

- Five focused unit tests in `sync::origin`: the default branch is followed for `master`, `main`, and a name neither fallback would guess (`trunk`, reached only through the `HEAD` symref); an explicit branch is taken as given; a branchless repository takes `main`; and a missing branch is refused while an existing one is not.
- `e2e/cli/test_dotfiles_origin_default_branch`: a setup repository published on `master` reconnects without `--branch`, is never described as empty, gains no `main` beside it, and refuses an explicit `--branch main` while leaving the existing connection in place.
- `cargo test --bin mise sync::origin`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, and `cargo fmt --all` pass with no exclusions.
- `mise run render:usage` regenerated `mise.usage.kdl` and `docs/cli/bootstrap/dotfiles/origin/set.md`.

The cargo-backed `hk` steps could not run in this environment (no Rust toolchain on `PATH` for the task), so `cargo fmt`, `cargo clippy`, `shfmt -d -s`, and `shellcheck` were run directly instead; all pass.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.236.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `mise bootstrap dotfiles origin set` now uses the setup repository’s default branch when `--branch` is omitted.
  - Explicit branch selection remains available.

- **Bug Fixes**
  - Dotfiles repositories using a default branch other than `main` are handled correctly.
  - Existing connections retain their configured branch during reconnection.
  - Missing or unreachable branches are reported clearly instead of being mistaken for empty repositories.

- **Documentation**
  - Updated command help and documentation to describe branch resolution, including the `main` fallback for repositories without branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->