### PR TITLE
fix(dotfiles): keep history locks independent of cache directories

### DIFF
--- a/e2e/cli/test_dotfiles_watch_cache
+++ b/e2e/cli/test_dotfiles_watch_cache
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# The history store owns its locks, even when a service and an interactive
+# shell use different cache directories (for example, a macOS LaunchAgent
+# that does not read XDG_CACHE_HOME from .zshenv).
+require_cmd git
+
+export MISE_HISTORY_WATCH_DEBOUNCE=100ms
+
+echo initial >~/watched
+assert_succeed "mise bootstrap dotfiles track ~/watched"
+
+cat <<'EOF' >>"$MISE_CONFIG_DIR/config.toml"
+
+[bootstrap.services.mise-history]
+builtin = "history-watch"
+EOF
+
+MISE_CACHE_DIR="$HOME/service-cache" mise bootstrap dotfiles watch --json >watch.log 2>&1 &
+watcher=$!
+operation=""
+cleanup() {
+  if [[ -n $operation ]]; then
+    touch "$HOME/release-operation"
+    wait "$operation" || true
+  fi
+  kill "$watcher" 2>/dev/null || true
+  wait "$watcher" || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 100); do
+  grep -q '"event":"started"' watch.log && break
+  sleep 0.2
+done
+assert_contains "cat watch.log" '"event":"started"'
+
+# MISE_CACHE_DIR in the harness differs from the watcher's cache.
+assert "mise bootstrap dotfiles status --json | jq -r .history.watcher" "running"
+assert "mise doctor --json 2>/dev/null | jq -r .dotfiles.watcher" "running"
+# --once also takes the singleton lock, and exits even if that lock regresses.
+assert_contains "mise bootstrap dotfiles watch --once --json" '"event":"already-running"'
+
+# Exercise the XDG fallback as well as the explicit mise cache override.
+assert "env -u MISE_CACHE_DIR XDG_CACHE_HOME='$HOME/shell-cache' mise bootstrap dotfiles status --json | jq -r .history.watcher" "running"
+assert_contains "env -u MISE_CACHE_DIR XDG_CACHE_HOME='$HOME/shell-cache' mise bootstrap dotfiles watch --once --json" '"event":"already-running"'
+
+# A different store still permits its own watcher, even with the same cache.
+assert_not_contains "MISE_STATE_DIR='$HOME/other-state' MISE_CACHE_DIR='$HOME/service-cache' mise bootstrap dotfiles watch --once --json" '"event":"already-running"'
+
+# An operation from the shell cache must also exclude captures by the
+# watcher in the service cache. Intermediate file contents are not history.
+# shellcheck disable=SC2016
+mise bootstrap dotfiles capture -- sh -c '
+  echo intermediate >"$HOME/watched"
+  touch "$HOME/operation-ready"
+  while [ ! -f "$HOME/release-operation" ]; do sleep 0.1; done
+  echo final >"$HOME/watched"
+' >operation.log 2>&1 &
+operation=$!
+for _ in $(seq 1 100); do
+  [[ -f $HOME/operation-ready ]] && break
+  sleep 0.2
+done
+assert_succeed "test -f '$HOME/operation-ready'"
+before="$(mise bootstrap dotfiles history --json -n 0 | jq length)"
+sleep 2
+assert "mise bootstrap dotfiles history --json -n 0 | jq length" "$before"
+touch "$HOME/release-operation"
+wait "$operation"
+operation=""
+assert "mise bootstrap dotfiles history --json -n 0 | jq length" "$((before + 1))"
+
+kill -TERM "$watcher"
+wait "$watcher"
+trap - EXIT
+assert "mise bootstrap dotfiles status --json | jq -r .history.watcher" "declared-not-running"
+# Releasing the lock permits another watcher from either cache directory.
+assert_not_contains "mise bootstrap dotfiles watch --once --json" '"event":"already-running"'

