### PR TITLE
fix(sandbox): allow metadata on ancestors of readable paths

### DIFF
--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -172,9 +172,12 @@ control when `--allow-net` cannot express it.
 
 When reads are restricted, Seatbelt requires data access to the root directory for process startup.
 Sandboxed processes can enumerate names directly under `/`, but cannot read unallowed entries or
-their descendants. Mise also permits metadata access to `/private` so portable executables can
-resolve paths through macOS's private filesystem hierarchy; this does not permit listing that
-directory or reading its descendants.
+their descendants. Mise also permits metadata access to the directories leading to every readable
+path above — the system paths, `MISE_DATA_DIR`, and anything named by `--allow-read` or
+`--allow-write`. `realpath` resolves a path one component at a time, so without this a portable
+executable could not resolve its own location even inside a fully readable directory. The permission
+is metadata only: those directories can be stat'd, but not listed, and their other entries stay
+unreadable.
 
 ### Windows
 

--- a/e2e/tasks/test_task_sandbox_ancestor_metadata_macos
+++ b/e2e/tasks/test_task_sandbox_ancestor_metadata_macos
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A task's `allow_read` path is opened back up with Seatbelt's `(subpath …)`, but
+# `realpath(3)` resolves a path one component at a time. Without metadata access
+# to the directories leading to that path, resolving a file inside it fails with
+# EPERM even though reading the same file works — the kernel's path walk only
+# permission-checks the target vnode, which is why the two disagree.
+#
+# Ruby does this to its own executable at startup, so the third-party tap
+# metadata sandbox died before evaluating anything.
+# https://github.com/jdx/mise/discussions/12969
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "skipping: Seatbelt filesystem sandboxing is macOS-only"
+  exit 0
+fi
+
+if [[ ! -x /usr/bin/ruby ]]; then
+  echo "skipping: no /usr/bin/ruby to resolve a path with"
+  exit 0
+fi
+
+mkdir -p nested/deep
+echo payload >nested/deep/payload.txt
+
+# This only discriminates while the fixture sits outside the subtrees the
+# profile reads unconditionally: under one of those the walk is already
+# permitted and the test would pass without exercising anything. On CI the
+# harness lands in $TMPDIR — /private/var/folders/... on a macOS runner, whose
+# /private/var is not in SYSTEM_READ_PATHS — but TMPDIR=/tmp locally would put
+# it somewhere always readable. Skip loudly there rather than pass vacuously.
+FIXTURE="$(cd nested/deep && pwd -P)"
+case "$FIXTURE" in
+  /System/* | /Library/* | /usr/* | /bin/* | /sbin/* | /dev/* | /etc/* | /var/run/* | /tmp/* | /private/tmp/* | /private/etc/* | /private/var/run/* | /opt/homebrew/* | /nix/*)
+    echo "skipping: $FIXTURE is inside an always-readable subtree, so the walk is permitted without the ancestor rules"
+    exit 0
+    ;;
+esac
+
+# Absolute, because `getcwd` is denied under this profile and resolving a
+# relative path needs it — that is a separate gap, not the one being fixed here.
+cat >mise.toml <<TOML
+[tasks.resolve]
+run = "/usr/bin/ruby --disable-gems -e 'puts File.realpath(ARGV[0]); puts File.read(ARGV[0])' $PWD/nested/deep/payload.txt"
+allow_read = ["$PWD/nested/deep"]
+TOML
+
+# Assert both halves. Reading it is what already worked, so a read that still
+# works is part of what this pins; resolving it is the regression.
+assert_contains "mise run resolve" "nested/deep/payload.txt"
+assert_contains "mise run resolve" "payload"

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -373,6 +373,7 @@ impl Exec {
                 allow_env: self.allow_env,
                 pass_through_env: vec![],
                 cache_env: vec![],
+                symlinked_allow_paths: vec![],
             },
         );
         sandbox.resolve_paths();

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1296,6 +1296,7 @@ impl Run {
                     allow_env: self.allow_env.clone(),
                     pass_through_env: vec![],
                     cache_env: vec![],
+                    symlinked_allow_paths: vec![],
                 },
             ),
         };

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -1,3 +1,6 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
 use super::SandboxConfig;
 
 /// Sanitize a string for use in an SBPL profile.
@@ -23,6 +26,67 @@ const SYSTEM_READ_PATHS: &[&str] = &[
     "/opt/homebrew",
     "/nix",
 ];
+
+/// Ancestor directories a read-restricted profile has to expose metadata for,
+/// each one once and in a stable order.
+///
+/// `realpath(3)` resolves a path one component at a time, so a denied `lstat`
+/// on an intermediate directory fails the whole call even when the target
+/// subtree is fully readable — an ordinary `open` of the same file still
+/// succeeds, because the kernel's path walk only permission-checks the target
+/// vnode. Ruby hits this before running a line of code: the portable builds use
+/// `--enable-load-relative` and resolve their own executable at startup. That
+/// breaks evaluating a third-party tap definition for every Ruby mise can pick
+/// — the provisioned one under `MISE_DATA_DIR`
+/// (<https://github.com/jdx/mise/discussions/12969>) and Homebrew's vendored
+/// one under `/opt/homebrew` alike; `/private/tmp`
+/// (<https://github.com/jdx/mise/discussions/12937>) was the first case found
+/// and is covered here by the same derivation rather than by a rule of its own.
+///
+/// Metadata only, so this does not widen what the sandbox exposes in kind: a
+/// directory named here can be `stat`ed but not listed, and its entries stay
+/// unreadable. Nothing outside the ancestor chains becomes reachable.
+///
+/// `/` is left out. Nothing asks for its metadata — a profile carrying only
+/// `/opt` lets a Ruby under `/opt/homebrew` start — and
+/// `(allow file-read-data (literal "/"))` already covers process startup.
+///
+/// Lexical, which only matters for a path that does not exist:
+/// [`SandboxConfig::resolve_paths`] canonicalizes the ones that do, and a rule
+/// naming a missing directory is inert either way.
+fn metadata_ancestors<'a>(paths: impl IntoIterator<Item = &'a Path>) -> BTreeSet<PathBuf> {
+    let root = Path::new("/");
+    paths
+        .into_iter()
+        .flat_map(|path| path.ancestors().skip(1))
+        .filter(|ancestor| *ancestor != root && !ancestor.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .collect()
+}
+
+/// [`metadata_ancestors`] plus `path` itself.
+///
+/// For a spelling no `(subpath …)` rule names — a symlink, since Seatbelt
+/// matches the canonical path — the link node has to be `lstat`-able too, or the
+/// walk stops on it rather than on one of its parents. Still metadata: the link
+/// can be resolved, and what it points at is readable only because the
+/// canonical target has its own rule.
+fn walk_through(path: &Path) -> BTreeSet<PathBuf> {
+    let mut paths = metadata_ancestors(std::iter::once(path));
+    paths.insert(path.to_path_buf());
+    paths
+}
+
+/// [`metadata_ancestors`] for a directory whose rule names `target` while
+/// callers reach it as `configured`. The two differ only when `configured` runs
+/// through a symlink, and then both spellings have to be walkable.
+fn walk_metadata(configured: &Path, target: &Path) -> BTreeSet<PathBuf> {
+    let mut paths = metadata_ancestors(std::iter::once(target));
+    if configured != target {
+        paths.extend(walk_through(configured));
+    }
+    paths
+}
 
 /// Generate a Seatbelt (SBPL) profile string from sandbox config.
 pub(crate) async fn generate_seatbelt_profile(
@@ -54,14 +118,20 @@ pub(crate) async fn generate_seatbelt_profile(
         // Seatbelt requires data access to the root vnode for process startup and getcwd.
         // This exposes names directly under `/`, but descendants still obey the read rules.
         rules.push("(allow file-read-data (literal \"/\"))".to_string());
-        // Portable executables may resolve paths through macOS's `/private` hierarchy
-        // during startup (for example, Ruby built with --enable-load-relative).
-        rules.push("(allow file-read-metadata (literal \"/private\"))".to_string());
         for path in SYSTEM_READ_PATHS {
             rules.push(format!("(allow file-read* (subpath \"{path}\"))"));
         }
+        // Seatbelt matches a rule against the canonical path, so a subpath
+        // naming a symlinked data dir grants nothing at all — not even a read.
+        // Name what it resolves to; `walk_metadata` keeps the configured
+        // spelling walkable. Unlike this one, SYSTEM_READ_PATHS is left alone:
+        // it already lists both spellings where they differ (`/tmp` and
+        // `/private/tmp`, `/etc` and `/private/etc`, `/var/run` and
+        // `/private/var/run`).
         let data_dir = &*crate::env::MISE_DATA_DIR;
-        let data_str = sbpl_escape(&data_dir.to_string_lossy());
+        let data_canonical = data_dir.canonicalize();
+        let data_target = data_canonical.as_deref().unwrap_or(data_dir.as_path());
+        let data_str = sbpl_escape(&data_target.to_string_lossy());
         rules.push(format!("(allow file-read* (subpath \"{data_str}\"))"));
         for path in &config.allow_read {
             let path_str = sbpl_escape(&path.to_string_lossy());
@@ -73,6 +143,28 @@ pub(crate) async fn generate_seatbelt_profile(
             let path_str = sbpl_escape(&path.to_string_lossy());
             rules.push(format!("(allow file-read* (subpath \"{path_str}\"))"));
             rules.push(format!("(allow file-read* (literal \"{path_str}\"))"));
+        }
+        // Every path allowed above, so a `realpath` of anything inside one of
+        // them can walk down to it. See `metadata_ancestors`.
+        let mut metadata = metadata_ancestors(
+            SYSTEM_READ_PATHS
+                .iter()
+                .copied()
+                .map(Path::new)
+                .chain(config.allow_read.iter().map(PathBuf::as_path))
+                .chain(config.allow_write.iter().map(PathBuf::as_path)),
+        );
+        metadata.extend(walk_metadata(data_dir, data_target));
+        // The allow-list entries above are canonical — `resolve_paths` made them
+        // so — and the spellings it replaced are the ones a caller will use.
+        for path in &config.symlinked_allow_paths {
+            metadata.extend(walk_through(path));
+        }
+        for ancestor in metadata {
+            let path_str = sbpl_escape(&ancestor.to_string_lossy());
+            rules.push(format!(
+                "(allow file-read-metadata (literal \"{path_str}\"))"
+            ));
         }
     }
 
@@ -140,12 +232,9 @@ pub(crate) async fn generate_seatbelt_profile(
 
 #[cfg(test)]
 mod tests {
+    // `Path` and `PathBuf` come from the parent module.
     use super::*;
-    use std::{
-        fs,
-        path::{Path, PathBuf},
-        process::Command,
-    };
+    use std::{fs, process::Command};
 
     #[tokio::test]
     async fn test_deny_write_profile() {
@@ -249,9 +338,259 @@ mod tests {
         assert!(!read(&denied_file).status.success());
     }
 
+    #[tokio::test]
+    async fn test_deny_read_allows_metadata_on_ancestors_of_system_paths() {
+        let config = SandboxConfig {
+            deny_read: true,
+            ..Default::default()
+        };
+        let profile = generate_seatbelt_profile(&config, None).await;
+        // `/private` is derived now rather than written by hand, so assert it
+        // explicitly: it is what made Ruby under `/private/tmp` start again.
+        for ancestor in ["/private", "/private/var", "/var", "/opt"] {
+            assert!(
+                profile.contains(&format!(
+                    "(allow file-read-metadata (literal \"{ancestor}\"))"
+                )),
+                "no metadata rule for {ancestor} in:\n{profile}"
+            );
+        }
+        // Root is already covered by the file-read-data rule and nothing asks
+        // for its metadata, so it should not appear.
+        assert!(!profile.contains("(allow file-read-metadata (literal \"/\"))"));
+    }
+
+    #[tokio::test]
+    async fn test_deny_read_allows_metadata_on_ancestors_of_the_data_dir() {
+        // Derived from the running configuration rather than hardcoded: the
+        // data dir moves with MISE_DATA_DIR, and the Ruby mise provisions for
+        // tap metadata lives under it.
+        let config = SandboxConfig {
+            deny_read: true,
+            ..Default::default()
+        };
+        let profile = generate_seatbelt_profile(&config, None).await;
+        let data_dir = &*crate::env::MISE_DATA_DIR;
+        let mut checked = 0;
+        for ancestor in data_dir.ancestors().skip(1) {
+            if ancestor == Path::new("/") || ancestor.as_os_str().is_empty() {
+                break;
+            }
+            assert!(
+                profile.contains(&format!(
+                    "(allow file-read-metadata (literal \"{}\"))",
+                    ancestor.display()
+                )),
+                "no metadata rule for {} in:\n{profile}",
+                ancestor.display()
+            );
+            checked += 1;
+        }
+        assert!(
+            checked > 0,
+            "{} has no ancestor to check",
+            data_dir.display()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_allow_read_and_allow_write_ancestors_get_metadata() {
+        let root = tempfile::tempdir().unwrap();
+        let readable = root.path().join("read").join("deep");
+        let writable = root.path().join("write").join("deep");
+        fs::create_dir_all(&readable).unwrap();
+        fs::create_dir_all(&writable).unwrap();
+        let readable = readable.canonicalize().unwrap();
+        let writable = writable.canonicalize().unwrap();
+
+        let mut config = SandboxConfig {
+            allow_read: vec![readable.clone()],
+            allow_write: vec![writable.clone()],
+            ..Default::default()
+        };
+        config.resolve_paths();
+        let profile = generate_seatbelt_profile(&config, None).await;
+
+        // A write-allowed path is implicitly readable, so it needs the walk too.
+        for path in [&readable, &writable] {
+            let parent = path.parent().unwrap();
+            assert!(
+                profile.contains(&format!(
+                    "(allow file-read-metadata (literal \"{}\"))",
+                    parent.display()
+                )),
+                "no metadata rule for {} in:\n{profile}",
+                parent.display()
+            );
+        }
+    }
+
+    #[test]
+    fn test_walk_metadata_is_just_the_ancestors_when_the_path_is_canonical() {
+        let path = Path::new("/a/b/c");
+        assert_eq!(
+            walk_metadata(path, path),
+            [PathBuf::from("/a"), PathBuf::from("/a/b")]
+                .into_iter()
+                .collect::<BTreeSet<_>>()
+        );
+    }
+
+    #[test]
+    fn test_walk_metadata_covers_both_spellings_of_a_symlinked_path() {
+        // Seatbelt matches the canonical path, so the rule names the target —
+        // but a caller reaching it through the configured path has to `lstat`
+        // the link itself and everything above it as well.
+        let configured = Path::new("/Users/me/data");
+        let target = Path::new("/Volumes/tools/mise");
+        assert_eq!(
+            walk_metadata(configured, target),
+            [
+                "/Users",
+                "/Users/me",
+                "/Users/me/data",
+                "/Volumes",
+                "/Volumes/tools",
+            ]
+            .into_iter()
+            .map(PathBuf::from)
+            .collect::<BTreeSet<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ancestor_metadata_is_emitted_once_per_directory() {
+        // `/private/tmp`, `/private/etc` and `/private/var/run` all descend
+        // from `/private`; one rule covers them.
+        let config = SandboxConfig {
+            deny_read: true,
+            ..Default::default()
+        };
+        let profile = generate_seatbelt_profile(&config, None).await;
+        assert_eq!(
+            profile
+                .matches("(allow file-read-metadata (literal \"/private\"))")
+                .count(),
+            1
+        );
+    }
+
     #[cfg(target_os = "macos")]
     #[tokio::test]
-    async fn test_private_metadata_does_not_expose_directory_contents() {
+    async fn test_ancestor_metadata_lets_a_nested_path_resolve() {
+        // The defect: `realpath(3)` walks component by component, so a file
+        // inside a fully allowed subtree could not be resolved while the
+        // directories leading to it were denied — while an ordinary read of the
+        // same file succeeded, because the kernel's path walk only checks the
+        // target. Ruby does this to its own executable at startup, which is what
+        // broke evaluating a third-party tap definition.
+        let root = tempfile::tempdir().unwrap();
+        let nested = root.path().join("allowed").join("deep");
+        fs::create_dir_all(&nested).unwrap();
+        let file = nested.join("payload.txt");
+        fs::write(&file, "payload").unwrap();
+        let nested = nested.canonicalize().unwrap();
+        let file = file.canonicalize().unwrap();
+
+        let mut config = SandboxConfig {
+            deny_read: true,
+            allow_read: vec![nested],
+            ..Default::default()
+        };
+        config.resolve_paths();
+        let profile = generate_seatbelt_profile(&config, None).await;
+
+        // Assert both halves: the two disagreeing is the signature of the bug,
+        // so a read that still works is part of what is being pinned.
+        let script = r#"
+path = ARGV[0]
+puts "realpath #{File.realpath(path)}"
+puts "read #{File.read(path)}"
+"#;
+        let output = Command::new("sandbox-exec")
+            .args([
+                "-p",
+                &profile,
+                "--",
+                "/usr/bin/ruby",
+                "--disable-gems",
+                "-e",
+                script,
+            ])
+            .arg(&file)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "sandboxed Ruby failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            format!("realpath {}\nread payload\n", file.display())
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn test_metadata_reaches_an_allow_listed_path_through_its_symlink() {
+        // `resolve_paths` canonicalizes the allow-list and Seatbelt matches the
+        // canonical path, so the rule names the target. A caller still refers to
+        // the directory the way it was allowed, and that walk has to survive —
+        // naming the target alone leaves it failing on the link.
+        let root_dir = tempfile::tempdir().unwrap();
+        let root = root_dir.path().canonicalize().unwrap();
+        let target = root.join("target");
+        fs::create_dir_all(target.join("deep")).unwrap();
+        fs::write(target.join("deep").join("payload.txt"), "payload").unwrap();
+        std::os::unix::fs::symlink(&target, root.join("link")).unwrap();
+        let configured = root.join("link").join("deep");
+
+        let mut config = SandboxConfig {
+            deny_read: true,
+            allow_read: vec![configured.clone()],
+            ..Default::default()
+        };
+        config.resolve_paths();
+        assert_eq!(config.allow_read, vec![target.join("deep")]);
+        assert_eq!(config.symlinked_allow_paths, vec![configured.clone()]);
+
+        let profile = generate_seatbelt_profile(&config, None).await;
+        let script = r#"
+path = ARGV[0]
+puts "realpath #{File.realpath(path)}"
+puts "read #{File.read(path)}"
+"#;
+        let output = Command::new("sandbox-exec")
+            .args([
+                "-p",
+                &profile,
+                "--",
+                "/usr/bin/ruby",
+                "--disable-gems",
+                "-e",
+                script,
+            ])
+            .arg(configured.join("payload.txt"))
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "sandboxed Ruby failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            format!(
+                "realpath {}\nread payload\n",
+                target.join("deep").join("payload.txt").display()
+            )
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn test_ancestor_metadata_does_not_expose_directory_contents() {
         let config = SandboxConfig {
             deny_read: true,
             ..Default::default()
@@ -265,13 +604,27 @@ mod tests {
                 .unwrap()
         };
 
-        let metadata = run("/usr/bin/stat", &["-f", "%N", "/private"]);
+        // Each reachable ancestor answers `stat` and nothing more.
+        for dir in ["/private", "/var", "/opt"] {
+            let metadata = run("/usr/bin/stat", &["-f", "%N", dir]);
+            assert!(
+                metadata.status.success(),
+                "sandboxed stat {dir} failed: {}",
+                String::from_utf8_lossy(&metadata.stderr)
+            );
+            assert!(
+                !run("/bin/ls", &[dir]).status.success(),
+                "sandboxed ls {dir} succeeded"
+            );
+        }
+        // A directory that is not an ancestor of anything allowed stays
+        // invisible, so what widened is the ancestor chains and not the
+        // filesystem.
         assert!(
-            metadata.status.success(),
-            "sandboxed stat failed: {}",
-            String::from_utf8_lossy(&metadata.stderr)
+            !run("/usr/bin/stat", &["-f", "%N", "/Applications"])
+                .status
+                .success()
         );
-        assert!(!run("/bin/ls", &["/private"]).status.success());
     }
 
     #[tokio::test]

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -32,6 +32,16 @@ pub(crate) struct SandboxConfig {
     pub pass_through_env: Vec<String>,
     /// Exact hashed environment names that survive an active env sandbox.
     pub cache_env: Vec<String>,
+    /// Allow-list spellings [`SandboxConfig::resolve_paths`] replaced with a
+    /// canonical target, for the entries that had one.
+    ///
+    /// Seatbelt matches a rule against the canonical path, so a caller reaching
+    /// an allowed directory through the symlink it was named by still has to
+    /// `lstat` the link and the directories above it. Only the macOS profile
+    /// needs this — Landlock resolves paths itself and restricts neither the
+    /// walk nor `stat`.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    pub symlinked_allow_paths: Vec<PathBuf>,
 }
 
 /// Minimal env vars inherited when deny_env is active.
@@ -126,7 +136,11 @@ impl SandboxConfig {
     /// Resolve allow_* paths to absolute paths relative to cwd.
     pub(crate) fn resolve_paths(&mut self) {
         let cwd = std::env::current_dir().unwrap_or_default();
-        let resolve = |paths: &mut Vec<PathBuf>| {
+        // Keep the spelling a canonicalization replaces. It is the one a caller
+        // inside the sandbox will use, and macOS has to let a walk take that
+        // route — see `symlinked_allow_paths`.
+        let mut symlinked = Vec::new();
+        let mut resolve = |paths: &mut Vec<PathBuf>| {
             paths.retain(|p| !p.as_os_str().is_empty());
             for p in paths.iter_mut() {
                 *p = replace_path(&*p);
@@ -134,13 +148,16 @@ impl SandboxConfig {
                     *p = cwd.join(&*p);
                 }
                 // Canonicalize to resolve symlinks (e.g., /var -> /private/var on macOS)
-                if let Ok(canonical) = p.canonicalize() {
-                    *p = canonical;
+                if let Ok(canonical) = p.canonicalize()
+                    && canonical != *p
+                {
+                    symlinked.push(std::mem::replace(p, canonical));
                 }
             }
         };
         resolve(&mut self.allow_read);
         resolve(&mut self.allow_write);
+        self.symlinked_allow_paths = symlinked;
     }
 
     /// Compute effective deny flags, accounting for allow_* implying deny_*.
@@ -433,6 +450,33 @@ mod tests {
         };
 
         assert_eq!(config.missing_allow_paths(), vec![missing.as_path()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_resolve_paths_keeps_the_spelling_a_canonicalization_replaced() {
+        // The replaced spelling is the one a caller inside the sandbox uses, and
+        // macOS has to keep that route walkable. A path that was already
+        // canonical contributes nothing.
+        let root_dir = tempfile::tempdir().unwrap();
+        let root = root_dir.path().canonicalize().unwrap();
+        let target = root.join("target");
+        let plain = root.join("plain");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::create_dir_all(&plain).unwrap();
+        std::os::unix::fs::symlink(&target, root.join("link")).unwrap();
+        let through_link = root.join("link");
+
+        let mut config = SandboxConfig {
+            allow_read: vec![through_link.clone()],
+            allow_write: vec![plain.clone()],
+            ..Default::default()
+        };
+        config.resolve_paths();
+
+        assert_eq!(config.allow_read, vec![target]);
+        assert_eq!(config.allow_write, vec![plain]);
+        assert_eq!(config.symlinked_allow_paths, vec![through_link]);
     }
 
     #[test]

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -468,6 +468,8 @@ impl TaskExecutor {
                 .chain(self.sandbox.cache_env.iter())
                 .cloned()
                 .collect(),
+            // Filled in by `resolve_paths` below.
+            symlinked_allow_paths: vec![],
         };
         sandbox.resolve_paths();
         Ok(sandbox)


### PR DESCRIPTION
Credit where it belongs: **@Guria diagnosed this in #12969** and the diagnosis is
correct as written — "nothing re-allows the **intermediate directories** of those
subpaths. Ruby resolves its own binary with a userland `realpath` that `lstat`s
every component, so `lstat("/Users")` matches only `(deny file-read*)`". This PR
is that fix, plus two things I found confirming it is not specific to `$HOME`.

## The defect

A read-restricted Seatbelt profile denies `file-read*` and opens the readable
subtrees back up with `(subpath …)`, but never allowed `file-read-metadata` on
the directories leading to them. `realpath(3)` resolves a path one component at
a time, so a denied `lstat` on an intermediate directory fails the whole call —
while an ordinary read of the same file succeeds, because the kernel's path walk
only permission-checks the target vnode. The two disagreeing is the signature.

Ruby hits it before running a line of code: the portable builds use
`--enable-load-relative` and resolve their own executable at startup.

```
.../bin/ruby: Operation not permitted @ rb_check_realpath_internal (Errno::EPERM)
mise ERROR failed to evaluate Casks/<token>.rb
mise ERROR sandbox-exec exited with non-zero status: exit code 1
```

### It is every Ruby mise can pick, not just one under `$HOME`

`ruby_for_metadata` in `src/system/packages/brew/tap.rs` chooses between three:

| Ruby | path | on 2026.9.3 |
| --- | --- | --- |
| provisioned by `source::ruby_bin()` — what `apply` uses | `MISE_DATA_DIR/installs/ruby/…` | **EPERM** (`/Users`, `$HOME`, `.local`, `share` denied) |
| Homebrew's own vendored portable Ruby | `/opt/homebrew/Library/Homebrew/vendor/portable-ruby/…` | **EPERM** (`/opt` denied) |
| macOS system Ruby | `/usr/bin/ruby` | 2.6, rejected by the Ruby 3+ requirement |

So on macOS, evaluating a third-party tap that publishes no API metadata — the
path #12774 added — does not currently succeed by any route. Reproduced on
2026.9.3 against `brew-cask:ctrlspice/otel-desktop-viewer/otel-desktop-viewer`
(the tap from discussion #995): `Casks/otel-desktop-viewer.rb` fetches 200 OK at
the pinned commit, then the eval dies in `rb_check_realpath_internal`.

### Relationship to #12940

#12940 fixed the `/private/tmp` report (#12937) by writing one rule by hand:

```rust
rules.push("(allow file-read-metadata (literal \"/private\"))".to_string());
```

That is the right rule for the right reason, applied to one of the paths that
needs it. This PR derives the set instead, so `/private` keeps coming out of it —
pinned by a unit test that names `/private` explicitly, so the case #12940 closed
cannot regress.

## The change

`metadata_ancestors` collects the ancestors of every path the profile already
allows for reading — `SYSTEM_READ_PATHS`, `MISE_DATA_DIR`, `--allow-read`, and
`--allow-write` (already implicitly readable) — and emits one
`file-read-metadata` literal each. With the default settings that is eight rules:

```
/Users  /Users/<user>  /Users/<user>/.local  /Users/<user>/.local/share
/opt  /private  /private/var  /var
```

`/` is deliberately excluded: nothing asks for its metadata (a profile carrying
only `/opt` is enough for a Ruby under `/opt/homebrew` to start) and
`(allow file-read-data (literal "/"))` already covers process startup.

### A symlinked `MISE_DATA_DIR` needed one more thing

Raised by Greptile, and measuring it showed the gap is bigger than the ancestor
set. Seatbelt matches a rule against the **canonical** path, so
`(allow file-read* (subpath "<symlinked data dir>"))` grants nothing at all —
not even a read — which means a symlinked data dir is already unusable under a
read-restricted profile on main, before `realpath` is reached:

| profile allows | access via | `File.read` | `File.realpath` |
| --- | --- | --- | --- |
| the symlink path (what main emits) | symlink path | **EPERM** | EPERM |
| the canonical target | symlink path | **EPERM** | EPERM @ the link's parent |
| the canonical target | canonical path | ok | ok |
| canonical target **+ metadata on the link and its ancestors** | either | ok | ok |

So the data dir's subpath rule now names `canonicalize()` (falling back to the
configured path when it cannot be resolved), and `walk_metadata` contributes
both spellings when they differ. `ls` of the link's parent stays denied.

`SandboxConfig::resolve_paths` does the same canonicalization to `--allow-read`
and `--allow-write`, so — raised by CodeRabbit — it now keeps the spellings it
replaced and the profile walks those too. Ancestors alone are not enough there:
the walk stops on the **link node itself**, which no `(subpath …)` rule names
once the rule points at the target, so `walk_through` contributes the path as
well as what is above it.

`SYSTEM_READ_PATHS` is deliberately not canonicalized — it already lists both
spellings where they differ (`/tmp` and `/private/tmp`, `/etc` and
`/private/etc`, `/var/run` and `/private/var/run`). Landlock needs none of this:
it resolves paths itself and restricts neither the walk nor `stat`, so the new
field is macOS-only.

**Linux is unaffected.** Landlock binds rules to the file hierarchy and has no
metadata/`stat` access right at all, so path walking is not restricted and
`realpath` already works there.

## The permission stays narrow

Verified by feeding the exact rule text to `sandbox-exec` directly:

| check | result |
| --- | --- |
| Homebrew portable Ruby 3.4.8 starts | **yes** with the ancestor rules, `EPERM` without |
| `File.realpath` under a `$HOME`- or tempdir-nested allow-list | **fails** without, **succeeds** with; `File.read` works either way |
| `ls /opt`, `/Users`, `$HOME`, `.local`, `share`, `/var`, `/private`, `/private/var` | **denied**, all eight |
| `stat` those same directories | allowed — which is the point |
| `stat /Applications`, `/Volumes` (not ancestors of anything allowed) | **denied**, unchanged |
| sibling file next to an allowed file, with the parent now stat-able | still **unreadable** |

So what widened is the ancestor chains, by metadata only, and not the filesystem.

## Tests

Unit, on the profile text:

- `test_deny_read_allows_metadata_on_ancestors_of_system_paths` — `/opt`, `/var`,
  `/private`, `/private/var` present; `/` absent
- `test_deny_read_allows_metadata_on_ancestors_of_the_data_dir` — expectations
  built from `MISE_DATA_DIR` rather than hardcoded
- `test_allow_read_and_allow_write_ancestors_get_metadata` — covers the
  user-supplied allow-lists through `resolve_paths`
- `test_ancestor_metadata_is_emitted_once_per_directory` — `/private` once,
  though three allowed paths descend from it
- `test_walk_metadata_is_just_the_ancestors_when_the_path_is_canonical` and
  `test_walk_metadata_covers_both_spellings_of_a_symlinked_path` — the symlink
  handling, tested on the pure helper because `MISE_DATA_DIR` is a process-global
  `Lazy` that a test cannot vary inside the test binary
- `test_resolve_paths_keeps_the_spelling_a_canonicalization_replaced` (in
  `src/sandbox/mod.rs`) — the recording itself, including that an
  already-canonical entry contributes nothing

Runtime, macOS-gated, through `sandbox-exec` like the existing tests there:

- `test_ancestor_metadata_lets_a_nested_path_resolve` — the regression test.
  Asserts `File.realpath` **and** `File.read`, since the two disagreeing is what
  the bug looked like. Confirmed by hand that it fails with
  `Errno::EPERM @ realpath_rec` before this change and passes after
- `test_metadata_reaches_an_allow_listed_path_through_its_symlink` — reads and
  resolves through a symlinked `allow_read` entry under the generated profile
- `test_ancestor_metadata_does_not_expose_directory_contents` — generalizes the
  `/private`-only test from #12940 to the table above

E2E: `e2e/tasks/test_task_sandbox_ancestor_metadata_macos` runs the same check
through a task's `allow_read`, mirroring the Linux-gated
`e2e/tasks/test_task_sandbox_missing_path`. Two things stated in its comments
rather than left for a reviewer to find:

- it uses an **absolute** path, because `getcwd` is denied under this profile and
  resolving a relative path needs it. That is a separate gap and not one this PR
  claims to close
- it only discriminates while the test directory sits outside the always-readable
  subtrees, so it now checks that precondition and **skips with a message rather
  than passing vacuously**. On the macOS runner the harness lands in
  `/private/var/folders/…`, whose `/private/var` is not in `SYSTEM_READ_PATHS`, so
  it does exercise the change there; `TMPDIR=/tmp` locally would not

No local `cargo` build — compilation and the test run are left to CI, where
`unit-macos` runs both `cargo test --all-features` and the e2e suite. What CI
cannot check cheaply is whether the emitted SBPL means what it is supposed to, so
that part was verified directly against `sandbox-exec` as tabulated above.

Fixes #12969. Finishes what #12940 started for #12937.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.236.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS sandbox support for accessing allowed files through nested paths and symbolic links.
  - Tasks can now resolve permitted paths component by component without gaining access to directory listings or unrelated entries.
  - Expanded handling of metadata permissions for readable and writable paths.

- **Documentation**
  - Clarified macOS sandbox metadata access and its limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->