### PR TITLE
fix(brew-cask): leave a running self-updating app to update itself

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -160,10 +160,14 @@ default decision: `latest` and matching receipt versions skip. Otherwise, casks
 with a single owned app upgrade when its live `CFBundleShortVersionString` and
 `CFBundleVersion` indicate an older version using Homebrew's comparison rules,
 including CSV and combined short/build versions. Current, newer, unreadable, or
-incomparable app versions skip replacement. mise checks again after downloading
-and acquiring the install lock; an external self-updater can still change the app
-between that check and replacement. Dry-run reports the decision without replacing
-the app.
+incomparable app versions skip replacement. An outdated app that is running is
+also skipped and left to update itself. Browsers, Electron apps, and similar
+launch helper processes from their bundle on demand, so replacing the bundle
+under a live process strands every helper it starts afterwards; the app's own
+updater moves between versions without that. mise checks again after
+downloading and acquiring the install lock; an external self-updater can still
+change the app between that check and replacement. Dry-run reports the decision
+without replacing the app.
 
 `mise bootstrap status` marks these entries as `installed (auto-updates)`.
 For mise-owned casks, the `Current` column is the version recorded in the mise

--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -165,9 +165,12 @@ also skipped and left to update itself. Browsers, Electron apps, and similar
 launch helper processes from their bundle on demand, so replacing the bundle
 under a live process strands every helper it starts afterwards; the app's own
 updater moves between versions without that. mise checks again after
-downloading and acquiring the install lock; an external self-updater can still
-change the app between that check and replacement. Dry-run reports the decision
-without replacing the app.
+downloading and acquiring the install lock, and once more right before the
+bundle is replaced, because preflight steps and installers can start the app
+themselves; that last skip restores what preflight protected and leaves the
+receipt unchanged. An external self-updater can still change the app between
+the lock check and replacement. Dry-run reports the decision without replacing
+the app.
 
 `mise bootstrap status` marks these entries as `installed (auto-updates)`.
 For mise-owned casks, the `Current` column is the version recorded in the mise

--- a/e2e/cli/test_system_upgrade_brew_cask_auto_updates_macos
+++ b/e2e/cli/test_system_upgrade_brew_cask_auto_updates_macos
@@ -116,6 +116,26 @@ try:
     missing_app.rename(parent_app)
     live_plist.write_bytes(plistlib.dumps({"CFBundleShortVersionString": "1"}))
 