--- a/src/lock_file.rs
+++ b/src/lock_file.rs
@@ -16,8 +16,15 @@ pub(crate) struct LockFile {
 impl LockFile {
     pub(crate) fn new(path: &Path) -> Self {
         let path = dirs::CACHE.join("lockfiles").join(hash_to_str(&path));
+        Self::at(&path)
+    }
+
+    /// Locks this exact path instead of hashing it into the cache directory.
+    /// Use for shared state whose users may have different cache directories.
+    /// The file must remain in place while any process could hold its lock.
+    pub(crate) fn at(path: &Path) -> Self {
         Self {
-            path,
+            path: path.to_path_buf(),
             on_locked: None,
         }
     }
@@ -77,4 +84,28 @@ pub(crate) fn get(path: &Path, force: bool) -> eyre::Result<Option<fslock::LockF
         Some(lock)
     };
     Ok(lock)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_path_coordinates_with_direct_file_lock() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state/watch.lock");
+        let held = LockFile::at(&path).try_lock().unwrap().unwrap();
+        let mut direct = fslock::LockFile::open(&path).unwrap();
+        assert!(!direct.try_lock().unwrap());
+        assert!(LockFile::at(&path).try_lock().unwrap().is_none());
+
+        // Unlocking keeps the file in place so existing descriptors and
+        // future callers continue to coordinate on the same file.
+        drop(held);
+        assert!(path.exists());
+        assert!(direct.try_lock().unwrap());
+        assert!(LockFile::at(&path).try_lock().unwrap().is_none());
+        drop(direct);
+        assert!(LockFile::at(&path).try_lock().unwrap().is_some());
+    }
 }

--- a/src/system/history/checkpoint.rs
+++ b/src/system/history/checkpoint.rs
@@ -150,7 +150,7 @@ impl Store {
 
     /// Serializes captures and index writes.
     pub(crate) fn lock(&self) -> Result<fslock::LockFile> {
-        LockFile::new(&store::store_lock_path_in(&self.state_dir))
+        LockFile::at(&store::store_lock_path_in(&self.state_dir))
             .with_callback(|path| {
                 debug!("waiting for the history store lock {}", display_path(path));
             })

--- a/src/system/history/scope.rs
+++ b/src/system/history/scope.rs
@@ -658,7 +658,7 @@ pub(crate) fn try_operation_lock(
     store: &Store,
     tracked: &TrackedSet,
 ) -> Result<Option<fslock::LockFile>> {
-    let Some(lock) = LockFile::new(&store::operation_lock_in(store.state_dir())).try_lock()? else {
+    let Some(lock) = LockFile::at(&store::operation_lock_in(store.state_dir())).try_lock()? else {
         return Ok(None);
     };
     recover_stale(store, tracked)?;
@@ -689,7 +689,7 @@ fn acquire_operation_lock(store: &Store, wait: std::time::Duration) -> Result<fs
     let deadline = std::time::Instant::now() + wait;
     let mut announced = false;
     let lock = loop {
-        if let Some(lock) = LockFile::new(&path).try_lock()? {
+        if let Some(lock) = LockFile::at(&path).try_lock()? {
             break lock;
         }
         let marker = store::read_marker_in(state_dir)?;
@@ -1077,7 +1077,7 @@ mod tests {
     fn automatic_operation_lock_does_not_wait() {
         let temp = tempfile::tempdir().unwrap();
         let store = Store::open_in(temp.path()).unwrap();
-        let held = LockFile::new(&store::operation_lock_in(temp.path()))
+        let held = LockFile::at(&store::operation_lock_in(temp.path()))
             .try_lock()
             .unwrap()
             .unwrap();

--- a/src/system/history/store.rs
+++ b/src/system/history/store.rs
@@ -6,6 +6,10 @@
 //! in the directory is a rebuildable index or machine-local bookkeeping. Every
 //! function takes the state directory explicitly (`*_in`) so tests can point
 //! it at a temporary directory.
+//!
+//! Locks live alongside the state they protect, opened with `LockFile::at`.
+//! Do not put them in the cache: a service and a shell can use different
+//! cache directories while sharing the same history store.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};

--- a/src/system/history/sync/run.rs
+++ b/src/system/history/sync/run.rs
@@ -465,7 +465,7 @@ pub(crate) fn lock(store: &Store) -> Result<fslock::LockFile> {
 }
 
 pub(crate) fn lock_in(state_dir: &Path) -> Result<fslock::LockFile> {
-    crate::lock_file::LockFile::new(&lock_path(state_dir))
+    crate::lock_file::LockFile::at(&lock_path(state_dir))
         .try_lock()?
         .ok_or_else(|| eyre::eyre!("another setup sync or pull is running; retry shortly"))
 }
@@ -488,7 +488,7 @@ pub(crate) fn update_status(
 pub(crate) fn lock_wait(state_dir: &Path, wait: Duration) -> Result<fslock::LockFile> {
     let deadline = Instant::now() + wait;
     loop {
-        if let Some(lock) = crate::lock_file::LockFile::new(&lock_path(state_dir)).try_lock()? {
+        if let Some(lock) = crate::lock_file::LockFile::at(&lock_path(state_dir)).try_lock()? {
             return Ok(lock);
         }
         if Instant::now() >= deadline {

--- a/src/system/history/watch/runtime.rs
+++ b/src/system/history/watch/runtime.rs
@@ -107,7 +107,7 @@ pub(crate) async fn run(opts: WatchOptions) -> Result<i32> {
     // moment tries again rather than concluding another watcher runs
     let mut watch_lock = None;
     for attempt in 0..WATCH_LOCK_TRIES {
-        if let Some(lock) = LockFile::new(&watch_lock_in(store.state_dir())).try_lock()? {
+        if let Some(lock) = LockFile::at(&watch_lock_in(store.state_dir())).try_lock()? {
             watch_lock = Some(lock);
             break;
         }
@@ -1568,7 +1568,7 @@ impl Capture {
             return self.retry_kind.unwrap_or(Attempt::Failed);
         }
         let operation =
-            match LockFile::new(&store::operation_lock_in(self.store.state_dir())).try_lock() {
+            match LockFile::at(&store::operation_lock_in(self.store.state_dir())).try_lock() {
                 Ok(Some(lock)) => lock,
                 Ok(None) => {
                     self.out.emit(
@@ -1806,10 +1806,7 @@ pub(crate) fn schedule_path_in(state_dir: &Path) -> PathBuf {
 
 /// Whether a watcher currently holds the lock for this store.
 pub(crate) fn is_running(state_dir: &Path) -> bool {
-    matches!(
-        LockFile::new(&watch_lock_in(state_dir)).try_lock(),
-        Ok(None)
-    )
+    matches!(LockFile::at(&watch_lock_in(state_dir)).try_lock(), Ok(None))
 }
 
 struct Shutdown {


### PR DESCRIPTION
A macOS history watcher launched by launchd can use `~/Library/Caches/mise` while an interactive shell sets `XDG_CACHE_HOME=~/.cache`. Both processes share the same history store, but `dotfiles status` reports `declared-not-running` because `LockFile::new` hashes the watcher lock path into each process's cache directory. The same mismatch also bypasses the history operation, store, and sync locks.

Add an explicit-path lock constructor and keep all four history locks alongside the state they protect in `$MISE_STATE_DIR/history`. Processes sharing a history store now detect the same watcher and coordinate writes regardless of `MISE_CACHE_DIR` or `XDG_CACHE_HOME`. Other subsystems retain their existing cache-based locks.

The regression test covers status and doctor, duplicate-watcher prevention under both cache overrides, independent stores, operation capture isolation across caches, and lock release/restart. It reproduces the exact `declared-not-running` failure with mise 2026.9.3 and passes with this change.

Validation on macOS arm64:
- All-features build (with `--features openssl/vendored` because the host has no system OpenSSL development library).
- 155 history unit tests and the new explicit-path lock unit test.
- Watcher, cache-mismatch, pending-file, throttling, and capture e2e scripts through `mise run test:e2e`.
- `cargo clippy --workspace --all-features --all-targets --features openssl/vendored -- -D warnings`.
- Scoped hk formatting and shell lint checks.

Upgrade note: existing watchers must be stopped and restarted with the updated binary; old and new binaries use different history lock paths.

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved history watcher coordination when services and interactive shells use different cache directories.
  - Watcher status, diagnostics, and one-time watch commands now consistently recognize active watchers across supported cache configurations.
  - History capture operations are correctly isolated until the associated watcher is released.
  - Stopping a watcher now reliably releases its lock, allowing a new watcher to start.

- **Documentation**
  - Clarified how history watcher state is coordinated across cache and state locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->