+    # An outdated self-updating app that is running is left to update itself:
+    # a process launched from inside the bundle blocks the replacement, and
+    # the bundle is replaced once nothing runs from it any more. The executable
+    # links to /bin/sleep because a copied platform binary is killed on exec.
+    executable = parent_app / "Contents/MacOS/auto-parent"
+    executable.parent.mkdir(parents=True)
+    executable.symlink_to("/bin/sleep")
+    sleeper = subprocess.Popen([str(executable), "600"], stdin=subprocess.DEVNULL,
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        for args in (("upgrade", "--dry-run", "--yes"), ("upgrade", "--yes")):
+            output = run(*args)
+            assert "skipped: installed app is running and updates itself" in output, output
+            assert downloads == [], downloads
+            assert parent.read_text() == "original"
+            assert parent_receipt.read_bytes() == original_receipt
+    finally:
+        sleeper.kill()
+        sleeper.wait()
+
     output = run("upgrade", "--yes")
     assert "upgraded auto-parent 1 -> 2" in output, output
     assert downloads == ["/auto-parent.zip"], downloads

--- a/e2e/cli/test_system_upgrade_brew_cask_auto_updates_macos
+++ b/e2e/cli/test_system_upgrade_brew_cask_auto_updates_macos
@@ -13,6 +13,7 @@ import plistlib
 import subprocess
 import sys
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import zipfile
 
@@ -146,6 +147,7 @@ try:
     receipt = prefix / "Caskroom/auto-parent/2/.mise-cask.toml"
     assert 'version = "2"' in receipt.read_text()
     original = receipt.read_bytes()
+    original_receipt_v2 = original
     live_plist.write_bytes(plistlib.dumps({"CFBundleShortVersionString": "1"}, fmt=plistlib.FMT_BINARY))
     parent.write_text("older despite equal receipt")
     output = run("upgrade", "--dry-run", "--yes")
@@ -163,6 +165,63 @@ try:
     latest_receipt, original = receipts["auto-latest"]
     assert latest_receipt.read_bytes() == original
     assert (prefix / "Applications/auto-latest.app/Contents/payload").read_text() == "original"
+
+    # Preflight steps run after the last skip check and can start the app
+    # themselves, so one more check runs right before the bundle swap. It
+    # undoes the preflight work and skips instead of replacing a bundle that
+    # just came to life, leaving no pending journal behind. The launcher
+    # spawns once: the pid file it leaves behind stops it from spawning again
+    # on the rerun.
+    pidfile = root / "preflight.pid"
+    launcher = "\n".join([
+        "#!/bin/sh",
+        "[ -e \"$2\" ] && exit 0",
+        "mkdir -p \"$(dirname \"$1\")\"",
+        "ln -sf /bin/sleep \"$1\"",
+        "\"$1\" 600 </dev/null >/dev/null 2>&1 &",
+        "echo $! > \"$2\"",
+        "",
+    ])
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as bundle:
+        bundle.writestr(f"{parent_app.name}/Contents/payload", "third")
+        bundle.writestr(f"{parent_app.name}/Contents/Info.plist", plistlib.dumps({"CFBundleShortVersionString": "3"}))
+        info = zipfile.ZipInfo("launch")
+        info.external_attr = 0o755 << 16
+        bundle.writestr(info, launcher)
+    responses["/auto-parent-3.zip"] = archive.getvalue()
+    metadata = json.loads(responses["/api/cask/auto-parent.json"])
+    metadata["version"] = "3"
+    metadata["url"] = f"{base}/auto-parent-3.zip"
+    metadata["artifacts"] = [
+        {"preflight_steps": [{"steps": [{
+            "type": "run",
+            "command": {"base": "staged_path", "path": "launch"},
+            "args": [str(executable), str(pidfile)],
+        }]}]},
+        {"app": [parent_app.name]},
+    ]
+    responses["/api/cask/auto-parent.json"] = json.dumps(metadata).encode()
+    live_plist.write_bytes(plistlib.dumps({"CFBundleShortVersionString": "2"}))
+    journals = Path(os.environ["MISE_STATE_DIR"]) / "brew-cask/auto-parent"
+    try:
+        output = run("upgrade", "--yes")
+        assert "skipped: installed app started running during the upgrade and updates itself" in output, output
+        assert pidfile.exists()
+        assert parent.read_text() == "older despite equal receipt"
+        assert receipt.read_bytes() == original_receipt_v2
+        assert not journals.exists() or not any(journals.iterdir())
+    finally:
+        if pidfile.exists():
+            os.kill(int(pidfile.read_text()), 9)
+    for _ in range(50):
+        listing = subprocess.run(["ps", "-axo", "comm="], capture_output=True, text=True).stdout
+        if str(executable) not in listing:
+            break
+        time.sleep(0.1)
+    output = run("upgrade", "--yes")
+    assert "upgraded auto-parent 2 -> 3" in output, output
+    assert parent.read_text() == "third"
 finally:
     server.shutdown()
     thread.join()

--- a/e2e/cli/test_system_upgrade_brew_cask_auto_updates_macos
+++ b/e2e/cli/test_system_upgrade_brew_cask_auto_updates_macos
@@ -117,10 +117,8 @@ try:
     missing_app.rename(parent_app)
     live_plist.write_bytes(plistlib.dumps({"CFBundleShortVersionString": "1"}))
 
-    # An outdated self-updating app that is running is left to update itself:
-    # a process launched from inside the bundle blocks the replacement, and
-    # the bundle is replaced once nothing runs from it any more. The executable
-    # links to /bin/sleep because a copied platform binary is killed on exec.
+    # A running outdated app is left to update itself until nothing runs from
+    # its bundle. The executable links to /bin/sleep; a copy is killed on exec.
     executable = parent_app / "Contents/MacOS/auto-parent"
     executable.parent.mkdir(parents=True)
     executable.symlink_to("/bin/sleep")
@@ -166,12 +164,9 @@ try:
     assert latest_receipt.read_bytes() == original
     assert (prefix / "Applications/auto-latest.app/Contents/payload").read_text() == "original"
 
-    # Preflight steps run after the last skip check and can start the app
-    # themselves, so one more check runs right before the bundle swap. It
-    # undoes the preflight work and skips instead of replacing a bundle that
-    # just came to life, leaving no pending journal behind. The launcher
-    # spawns once: the pid file it leaves behind stops it from spawning again
-    # on the rerun.
+    # A preflight step can start the app itself. The swap is skipped, preflight
+    # work is undone, and no journal is left pending. The launcher spawns once;
+    # its pid file stops it from spawning again on the rerun.
     pidfile = root / "preflight.pid"
     launcher = "\n".join([
         "#!/bin/sh",

--- a/src/system/packages/brew/cask/mod.rs
+++ b/src/system/packages/brew/cask/mod.rs
@@ -704,6 +704,25 @@ impl BrewCaskManager {
         )?;
         let mut metadata_only_apps = Vec::new();
         for (index, app) in artifacts.apps.iter().enumerate() {
+            // Preflight steps, hooks, and installers ran after the last skip
+            // check and may have launched the app. Replacing it now would
+            // strand the helpers it spawns later, so undo the preflight work
+            // and leave the app to update itself. A failure here would leave a
+            // pending journal, and the next apply would replace the running
+            // app after all.
+            if mode == InstallMode::Upgrade
+                && cask.auto_updates
+                && app_is_running(&app_target_path(app.target_name())?)
+            {
+                flight_targets.rollback()?;
+                remove_cask_journals(&cask.token)?;
+                file::remove_all(&tmp_caskroom)?;
+                file::remove_all(&stage)?;
+                let reason =
+                    "skipped: installed app started running during the upgrade and updates itself";
+                info!("brew-cask:{}: {reason}", cask.token);
+                return Ok(reason.to_string());
+            }
             if install_app(
                 &stage,
                 &tmp_caskroom,

--- a/src/system/packages/brew/cask/mod.rs
+++ b/src/system/packages/brew/cask/mod.rs
@@ -37,6 +37,7 @@ mod fetch;
 mod flight;
 mod model;
 mod paths;
+mod running;
 mod state;
 
 use app_version::*;
@@ -45,6 +46,7 @@ use fetch::*;
 use flight::*;
 pub(super) use model::Cask;
 use paths::*;
+use running::*;
 use state::*;
 pub(crate) use state::{apply_cask_prune_plan, cask_formula_dependencies, cask_prune_plan};
 
@@ -75,7 +77,9 @@ fn should_skip_installed(cask: &Cask, version: &str, mode: InstallMode) -> bool 
 
 /// Returns a user-facing reason to preserve an installed cask, or `None` to proceed.
 /// Self-updating upgrades require a single owned app with readable, outdated live
-/// metadata. Receipt lookup failures propagate as errors.
+/// metadata and no live process, since a running self-updater will replace its
+/// own bundle without stranding helpers it spawns later. Receipt lookup failures
+/// propagate as errors.
 fn installed_skip_reason(
     cask: &Cask,
     artifacts: &CaskArtifacts,
@@ -111,10 +115,15 @@ fn installed_skip_reason(
     let Ok(live) = read_app_version(&app_path) else {
         return Ok(Some("skipped: installed app version is unreadable"));
     };
-    Ok(
-        (!app_version_outdated(&cask.version, live.short.as_deref(), live.build.as_deref()))
-            .then_some("skipped: installed app is current, newer, or incomparable"),
-    )
+    if !app_version_outdated(&cask.version, live.short.as_deref(), live.build.as_deref()) {
+        return Ok(Some(
+            "skipped: installed app is current, newer, or incomparable",
+        ));
+    }
+    if app_is_running(&app_path) {
+        return Ok(Some("skipped: installed app is running and updates itself"));
+    }
+    Ok(None)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/system/packages/brew/cask/mod.rs
+++ b/src/system/packages/brew/cask/mod.rs
@@ -77,9 +77,7 @@ fn should_skip_installed(cask: &Cask, version: &str, mode: InstallMode) -> bool 
 
 /// Returns a user-facing reason to preserve an installed cask, or `None` to proceed.
 /// Self-updating upgrades require a single owned app with readable, outdated live
-/// metadata and no live process, since a running self-updater will replace its
-/// own bundle without stranding helpers it spawns later. Receipt lookup failures
-/// propagate as errors.
+/// metadata that is not running. Receipt lookup failures propagate as errors.
 fn installed_skip_reason(
     cask: &Cask,
     artifacts: &CaskArtifacts,
@@ -702,36 +700,38 @@ impl BrewCaskManager {
             &mut flight_targets,
             |index| record_cask_action(&mut journal, &format!("installer[{index}]")),
         )?;
+        // Preflight, hooks, and installers may have launched a self-updating
+        // app since the last skip check. Check before copying and again at the
+        // swap in install_app; copying a large bundle takes a while. Such an
+        // upgrade owns exactly one app, so a deferral has replaced nothing.
+        let defer_running = mode == InstallMode::Upgrade && cask.auto_updates;
+        if defer_running {
+            for app in &artifacts.apps {
+                if app_is_running(&app_target_path(app.target_name())?) {
+                    return leave_running_app(&cask, &mut flight_targets, &tmp_caskroom, &stage);
+                }
+            }
+        }
         let mut metadata_only_apps = Vec::new();
         for (index, app) in artifacts.apps.iter().enumerate() {
-            // Preflight steps, hooks, and installers ran after the last skip
-            // check and may have launched the app. Replacing it now would
-            // strand the helpers it spawns later, so undo the preflight work
-            // and leave the app to update itself. A failure here would leave a
-            // pending journal, and the next apply would replace the running
-            // app after all.
-            if mode == InstallMode::Upgrade
-                && cask.auto_updates
-                && app_is_running(&app_target_path(app.target_name())?)
-            {
-                flight_targets.rollback()?;
-                remove_cask_journals(&cask.token)?;
-                file::remove_all(&tmp_caskroom)?;
-                file::remove_all(&stage)?;
-                let reason =
-                    "skipped: installed app started running during the upgrade and updates itself";
-                info!("brew-cask:{}: {reason}", cask.token);
-                return Ok(reason.to_string());
-            }
-            if install_app(
+            match install_app(
                 &stage,
                 &tmp_caskroom,
                 app,
                 !cask.auto_updates,
                 adopt,
                 !cask.auto_updates,
+                defer_running,
             )? {
-                metadata_only_apps.push(app_target_path(app.target_name())?);
+                AppInstall::Installed {
+                    metadata_only: true,
+                } => metadata_only_apps.push(app_target_path(app.target_name())?),
+                AppInstall::Installed {
+                    metadata_only: false,
+                } => {}
+                AppInstall::Running => {
+                    return leave_running_app(&cask, &mut flight_targets, &tmp_caskroom, &stage);
+                }
             }
             record_cask_action(&mut journal, &format!("app[{index}]"))?;
         }
@@ -1013,6 +1013,32 @@ impl SystemPackageManager for BrewCaskManager {
     }
 }
 
+/// Abandons an upgrade whose self-updating app is running. Failing instead
+/// would leave a pending journal, and the next apply would replace the app.
+fn leave_running_app(
+    cask: &Cask,
+    flight_targets: &mut FlightTargetTransaction,
+    tmp_caskroom: &Path,
+    stage: &Path,
+) -> Result<String> {
+    flight_targets.rollback()?;
+    remove_cask_journals(&cask.token)?;
+    file::remove_all(tmp_caskroom)?;
+    file::remove_all(stage)?;
+    let reason = "skipped: installed app started running during the upgrade and updates itself";
+    info!("brew-cask:{}: {reason}", cask.token);
+    Ok(reason.to_string())
+}
+
+/// Outcome of placing one app artifact.
+#[derive(Debug, PartialEq, Eq)]
+enum AppInstall {
+    /// The app is in place. `metadata_only` means the caskroom keeps no copy.
+    Installed { metadata_only: bool },
+    /// A self-updating app was running at the swap; nothing was changed.
+    Running,
+}
+
 fn install_app(
     stage: &Path,
     caskroom: &Path,
@@ -1020,7 +1046,8 @@ fn install_app(
     keep_caskroom_copy: bool,
     adopt: bool,
     verify_adopt: bool,
-) -> Result<bool> {
+    defer_if_running: bool,
+) -> Result<AppInstall> {
     let source = find_app(stage, &app.source)
         .ok_or_else(|| eyre!("brew-cask: app artifact '{}' was not found", app.source))?;
     let caskroom_app = caskroom.join(app_bundle_name(app.target_name())?);
@@ -1051,7 +1078,9 @@ fn install_app(
                 );
             }
         }
-        return Ok(true);
+        return Ok(AppInstall::Installed {
+            metadata_only: true,
+        });
     }
 
     ditto(&source, &caskroom_app)?;
@@ -1062,6 +1091,11 @@ fn install_app(
     let old_name = replace_bundle_extension(&name, &format!("mise-old-{name_hash}"));
     remove_all_at(&parent.fd, &tmp_name)?;
     ditto_into(&caskroom_app, &parent.fd, &tmp_name)?;
+    if defer_if_running && app_is_running(&logical_target) {
+        remove_all_at(&parent.fd, &tmp_name)?;
+        file::remove_all(&caskroom_app)?;
+        return Ok(AppInstall::Running);
+    }
     activate_app_at(
         &parent,
         &name,
@@ -1082,7 +1116,9 @@ fn install_app(
         ],
         &parent.fd,
     );
-    Ok(!keep_caskroom_copy)
+    Ok(AppInstall::Installed {
+        metadata_only: !keep_caskroom_copy,
+    })
 }
 
 fn validate_adoptable_apps(stage: &Path, apps: &[AppArtifact]) -> Result<()> {

--- a/src/system/packages/brew/cask/running.rs
+++ b/src/system/packages/brew/cask/running.rs
@@ -26,7 +26,15 @@ pub(super) fn app_is_running(app: &Path) -> bool {
         .stderr(Stdio::null())
         .output()
     {
-        Ok(output) => app_has_live_process(app, &output.stdout),
+        Ok(output) if output.status.success() => app_has_live_process(app, &output.stdout),
+        Ok(output) => {
+            debug!(
+                "brew-cask: process listing for {} exited with {}",
+                app.display(),
+                output.status
+            );
+            false
+        }
         Err(err) => {
             debug!(
                 "brew-cask: could not list processes for {}: {err:#}",
@@ -45,14 +53,12 @@ pub(super) fn app_is_running(_app: &Path) -> bool {
 /// Matches `ps -axo comm=` output, one executable path per line, against `app`.
 ///
 /// The comparison is by path component, so `Foo.app` does not claim processes
-/// from `Foo.app 2` or `Foobar.app`.
+/// from `Foo.app 2` or `Foobar.app`. Lines that are not UTF-8 are ignored; the
+/// paths mise installs come from UTF-8 cask metadata.
 pub(super) fn app_has_live_process(app: &Path, ps_output: &[u8]) -> bool {
-    use std::ffi::OsStr;
-    use std::os::unix::ffi::OsStrExt;
-
     ps_output
         .split(|byte| *byte == b'\n')
-        .map(<[u8]>::trim_ascii)
+        .filter_map(|line| std::str::from_utf8(line.trim_ascii()).ok())
         .filter(|line| !line.is_empty())
-        .any(|line| Path::new(OsStr::from_bytes(line)).starts_with(app))
+        .any(|line| Path::new(line).starts_with(app))
 }

--- a/src/system/packages/brew/cask/running.rs
+++ b/src/system/packages/brew/cask/running.rs
@@ -1,0 +1,58 @@
+//! Detects whether an installed app bundle currently has live processes.
+//!
+//! Replacing a bundle under a running app is only safe when nothing will ask
+//! the old bundle for more code. Chrome, Electron apps, and anything else that
+//! spawns helpers on demand exec them from the bundle path after launch, so a
+//! swap leaves every later helper pointing at files that no longer exist. A
+//! self-updating app already knows how to move itself between versions without
+//! that failure, which is why a live one is left alone.
+
+use std::path::Path;
+
+/// Whether any process on this machine runs an executable inside `app`.
+///
+/// Reads `ps -axo comm=`, which lists each process's executable path as it was
+/// launched. Bundles started through LaunchServices, `open`, or an absolute
+/// path all report a path inside the bundle, and so do helpers nested under
+/// `Contents/Frameworks`. A listing failure counts as "not running" so a broken
+/// `ps` degrades to the previous behaviour instead of blocking every upgrade.
+#[cfg(target_os = "macos")]
+pub(super) fn app_is_running(app: &Path) -> bool {
+    use std::process::{Command, Stdio};
+
+    match Command::new("ps")
+        .args(["-axo", "comm="])
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+    {
+        Ok(output) => app_has_live_process(app, &output.stdout),
+        Err(err) => {
+            debug!(
+                "brew-cask: could not list processes for {}: {err:#}",
+                app.display()
+            );
+            false
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(super) fn app_is_running(_app: &Path) -> bool {
+    false
+}
+
+/// Matches `ps -axo comm=` output, one executable path per line, against `app`.
+///
+/// The comparison is by path component, so `Foo.app` does not claim processes
+/// from `Foo.app 2` or `Foobar.app`.
+pub(super) fn app_has_live_process(app: &Path, ps_output: &[u8]) -> bool {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    ps_output
+        .split(|byte| *byte == b'\n')
+        .map(<[u8]>::trim_ascii)
+        .filter(|line| !line.is_empty())
+        .any(|line| Path::new(OsStr::from_bytes(line)).starts_with(app))
+}

--- a/src/system/packages/brew/cask/running.rs
+++ b/src/system/packages/brew/cask/running.rs
@@ -39,6 +39,7 @@ pub(super) fn app_is_running(_app: &Path) -> bool {
 
 /// Matches one executable path per line against `app` by path component, so
 /// `Foo.app` does not claim `Foo.app 2`. Lines that are not UTF-8 are ignored.
+#[cfg(any(target_os = "macos", test))]
 pub(super) fn app_has_live_process(app: &Path, ps_output: &[u8]) -> bool {
     ps_output
         .split(|byte| *byte == b'\n')

--- a/src/system/packages/brew/cask/running.rs
+++ b/src/system/packages/brew/cask/running.rs
@@ -1,21 +1,8 @@
-//! Detects whether an installed app bundle currently has live processes.
-//!
-//! Replacing a bundle under a running app is only safe when nothing will ask
-//! the old bundle for more code. Chrome, Electron apps, and anything else that
-//! spawns helpers on demand exec them from the bundle path after launch, so a
-//! swap leaves every later helper pointing at files that no longer exist. A
-//! self-updating app already knows how to move itself between versions without
-//! that failure, which is why a live one is left alone.
+use super::*;
 
-use std::path::Path;
-
-/// Whether any process on this machine runs an executable inside `app`.
-///
-/// Reads `ps -axo comm=`, which lists each process's executable path as it was
-/// launched. Bundles started through LaunchServices, `open`, or an absolute
-/// path all report a path inside the bundle, and so do helpers nested under
-/// `Contents/Frameworks`. A listing failure counts as "not running" so a broken
-/// `ps` degrades to the previous behaviour instead of blocking every upgrade.
+/// Whether any process runs an executable inside `app`. Reads `ps -axo comm=`,
+/// which reports each executable path as launched, so helpers nested under
+/// `Contents/Frameworks` count. A failed listing reports not running.
 #[cfg(target_os = "macos")]
 pub(super) fn app_is_running(app: &Path) -> bool {
     use std::process::{Command, Stdio};
@@ -50,11 +37,8 @@ pub(super) fn app_is_running(_app: &Path) -> bool {
     false
 }
 
-/// Matches `ps -axo comm=` output, one executable path per line, against `app`.
-///
-/// The comparison is by path component, so `Foo.app` does not claim processes
-/// from `Foo.app 2` or `Foobar.app`. Lines that are not UTF-8 are ignored; the
-/// paths mise installs come from UTF-8 cask metadata.
+/// Matches one executable path per line against `app` by path component, so
+/// `Foo.app` does not claim `Foo.app 2`. Lines that are not UTF-8 are ignored.
 pub(super) fn app_has_live_process(app: &Path, ps_output: &[u8]) -> bool {
     ps_output
         .split(|byte| *byte == b'\n')

--- a/src/system/packages/brew/cask/tests.rs
+++ b/src/system/packages/brew/cask/tests.rs
@@ -837,11 +837,16 @@ fn adopts_only_an_identical_existing_app() -> Result<()> {
         target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
     };
 
-    assert!(install_app(&stage, &caskroom, &app, true, true, true)?);
+    assert_eq!(
+        install_app(&stage, &caskroom, &app, true, true, true, false)?,
+        AppInstall::Installed {
+            metadata_only: true
+        }
+    );
     assert!(!caskroom.join("Example.app").exists());
 
     crate::file::write(target.join("app"), "different")?;
-    let error = install_app(&stage, &caskroom, &app, true, true, true).unwrap_err();
+    let error = install_app(&stage, &caskroom, &app, true, true, true, false).unwrap_err();
     assert!(error.to_string().contains("is not identical"));
     Ok(())
 }
@@ -865,7 +870,12 @@ fn self_updating_cask_adopts_a_different_existing_app() -> Result<()> {
         target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
     };
 
-    assert!(install_app(&stage, &caskroom, &app, false, true, false)?);
+    assert_eq!(
+        install_app(&stage, &caskroom, &app, false, true, false, false)?,
+        AppInstall::Installed {
+            metadata_only: true
+        }
+    );
     assert_eq!(
         std::fs::read_to_string(target.join("app"))?,
         "self-updated version"
@@ -7570,8 +7580,7 @@ fn auto_updates_reads_string_versions_from_xml_and_binary_plists() -> Result<()>
     Ok(())
 }
 
-/// Matches process listings against an app bundle by path component, so
-/// nested helpers count and sibling bundles sharing a prefix do not.
+/// Nested helpers match the bundle; sibling bundles sharing a prefix do not.
 #[test]
 fn running_app_matches_bundle_processes_by_path_component() {
     let app = Path::new("/Applications/Google Chrome.app");
@@ -7619,9 +7628,8 @@ fn running_app_matches_bundle_processes_by_path_component() {
     ));
 }
 
-/// Spawns a process from inside a bundle and checks the live listing sees it
-/// until it exits. The executable links to `/bin/sleep` because a copied
-/// platform binary is killed on exec.
+/// A process launched from inside the bundle is seen until it exits. The
+/// executable links to `/bin/sleep`; a copied platform binary is killed on exec.
 #[cfg(target_os = "macos")]
 #[test]
 fn running_app_sees_a_process_launched_from_the_bundle() -> Result<()> {
@@ -7642,6 +7650,63 @@ fn running_app_sees_a_process_launched_from_the_bundle() -> Result<()> {
     child.wait()?;
     assert!(running);
     assert!(!app_is_running(&app));
+    Ok(())
+}
+
+/// A running app defers the swap without leaving the staged copy behind, and
+/// the swap proceeds once the app has exited.
+#[cfg(target_os = "macos")]
+#[test]
+fn defers_a_running_self_updating_app_at_the_swap() -> Result<()> {
+    let _lock = crate::test::lock_ignoring_poison(&ENV_LOCK);
+    let tmp = trusted_tempdir()?;
+    let root = tmp.path().canonicalize()?;
+    let _guard = BrewPrefixGuard::set(&root);
+    let stage = root.join("stage");
+    let caskroom = root.join("Caskroom/example/2.0.0");
+    let appdir = root.join("Applications");
+    let target = appdir.join("Example.app");
+    file::create_dir_all(stage.join("Example.app/Contents"))?;
+    file::create_dir_all(target.join("Contents/MacOS"))?;
+    file::write(stage.join("Example.app/Contents/app"), "downloaded")?;
+    file::write(target.join("Contents/app"), "installed")?;
+    let executable = target.join("Contents/MacOS/Example");
+    std::os::unix::fs::symlink("/bin/sleep", &executable)?;
+    let app = AppArtifact {
+        source: "Example.app".to_string(),
+        target: Some("$HOMEBREW_PREFIX/Applications/Example.app".to_string()),
+    };
+
+    let mut child = std::process::Command::new(&executable)
+        .arg("600")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()?;
+    let result = install_app(&stage, &caskroom, &app, false, false, false, true);
+    child.kill()?;
+    child.wait()?;
+    assert_eq!(result?, AppInstall::Running);
+    assert_eq!(
+        std::fs::read_to_string(target.join("Contents/app"))?,
+        "installed"
+    );
+    assert!(!caskroom.join("Example.app").exists());
+    let leftovers = std::fs::read_dir(&appdir)?
+        .map(|entry| Ok(entry?.file_name()))
+        .collect::<Result<Vec<_>>>()?;
+    assert_eq!(leftovers, vec![std::ffi::OsString::from("Example.app")]);
+
+    assert_eq!(
+        install_app(&stage, &caskroom, &app, false, false, false, true)?,
+        AppInstall::Installed {
+            metadata_only: true
+        }
+    );
+    assert_eq!(
+        std::fs::read_to_string(target.join("Contents/app"))?,
+        "downloaded"
+    );
     Ok(())
 }
 

--- a/src/system/packages/brew/cask/tests.rs
+++ b/src/system/packages/brew/cask/tests.rs
@@ -7611,6 +7611,12 @@ fn running_app_matches_bundle_processes_by_path_component() {
             "listing={listing:?}"
         );
     }
+    let mixed = b"/Applications/Goo\xffgle Chrome.app/Contents/MacOS/x\n/Applications/Google Chrome.app/Contents/MacOS/Google Chrome\n";
+    assert!(app_has_live_process(app, mixed));
+    assert!(!app_has_live_process(
+        app,
+        b"/Applications/Goo\xffgle Chrome.app/Contents/MacOS/x\n"
+    ));
 }
 
 /// Spawns a process from inside a bundle and checks the live listing sees it

--- a/src/system/packages/brew/cask/tests.rs
+++ b/src/system/packages/brew/cask/tests.rs
@@ -7570,6 +7570,75 @@ fn auto_updates_reads_string_versions_from_xml_and_binary_plists() -> Result<()>
     Ok(())
 }
 
+/// Matches process listings against an app bundle by path component, so
+/// nested helpers count and sibling bundles sharing a prefix do not.
+#[test]
+fn running_app_matches_bundle_processes_by_path_component() {
+    let app = Path::new("/Applications/Google Chrome.app");
+    for (listing, expected) in [
+        (
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome\n",
+            true,
+        ),
+        (
+            "/sbin/launchd\n/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/153.0.8010.37/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer)\n",
+            true,
+        ),
+        (
+            "  /Applications/Google Chrome.app/Contents/MacOS/Google Chrome  \r\n",
+            true,
+        ),
+        ("/Applications/Google Chrome.app\n", true),
+        (
+            "/Applications/Google Chrome.app 2/Contents/MacOS/Google Chrome\n",
+            false,
+        ),
+        (
+            "/Applications/Google Chrome.appx/Contents/MacOS/Google Chrome\n",
+            false,
+        ),
+        (
+            "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome\n",
+            false,
+        ),
+        ("Google Chrome\n-/bin/zsh\n<defunct>\n", false),
+        ("", false),
+        ("\n\n", false),
+    ] {
+        assert_eq!(
+            app_has_live_process(app, listing.as_bytes()),
+            expected,
+            "listing={listing:?}"
+        );
+    }
+}
+
+/// Spawns a process from inside a bundle and checks the live listing sees it
+/// until it exits. The executable links to `/bin/sleep` because a copied
+/// platform binary is killed on exec.
+#[cfg(target_os = "macos")]
+#[test]
+fn running_app_sees_a_process_launched_from_the_bundle() -> Result<()> {
+    let tmp = trusted_tempdir()?;
+    let app = tmp.path().join("Sleeper.app");
+    let executable = app.join("Contents/MacOS/Sleeper");
+    file::create_dir_all(executable.parent().unwrap())?;
+    std::os::unix::fs::symlink("/bin/sleep", &executable)?;
+    assert!(!app_is_running(&app));
+    let mut child = std::process::Command::new(&executable)
+        .arg("600")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()?;
+    let running = app_is_running(&app);
+    child.kill()?;
+    child.wait()?;
+    assert!(running);
+    assert!(!app_is_running(&app));
+    Ok(())
+}
+
 /// Checks that symlinked bundle components and FIFO plists are rejected before
 /// live version data can be trusted or a FIFO read can block the caller.
 #[cfg(unix)]


### PR DESCRIPTION
## Problem

`mise bootstrap packages upgrade` replaces the bundle of an outdated self-updating app while that app is running. I hit it with Chrome, written up in https://github.com/jdx/mise/discussions/13040: 153.0.8010.37 had just been published, the running Chrome was 152.0.7977.76, and Keystone hadn't applied the update yet. The live-version check correctly judged the app behind and swapped `/Applications/Google Chrome.app`. The 152 browser process kept running, but it spawns its renderer and GPU helpers from its own versioned framework directory, which was gone, so every tab opened afterwards was blank until relaunch.

Any app that execs helpers from its bundle after launch fails the same way. A self-updating app already knows how to move itself between versions without stranding those helpers, which is the reason its cask declares `auto_updates` in the first place.

## Fix

`installed_skip_reason` gains one more step for `Upgrade` mode on `auto_updates` casks: once the live version is judged outdated, a bundle with a live process is skipped with `skipped: installed app is running and updates itself`. It sits after the version comparison so a current app still reports the more useful reason, and it runs in both the pre-stage check and the recheck under the install lock, so an app launched during the download is protected as well. Dry-run reports it like the other reasons.

Preflight steps, lifecycle hooks, and installers run between that recheck and the swap, and they can start the app themselves. Copying a large bundle into the appdir takes long enough for the same thing to happen. So there are two more checks: one over every app artifact before any bundle is copied, and one inside `install_app` immediately before the swap, which discards the staged copy. Both roll back what preflight protected, clear the journal, and skip with `skipped: installed app started running during the upgrade and updates itself`. Failing there instead would leave a pending journal, and the next apply would replace the running app after all. Self-updating upgrades already require a single owned app, so a late skip has replaced nothing.

`running.rs` holds the detection: `ps -axo comm=` on macOS, matched against the app path by component so `Foo.app` never claims `Foo.app 2`, and a `false` stub elsewhere. A `ps` that cannot run or exits unsuccessfully counts as not running, so a broken listing degrades to today's behaviour instead of blocking every upgrade. The matcher works on `str`, so the module builds everywhere the cask module does, Windows included.

Scope stays narrow:

- non-self-updating casks are unchanged; an always-open app would otherwise never upgrade
- install and apply are unchanged; they already leave installed self-updating apps alone
- no new flag, setting, or receipt field

`docs/bootstrap/packages/brew.md` describes the new skip beside the existing upgrade rules.

## Tests

- `running_app_matches_bundle_processes_by_path_component`: the main executable, a Chrome-shaped nested helper, padded lines, sibling bundles sharing a prefix, non-path entries, and empty output
- `running_app_sees_a_process_launched_from_the_bundle` (macOS): links `/bin/sleep` into a bundle, spawns it through that path, and checks the listing sees it until it exits; a copied platform binary is killed on exec, so the link is what keeps the test honest
- `defers_a_running_self_updating_app_at_the_swap` (macOS): the installed app is running when `install_app` reaches the swap; the swap is deferred, the staged copy and caskroom entry are gone, and the swap proceeds once the app has exited
- `test_system_upgrade_brew_cask_auto_updates_macos` gains two steps. In the first, a process runs from `auto-parent.app` while the app is outdated: dry-run and the real upgrade both report the skip, download nothing, and leave the payload and receipt alone; killing it lets the existing `upgraded auto-parent 1 -> 2` step proceed. In the second, version 3 ships a preflight `run` step that launches the app from its bundle: the upgrade skips with the late reason, leaves the payload, receipt, and journal directory untouched, and upgrades `2 -> 3` once the process is gone.

`cargo test --all-features --bin mise -- system::packages::brew::cask` passes all 272 tests here, the three new ones included. The macOS e2e test passes in 25s, which trips the 20s slow-test warning; I left the name alone because `_slow` tests only run in CI on the release branch. `cargo clippy --all-features --bin mise --tests -- -D warnings` and `cargo fmt --check` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Self-updating macOS apps that are running are now skipped during Homebrew upgrades, preventing disruption to active apps.
  * Running-app status is rechecked after preparation and immediately before replacement.
  * Upgrade state is safely cleaned up when an app is skipped.
  * Upgrades proceed successfully after the app exits.

* **Documentation**
  * Updated Homebrew upgrade documentation to explain running-app behavior, rechecks, and dry-run reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->