### PR TITLE
fix(config): scope runtime lockfile lookup to effective tool config

### DIFF
--- a/docs/dev-tools/mise-lock.md
+++ b/docs/dev-tools/mise-lock.md
@@ -88,6 +88,32 @@ dependencies, hooks, or tool installers. This lets task-specific tools be locked
 task execution. Their entries use the same `[[tools.*]]` format and are written to the lockfile for
 the config that owns the task.
 
+### Runtime resolution
+
+Runtime command-line requests that read lockfiles use the lockfile belonging to
+the effective tool configuration.
+If a project defines `hk`, it overrides the global `hk` definition, including its
+lockfile pins. A missing matching project entry falls back to normal unlocked
+resolution, not an overridden pin. If the project does not define `hk`, the
+inherited definition and its lockfile remain available.
+
+In locked mode, a missing matching entry is an error even for read-only lookups
+such as `mise which hk --tool hk@latest` and even when the tool is already installed.
+Commands that intentionally bypass lockfiles, such as `mise exec hk@latest`,
+retain that behavior.
+
+Reading a configuration's pin does not make a command-line override part of that
+configuration. For example, `mise exec node@24` does not replace the pin for a
+project configured with `node = "22"`. Use `mise use` or `mise upgrade` to make an
+intentional update. Environment-variable version overrides retain their existing
+lockfile lookup behavior.
+
+`mise which --tool` warns when the effective source has no matching pin but an
+overridden configuration's lockfile does. This includes global, parent-project,
+and environment-specific definitions. An unrelated lockfile containing a match
+is not enough: that lower-precedence configuration must actually define the tool.
+A matching effective pin produces no override warning.
+
 ## File Format
 
 The lockfile is TOML. This abbreviated example shows how a request is bound to

--- a/e2e/backend/test_conda
+++ b/e2e/backend/test_conda
@@ -16,3 +16,15 @@ assert_contains "mise x conda:jq@1.7.1 -- jq --version" "jq-1.7.1"
 # postgresql has ~23 dependencies including ncurses, readline, openssl, etc.
 # This tests that hardcoded library paths are correctly patched
 assert_contains "mise x conda:postgresql@17.2 -- psql --version" "17.2"
+
+# A borrowed runtime pin must also select the owning conda dependency table.
+export MISE_LOCKFILE=1
+detect_platform
+cat >mise.toml <<'TOML'
+[tools]
+"conda:jq" = "1.7.1"
+TOML
+mise lock --platform "$MISE_PLATFORM"
+assert_contains "cat mise.lock" 'conda_deps = ['
+mise uninstall conda:jq@1.7.1
+assert_contains "MISE_LOCKED=1 mise x conda:jq@1.7.1 -- jq --version" "jq-1.7.1"

--- a/e2e/backend/test_pkgx
+++ b/e2e/backend/test_pkgx
@@ -33,3 +33,7 @@ assert_contains "cat mise.lock" 'pkgx_provides = ["bin/onig-config"]'
 
 mise install --locked
 assert_contains "mise x -- jq --version" "jq-1.7.1"
+
+# Explicit runtime requests borrow both the pin and its dependency table.
+mise uninstall pkgx:stedolan.github.io/jq@1.7.1
+assert_contains "MISE_LOCKED=1 mise x pkgx:stedolan.github.io/jq@1.7.1 -- jq --version" "jq-1.7.1"

--- a/e2e/lockfile/test_lockfile_candidate_errors
+++ b/e2e/lockfile/test_lockfile_candidate_errors
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE=1
+
+mise install dummy@1.0.0 dummy@1.1.0
+
+cat >mise.toml <<'TOML'
+[tools]
+dummy = { version = "latest", foo = "one", "vars.foo" = "two" }
+TOML
+
+# Keep initial backend discovery on ASDF so each case exercises candidate
+# selection rather than validation of the initially selected backend.
+cat >base.lock <<'TOML'
+lockfile_version = 1
+
+[[tools.dummy]]
+version = "0.0.0"
+backend = "asdf:dummy"
+specifiers = ["unrelated"]
+TOML
+
+cat >valid.entry <<'TOML'
+
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+specifiers = ["latest"]
+TOML
+
+cat >stale.entry <<'TOML'
+
+[[tools.dummy]]
+version = "9.9.0"
+backend = "aqua:jdx/hk"
+specifiers = ["latest"]
+options = { "vars.foo" = "stale" }
+TOML
+
+# A broken candidate cannot discard a match already found or prevent a later match.
+for order in 'valid.entry stale.entry' 'stale.entry valid.entry'; do
+  read -r first second <<<"$order"
+  cat base.lock "$first" "$second" >mise.lock
+  assert "MISE_LOCKED=1 mise which dummy --tool dummy@latest --version" "1.0.0"
+done
+
+# Mixed-format lockfiles must retain their existing unbound-pin fallback too.
+sed '/^specifiers = /d' valid.entry >unbound.entry
+cat base.lock stale.entry unbound.entry >mise.lock
+assert "MISE_LOCKED=1 mise which dummy --tool dummy@latest --version" "1.0.0"
+
+# Without a valid candidate, retain the backend error even in unlocked mode.
+cat base.lock stale.entry >mise.lock
+assert_fail_contains "mise which dummy --tool dummy@latest 2>&1" 'conflicting aqua var'
+
+# A broken candidate must not hide ambiguity between two valid bindings.
+cat base.lock stale.entry valid.entry >mise.lock
+cat >>mise.lock <<'TOML'
+
+[[tools.dummy]]
+version = "1.1.0"
+backend = "asdf:dummy"
+specifiers = ["latest"]
+TOML
+assert_fail_contains "mise which dummy --tool dummy@latest 2>&1" 'lockfile contains multiple resolutions for dummy@latest with the same options'

--- a/e2e/lockfile/test_lockfile_missing_plugin
+++ b/e2e/lockfile/test_lockfile_missing_plugin
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE=1
+export MISE_LOCKED=1
+
+# Temporarily move the harness's fixture symlink so resolution sees a missing plugin.
+mv "$MISE_DATA_DIR/plugins/dummy" "$HOME/dummy-plugin"
+
+for selector in 1 prefix:1 ref:main; do
+  # Keep the backend known even when the plugin cannot supply its identity.
+  printf '[tools]\ndummy = "%s"\n\n[tool_alias]\ndummy = "asdf:dummy"\n' "$selector" >mise.toml
+
+  # Missing plugins defer resolution for every selector, keeping the request
+  # discoverable so the installer can install the plugin and resolve again.
+  mise ls --current --json >listing.json 2>warning
+  assert "jq -r '.dummy[0].version' listing.json" "$selector"
+  assert "jq -r '.dummy[0].installed' listing.json" "false"
+  assert_not_contains "cat warning" "not in the lockfile"
+done
+
+mv "$HOME/dummy-plugin" "$MISE_DATA_DIR/plugins/dummy"
+
+for selector in 1 prefix:1 ref:main; do
+  printf '[tools]\ndummy = "%s"\n\n[tool_alias]\ndummy = "asdf:dummy"\n' "$selector" >mise.toml
+
+  # Once the plugin exists, the deferred request must pass the locked check
+  # before any unlocked resolution or installation can take place.
+  assert_fail_contains "mise which dummy --tool dummy@$selector 2>&1" "dummy@$selector is not in the lockfile"
+done

--- a/e2e/lockfile/test_lockfile_request_precedence
+++ b/e2e/lockfile/test_lockfile_request_precedence
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+
+mise install dummy@1.0.0 dummy@1.1.0 dummy@2.0.0
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[settings]
+lockfile = true
+
+[tools]
+dummy = "latest"
+TOML
+cat >"$MISE_CONFIG_DIR/mise.lock" <<'TOML'
+lockfile_version = 1
+
+[[tools.dummy]]
+version = "2.0.0"
+backend = "asdf:dummy"
+specifiers = ["latest", "2"]
+TOML
+
+mkdir project
+cp "$MISE_CONFIG_DIR/config.toml" project/mise.toml
+cat >project/mise.lock <<'TOML'
+lockfile_version = 1
+
+[[tools.dummy]]
+version = "1.1.0"
+backend = "asdf:dummy"
+specifiers = ["latest"]
+TOML
+
+assert_contains "cd project && mise which dummy --tool dummy@latest" "/dummy/1.1.0/bin/dummy"
+assert "cd project && mise x dummy -- dummy --version" "This is Dummy 1.1.0! --version"
+assert "cd project && mise x dummy@2 -- dummy --version" "This is Dummy 2.0.0! --version"
+assert "mise x dummy -- dummy --version" "This is Dummy 2.0.0! --version"
+
+cp project/mise.toml project/mise.local.toml
+cat >project/mise.local.lock <<'TOML'
+lockfile_version = 1
+
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+specifiers = ["latest"]
+TOML
+assert "cd project && mise x dummy -- dummy --version" "This is Dummy 1.0.0! --version"
+assert "cd project && mise x dummy@latest -- dummy --version" "This is Dummy 2.0.0! --version"
+
+mkdir project/child
+cp project/mise.toml project/child/mise.toml
+cp project/mise.lock project/child/mise.lock
+assert "cd project/child && mise x dummy -- dummy --version" "This is Dummy 1.1.0! --version"
+
+cp project/mise.toml project/mise.ci.toml
+cp project/mise.lock project/mise.ci.lock
+assert "cd project && MISE_ENV=ci mise x dummy -- dummy --version" "This is Dummy 1.1.0! --version"
+cp project/mise.toml project/mise.ci.local.toml
+cp "$MISE_CONFIG_DIR/mise.lock" project/mise.ci.local.lock
+assert "cd project && MISE_ENV=ci mise x dummy -- dummy --version" "This is Dummy 2.0.0! --version"
+
+cat >>project/mise.local.lock <<'TOML'
+
+[[tools.dummy]]
+version = "1.1.0"
+backend = "asdf:dummy"
+specifiers = ["latest"]
+TOML
+assert_fail_contains "cd project && mise which dummy --tool dummy@latest 2>&1" "lockfile contains multiple resolutions for dummy@latest with the same options"
+
+mkdir backend-project
+cat >backend-project/mise.toml <<'TOML'
+[tools]
+dummy = { version = "latest", format = "tar.xz", url = "https://example.com/dummy-{{version}}.tar.xz" }
+TOML
+cat >backend-project/mise.lock <<'TOML'
+lockfile_version = 1
+
+[[tools.dummy]]
+version = "1.0.0"
+backend = "http:dummy"
+specifiers = ["latest"]
+options = { format = "tar.xz" }
+TOML
+assert_contains "cd backend-project && mise which dummy --tool dummy@latest" "/dummy/1.0.0/bin/dummy"
+assert "cd backend-project && mise which dummy --tool dummy@2 --version" "2.0.0"
+
+cat >>backend-project/mise.lock <<'TOML'
+
+[[tools.dummy]]
+version = "1.1.0"
+backend = "asdf:dummy"
+specifiers = ["latest"]
+TOML
+assert_fail_contains "cd backend-project && mise which dummy --tool dummy@latest 2>&1" "lockfile contains multiple resolutions for dummy@latest with the same options"
+
+# A configured override owns resolution even when only a lower source has a pin
+mkdir missing-pin
+cp project/mise.toml missing-pin/mise.toml
+sed 's/2.0.0/1.0.0/' "$MISE_CONFIG_DIR/mise.lock" >global.lock
+cp global.lock "$MISE_CONFIG_DIR/mise.lock"
+assert "cd missing-pin && mise which dummy --tool dummy@latest --version 2>warning" "2.0.0"
+assert_contains "cat missing-pin/warning" "Ignoring lockfile pins for dummy@latest"
+assert_contains "cat missing-pin/warning" "overrides that tool and has no matching lock entry"
+assert_fail_contains "cd missing-pin && MISE_LOCKED=1 mise which dummy --tool dummy@latest 2>&1" "dummy@latest is not in the lockfile"
+assert_fail_contains "cd missing-pin && MISE_LOCKED=1 mise which dummy --tool dummy@2.0.0 2>&1" "dummy@2.0.0 is not in the lockfile"
+assert_fail_contains "cd missing-pin && MISE_LOCKED=1 mise which dummy --tool dummy@prefix:2 2>&1" "dummy@prefix:2 is not in the lockfile"
+assert "cd missing-pin && MISE_LOCKED=1 mise x dummy@latest -- dummy --version" "This is Dummy 2.0.0! --version"
+assert "cd missing-pin && mise x dummy -- dummy --version" "This is Dummy 2.0.0! --version"
+
+# Merely having a project config does not override an inherited tool
+mkdir inherited
+printf '[env]\nEXAMPLE = "true"\n' >inherited/mise.toml
+assert_contains "cd inherited && mise which dummy --tool dummy@latest 2>warning" "/dummy/1.0.0/bin/dummy"
+assert_not_contains "cat inherited/warning" "Ignoring lockfile pin"
+
+# A matching effective pin suppresses warnings even when lower pins differ
+cp project/mise.lock missing-pin/mise.lock
+assert_contains "cd missing-pin && MISE_LOCKED=1 mise which dummy --tool dummy@latest 2>warning" "/dummy/1.1.0/bin/dummy"
+assert_not_contains "cat missing-pin/warning" "Ignoring lockfile pin"
+
+# No warning for a stale pin in a source that does not define this tool
+printf '[settings]\nlockfile = true\n' >"$MISE_CONFIG_DIR/config.toml"
+printf 'lockfile_version = 1\n' >missing-pin/mise.lock
+assert "cd missing-pin && mise which dummy --tool dummy@latest --version 2>warning" "2.0.0"
+assert_not_contains "cat missing-pin/warning" "Ignoring lockfile pin"
+
+# Parent and environment warnings follow definitions, not lockfile proximity
+mkdir -p parent/child
+cp project/mise.toml parent/mise.toml
+cp global.lock parent/mise.lock
+cp project/mise.toml parent/child/mise.toml
+assert "cd parent/child && mise which dummy --tool dummy@latest --version 2>warning" "2.0.0"
+assert_contains "cat parent/child/warning" "Ignoring lockfile pins for dummy@latest"
+assert_contains "cat parent/child/warning" "parent/mise.toml"
+printf '[env]\nEXAMPLE = "true"\n' >parent/mise.toml
+assert "cd parent/child && mise which dummy --tool dummy@latest --version 2>warning" "2.0.0"
+assert_not_contains "cat parent/child/warning" "Ignoring lockfile pin"
+cp project/mise.toml parent/mise.ci.toml
+cp global.lock parent/mise.ci.lock
+assert "cd parent/child && MISE_ENV=ci mise which dummy --tool dummy@latest --version 2>warning" "2.0.0"
+assert_contains "cat parent/child/warning" "parent/mise.ci.toml"
+printf '[env]\nEXAMPLE = "true"\n' >parent/mise.ci.toml
+assert "cd parent/child && MISE_ENV=ci mise which dummy --tool dummy@latest --version 2>warning" "2.0.0"
+assert_not_contains "cat parent/child/warning" "Ignoring lockfile pin"
+
+# An unconfigured runtime request cannot adopt an unrelated lockfile pin
+assert "mise which dummy --tool dummy@latest --version 2>warning" "2.0.0"
+assert_not_contains "cat warning" "Ignoring lockfile pin"
+
+# Source-scoped locked policy also applies to an installed runtime argument
+cat >>missing-pin/mise.toml <<'TOML'
+
+[tool_config]
+locked = true
+TOML
+assert_fail_contains "cd missing-pin && mise which dummy --tool dummy@latest 2>&1" "dummy@latest is not in the lockfile"
+
+# Ref selectors cannot bypass locked lookup either
+assert_fail_contains "cd missing-pin && mise which dummy --tool dummy@ref:main 2>&1" "dummy@ref:main is not in the lockfile"
+
+# Diagnosing an overridden source must not turn its ambiguity into a failure
+cp project/mise.toml "$MISE_CONFIG_DIR/config.toml"
+cat >>"$MISE_CONFIG_DIR/mise.lock" <<'TOML'
+
+[[tools.dummy]]
+version = "1.1.0"
+backend = "asdf:dummy"
+specifiers = ["latest"]
+TOML
+assert "cd parent/child && mise which dummy --tool dummy@latest --version 2>warning" "2.0.0"
+assert_contains "cat parent/child/warning" "Ignoring lockfile pin"
+
+# A legacy pin found after alias resolution also suppresses override warnings
+mkdir alias-project
+cat >alias-project/mise.toml <<'TOML'
+[tools]
+dummy = "latest"
+
+[tool_alias.dummy.versions]
+stable = "1"
+TOML
+cat >alias-project/mise.lock <<'TOML'
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+TOML
+cat >>"$MISE_CONFIG_DIR/mise.lock" <<'TOML'
+
+[[tools.dummy]]
+version = "2.0.0"
+backend = "asdf:dummy"
+specifiers = ["stable"]
+TOML
+assert "cd alias-project && mise which dummy --tool dummy@stable --version 2>warning" "1.0.0"
+assert_not_contains "cat alias-project/warning" "Ignoring lockfile pin"
+
+# Non-TOML sources use their existing lockfile mapping
+mkdir tool-versions-project
+printf 'dummy latest\n' >tool-versions-project/.tool-versions
+assert "cd tool-versions-project && mise which dummy --tool dummy@latest --version 2>warning" "2.0.0"
+assert_contains "cat tool-versions-project/warning" "Ignoring lockfile pin"
+assert_fail_contains "cd tool-versions-project && MISE_LOCKED=1 mise which dummy --tool dummy@latest 2>&1" "dummy@latest is not in the lockfile"
+
+mkdir idiomatic-project
+cat >idiomatic-project/mise.toml <<'TOML'
+[settings]
+idiomatic_version_file_enable_tools = ["dummy"]
+TOML
+printf 'latest\n' >idiomatic-project/.dummy-version
+cp project/mise.lock idiomatic-project/mise.lock
+assert "cd idiomatic-project && MISE_LOCKED=1 mise which dummy --tool dummy@latest --version 2>warning" "1.1.0"
+assert_not_contains "cat idiomatic-project/warning" "Ignoring lockfile pin"
+printf 'lockfile_version = 1\n' >idiomatic-project/mise.lock
+assert "cd idiomatic-project && mise which dummy --tool dummy@latest --version 2>warning" "2.0.0"
+assert_contains "cat idiomatic-project/warning" "Ignoring lockfile pin"
+assert_fail_contains "cd idiomatic-project && MISE_LOCKED=1 mise which dummy --tool dummy@latest 2>&1" "dummy@latest is not in the lockfile"
+
+# Unavailable and disabled candidates cannot hide a valid pin in the same file
+mkdir stale-backend-project
+cp project/mise.toml stale-backend-project/mise.toml
+for stale_backend in removed-backend:dummy core:dummy http:dummy; do
+  cat >stale-backend-project/mise.lock <<TOML
+lockfile_version = 1
+
+[[tools.dummy]]
+version = "1.0.0"
+backend = "$stale_backend"
+specifiers = ["latest"]
+TOML
+  cp stale-backend-project/mise.lock stale-backend.lock
+  cat >>stale-backend-project/mise.lock <<'TOML'
+
+[[tools.dummy]]
+version = "1.1.0"
+backend = "asdf:dummy"
+specifiers = ["latest"]
+TOML
+  assert "cd stale-backend-project && MISE_DISABLE_BACKENDS=http MISE_LOCKED=1 mise which dummy --tool dummy@latest --version 2>&1" "1.1.0"
+  cp stale-backend.lock stale-backend-project/mise.lock
+  assert_fail_contains "cd stale-backend-project && MISE_DISABLE_BACKENDS=http MISE_LOCKED=1 mise which dummy --tool dummy@latest 2>&1" "dummy@latest is not in the lockfile"
+done
+
+# Invalid options in an overridden source are diagnostic failures only.
+# Keep an asdf candidate first so discovery still chooses the dummy plugin.
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[settings]
+lockfile = true
+
+[tools]
+dummy = { version = "latest", foo = "one", "vars.foo" = "two" }
+TOML
+cat >"$MISE_CONFIG_DIR/mise.lock" <<'TOML'
+lockfile_version = 1
+
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+specifiers = ["latest"]
+
+[[tools.dummy]]
+version = "1.1.0"
+backend = "aqua:jdx/hk"
+specifiers = ["latest"]
+TOML
+assert "cd parent/child && mise which dummy --tool dummy@latest --version 2>warning" "2.0.0"
+assert_not_contains "cat parent/child/warning" 'conflicting aqua var'
+assert_fail "cd parent/child && MISE_LOCKED=1 mise which dummy --tool dummy@latest >primary-error 2>&1"
+assert_contains "cat parent/child/primary-error" "dummy@latest is not in the lockfile"
+assert_not_contains "cat parent/child/primary-error" 'conflicting aqua var'
+assert_not_contains "cat parent/child/primary-error" 'Ignoring lockfile pin'
+
+# An invalid parent must not prevent inspection of a valid global pin.
+cp "$MISE_CONFIG_DIR/config.toml" parent/mise.toml
+cp "$MISE_CONFIG_DIR/mise.lock" parent/mise.lock
+cp project/mise.toml "$MISE_CONFIG_DIR/config.toml"
+cp global.lock "$MISE_CONFIG_DIR/mise.lock"
+assert "cd parent/child && mise which dummy --tool dummy@latest --version 2>warning" "2.0.0"
+assert_contains "cat parent/child/warning" 'Ignoring lockfile pins for dummy@latest'
+assert_contains "cat parent/child/warning" '.config/mise/config.toml'
+
+# Exempting a config scope cannot exempt an explicit runtime argument.
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[settings]
+lockfile = true
+locked_scopes = ["project"]
+
+[tools]
+dummy = "latest"
+TOML
+printf 'lockfile_version = 1\n' >"$MISE_CONFIG_DIR/mise.lock"
+assert "MISE_LOCKED=1 mise x -- dummy --version" "This is Dummy 2.0.0! --version"
+assert_fail_contains "MISE_LOCKED=1 mise which dummy --tool dummy@latest 2>&1" "dummy@latest is not in the lockfile"

--- a/e2e/lockfile/test_lockfile_runtime_scope
+++ b/e2e/lockfile/test_lockfile_runtime_scope
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+export MISE_LOCKFILE=1
+
+# Exercise the install path, which resolves runtime requests a second time.
+# Both writers must keep CLI provenance separate from the borrowed pin owner.
+for mode in merge generate; do
+  (
+    export MISE_LOCKFILE_MODE="$mode"
+    mkdir "$mode"
+    cd "$mode"
+    cat >mise.toml <<'TOML'
+[tools]
+dummy = "1"
+TOML
+    cat >mise.lock <<'TOML'
+lockfile_version = 1
+
+[[tools.dummy]]
+version = "1.0.0"
+backend = "asdf:dummy"
+specifiers = ["1"]
+TOML
+    mise uninstall dummy --all
+    assert "mise x dummy -- dummy --version" "This is Dummy 1.0.0! --version"
+    assert_contains "cat mise.lock" 'version = "1.0.0"'
+
+    assert "mise x dummy@2.0.0 -- dummy --version" "This is Dummy 2.0.0! --version"
+    assert_contains "cat mise.lock" 'version = "1.0.0"'
+    assert_not_contains "cat mise.lock" 'version = "2.0.0"'
+
+    # Direct use requests retain their ordinary pin lookup.
+    mise install dummy@1.1.0
+    mise use dummy@1
+    assert "mise x dummy -- dummy --version" "This is Dummy 1.0.0! --version"
+
+    # Upgrade intentionally reattributes the request to the config it updates.
+    # Remove the version installed for the use check so this exercises an upgrade,
+    # rather than the already-installed explicit-version no-op.
+    mise uninstall dummy@1.1.0
+    mise upgrade dummy@1.1.0
+    assert_contains "cat mise.lock" 'version = "1.1.0"'
+    assert_not_contains "cat mise.lock" 'version = "1.0.0"'
+    assert_not_contains "cat mise.lock" 'version = "2.0.0"'
+
+    # A matching runtime request may populate a missing entry after installation.
+    mise uninstall dummy --all
+    printf 'lockfile_version = 1\n' >mise.lock
+    assert "mise x dummy -- dummy --version" "This is Dummy 1.1.0! --version"
+    assert_contains "cat mise.lock" 'version = "1.1.0"'
+  )
+done

--- a/src/backend/conda.rs
+++ b/src/backend/conda.rs
@@ -10,7 +10,7 @@ use crate::config::Config;
 use crate::config::Settings;
 use crate::http::{HTTP, apply_url_replacements};
 use crate::install_context::InstallContext;
-use crate::lockfile::{self, Lockfile, PlatformInfo};
+use crate::lockfile::{Lockfile, PlatformInfo};
 use crate::toolset::{ToolVersion, ToolVersionOptions};
 use crate::{backend::Backend, dirs, parallel};
 use crate::{file, hash};
@@ -422,7 +422,7 @@ impl CondaBackend {
     }
 
     fn read_lockfile_for_tool(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<Lockfile> {
-        lockfile::read_lockfile_for_tool_source(&ctx.config, tv.request.source())
+        tv.request.read_lockfile(&ctx.config)
     }
 
     /// Install from a fresh solve (no lockfile deps).

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5002,6 +5002,7 @@ mod latest_version_tests {
             version: "nightly".to_string(),
             options: ResolvedToolOptions::default(),
             source: ToolSource::Argument,
+            lockfile_scope: Default::default(),
         };
         let tv = ToolVersion::new(request, "nightly".to_string());
 

--- a/src/backend/pkgx.rs
+++ b/src/backend/pkgx.rs
@@ -7,7 +7,7 @@ use crate::file::{ExtractOptions, ExtractionFormat};
 use crate::hash;
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
-use crate::lockfile::{self, Lockfile, PlatformInfo};
+use crate::lockfile::{Lockfile, PlatformInfo};
 use crate::toolset::{ToolRequest, ToolVersion};
 use crate::{backend::Backend, file};
 use async_trait::async_trait;
@@ -192,7 +192,7 @@ impl PkgxBackend {
     }
 
     fn read_lockfile_for_tool(&self, ctx: &InstallContext, tv: &ToolVersion) -> Result<Lockfile> {
-        lockfile::read_lockfile_for_tool_source(&ctx.config, tv.request.source())
+        tv.request.read_lockfile(&ctx.config)
     }
 
     async fn install_from_locked(

--- a/src/cli/use.rs
+++ b/src/cli/use.rs
@@ -357,6 +357,7 @@ impl Use {
                         && let ToolRequest::Version {
                             version: _version,
                             source,
+                            lockfile_scope,
                             options,
                             backend,
                         } = request
@@ -364,6 +365,7 @@ impl Use {
                         request = ToolRequest::Version {
                             version: tv.version.clone(),
                             source,
+                            lockfile_scope,
                             options,
                             backend,
                         };

--- a/src/cli/which.rs
+++ b/src/cli/which.rs
@@ -108,7 +108,9 @@ impl Which {
     async fn get_toolset(&self, config: &Arc<Config>) -> Result<Toolset> {
         let mut tsb = ToolsetBuilder::new();
         if let Some(tool) = &self.tool {
-            tsb = tsb.with_args(std::slice::from_ref(tool));
+            tsb = tsb
+                .with_args(std::slice::from_ref(tool))
+                .with_overridden_lockfile_warnings();
         }
         let ts = tsb.build(config).await?;
         Ok(ts)

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -256,6 +256,7 @@ impl dyn ConfigFile {
                     if let ToolRequest::Version {
                         version: _version,
                         source,
+                        lockfile_scope,
                         options,
                         backend,
                     } = tr
@@ -263,6 +264,7 @@ impl dyn ConfigFile {
                         tr = ToolRequest::Version {
                             version: tv.version,
                             source,
+                            lockfile_scope,
                             options,
                             backend,
                         };

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__env_var_in_tool.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__env_var_in_tool.snap
@@ -22,6 +22,7 @@ expression: "replace_path(&format!(\"{:#?}\", cf.to_tool_request_set().unwrap().
             source: MiseToml(
                 "~/cwd/.test.mise.toml",
             ),
+            lockfile_scope: Default,
         },
     ],
     BackendArg(jq): [
@@ -43,6 +44,7 @@ expression: "replace_path(&format!(\"{:#?}\", cf.to_tool_request_set().unwrap().
             source: MiseToml(
                 "~/cwd/.test.mise.toml",
             ),
+            lockfile_scope: Default,
         },
     ],
 }

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__fixture-3.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__fixture-3.snap
@@ -23,6 +23,7 @@ ToolRequestSet {
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
                 ),
+                lockfile_scope: Default,
             },
         ],
         BackendArg(node): [
@@ -44,6 +45,7 @@ ToolRequestSet {
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
                 ),
+                lockfile_scope: Default,
             },
             Prefix {
                 backend: BackendArg(node),
@@ -63,6 +65,7 @@ ToolRequestSet {
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
                 ),
+                lockfile_scope: Default,
             },
             Ref {
                 backend: BackendArg(node),
@@ -83,6 +86,7 @@ ToolRequestSet {
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
                 ),
+                lockfile_scope: Default,
             },
             Path {
                 backend: BackendArg(node),
@@ -102,6 +106,7 @@ ToolRequestSet {
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
                 ),
+                lockfile_scope: Default,
             },
         ],
         BackendArg(jq): [
@@ -123,6 +128,7 @@ ToolRequestSet {
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
                 ),
+                lockfile_scope: Default,
             },
         ],
         BackendArg(shellcheck): [
@@ -144,6 +150,7 @@ ToolRequestSet {
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
                 ),
+                lockfile_scope: Default,
             },
         ],
         BackendArg(python): [
@@ -169,6 +176,7 @@ ToolRequestSet {
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
                 ),
+                lockfile_scope: Default,
             },
             Version {
                 backend: BackendArg(python),
@@ -188,6 +196,7 @@ ToolRequestSet {
                 source: MiseToml(
                     "~/fixtures/.mise.toml",
                 ),
+                lockfile_scope: Default,
             },
         ],
     },

--- a/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__replace_versions.snap
+++ b/src/config/config_file/snapshots/mise__config__config_file__mise_toml__tests__replace_versions.snap
@@ -26,6 +26,7 @@ Toolset {
                     source: MiseToml(
                         "/tmp/.mise.toml",
                     ),
+                    lockfile_scope: Default,
                 },
                 Version {
                     backend: BackendArg(node),
@@ -45,6 +46,7 @@ Toolset {
                     source: MiseToml(
                         "/tmp/.mise.toml",
                     ),
+                    lockfile_scope: Default,
                 },
             ],
             source: MiseToml(

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -3734,10 +3734,10 @@ pub(crate) fn get_locked_version(
     };
     if let Some(tools) = lockfile.tools.get(short) {
         if lockfile.uses_request_bindings() {
-            let matching =
+            let (matching, binding_error) =
                 matching_request_bindings(lockfile.as_ref(), short, specifier, |tool| {
                     Ok(binding_options(tool)?.is_some_and(|(options, _)| tool.options == options))
-                })?;
+                });
             match matching.as_slice() {
                 [] => {}
                 [found] => {
@@ -3751,13 +3751,14 @@ pub(crate) fn get_locked_version(
                 }
             }
 
-            let legacy = matching_request_bindings(lockfile.as_ref(), short, specifier, |tool| {
-                Ok(
-                    binding_options(tool)?.is_some_and(|(options, allow_fallback)| {
-                        allow_fallback && !options.is_empty() && tool.options.is_empty()
-                    }),
-                )
-            })?;
+            let (legacy, legacy_error) =
+                matching_request_bindings(lockfile.as_ref(), short, specifier, |tool| {
+                    Ok(
+                        binding_options(tool)?.is_some_and(|(options, allow_fallback)| {
+                            allow_fallback && !options.is_empty() && tool.options.is_empty()
+                        }),
+                    )
+                });
             match legacy.as_slice() {
                 [] => {}
                 [found] => {
@@ -3812,6 +3813,11 @@ pub(crate) fn get_locked_version(
                     )));
                 }
             }
+            // A stale backend's options must not hide a valid binding or legacy
+            // pin, but its error remains useful when none of those matches exist.
+            if let Some(err) = binding_error.or(legacy_error) {
+                return Err(err);
+            }
             return Ok(None);
         }
         let version_matches = |v: &LockfileTool| {
@@ -3865,14 +3871,22 @@ fn matching_request_bindings<'a>(
     short: &str,
     specifier: &str,
     mut matches_options: impl FnMut(&LockfileTool) -> Result<bool>,
-) -> Result<Vec<&'a LockfileTool>> {
+) -> (Vec<&'a LockfileTool>, Option<Report>) {
     let mut matching = Vec::new();
+    let mut first_error = None;
     for tool in lockfile.tools.get(short).into_iter().flatten() {
-        if tool.specifiers.contains(specifier) && matches_options(tool)? {
-            matching.push(tool);
+        if !tool.specifiers.contains(specifier) {
+            continue;
+        }
+        match matches_options(tool) {
+            Ok(true) => matching.push(tool),
+            Ok(false) => {}
+            Err(err) => {
+                first_error.get_or_insert(err);
+            }
         }
     }
-    Ok(matching)
+    (matching, first_error)
 }
 
 /// Newest-first ordering for the lockfile entries that all satisfy one

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,17 +1,18 @@
 pub(crate) mod generate;
 
-use crate::backend::Backend;
 use crate::backend::backend_type::BackendType;
 use crate::backend::conda::CondaBackend;
 use crate::backend::pkgx::PkgxBackend;
 use crate::backend::platform_target::PlatformTarget;
+use crate::backend::{self, Backend};
+use crate::cli::args::BackendArg;
 use crate::config::{Config, Settings};
 use crate::env;
 use crate::file;
 use crate::file::display_path;
 use crate::path::PathExt;
 use crate::platform::Platform;
-use crate::toolset::{ToolSource, ToolVersion, ToolVersionOptions, Toolset};
+use crate::toolset::{ToolRequest, ToolSource, ToolVersion, ToolVersionOptions, Toolset};
 use eyre::{Report, Result, bail, eyre};
 use indexmap::IndexSet;
 use itertools::Itertools;
@@ -3648,13 +3649,17 @@ pub(crate) fn read_lockfile_for_tool_source(
         .clone())
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub(crate) struct AmbiguousRequestBinding(String);
+
 /// `legacy_options_fallback` lets a backend whose options describe the writing
 /// host (see `Backend::lockfile_options_are_host_specific`) fall back to an
 /// entry written before those options existed. The version pin is honored — it
 /// is the only record of what this project resolved to — but the artifact data
 /// is dropped, since there's no way to tell which variant it describes.
 pub(crate) struct LockedVersionQuery<'a> {
-    pub(crate) path: Option<&'a Path>,
+    pub(crate) request: &'a ToolRequest,
     pub(crate) short: &'a str,
     pub(crate) specifier: &'a str,
     pub(crate) prefix: &'a str,
@@ -3670,7 +3675,7 @@ pub(crate) fn get_locked_version(
     query: LockedVersionQuery<'_>,
 ) -> Result<Option<LockfileTool>> {
     let LockedVersionQuery {
-        path,
+        request,
         short,
         specifier,
         prefix,
@@ -3685,28 +3690,54 @@ pub(crate) fn get_locked_version(
         return Ok(None);
     }
 
-    let lockfile = match path {
-        Some(path) => {
+    let Some(source) = request.lockfile_source() else {
+        return Ok(None);
+    };
+    let lockfile = match source {
+        ToolSource::MiseToml(path) => {
             trace!(
                 "[{short}@{prefix}] reading lockfile for {}",
                 display_path(path)
             );
             read_lockfile_for(config, path)
         }
-        None => {
+        source if source.path().is_some() => {
+            Arc::new(read_lockfile_for_tool_source(config, source)?)
+        }
+        _ => {
             trace!("[{short}@{prefix}] reading all lockfiles");
             read_all_lockfiles(config)
         }
     };
 
+    let binding_options = |tool: &LockfileTool| -> Result<_> {
+        // A shorthand may discover another scope's backend before its owning
+        // config is known; interpret each pin using its recorded backend
+        if !request.ba().has_explicit_backend()
+            && let Some(full) = &tool.backend
+        {
+            // Keep the recorded identifier explicit through alias normalization
+            let Some(backend) =
+                backend::arg_to_backend(BackendArg::new(full.clone(), Some(full.clone())))
+            else {
+                return Ok(None);
+            };
+            if backend::is_disabled_backend_type(&backend.get_type()) {
+                return Ok(None);
+            }
+            return Ok(Some((
+                backend.resolve_lockfile_options(request, &PlatformTarget::from_current())?,
+                backend.lockfile_options_are_host_specific(),
+            )));
+        }
+        Ok(Some((request_options.clone(), legacy_options_fallback)))
+    };
     if let Some(tools) = lockfile.tools.get(short) {
         if lockfile.uses_request_bindings() {
-            let matching = tools
-                .iter()
-                .filter(|tool| {
-                    tool.specifiers.contains(specifier) && &tool.options == request_options
-                })
-                .collect_vec();
+            let matching =
+                matching_request_bindings(lockfile.as_ref(), short, specifier, |tool| {
+                    Ok(binding_options(tool)?.is_some_and(|(options, _)| tool.options == options))
+                })?;
             match matching.as_slice() {
                 [] => {}
                 [found] => {
@@ -3714,33 +3745,32 @@ pub(crate) fn get_locked_version(
                     return Ok(Some((*found).clone()));
                 }
                 _ => {
-                    bail!(
+                    bail!(AmbiguousRequestBinding(format!(
                         "lockfile contains multiple resolutions for {short}@{specifier} with the same options"
-                    )
+                    )))
                 }
             }
 
-            if legacy_options_fallback && !request_options.is_empty() {
-                let legacy = tools
-                    .iter()
-                    .filter(|tool| tool.specifiers.contains(specifier) && tool.options.is_empty())
-                    .collect_vec();
-                match legacy.as_slice() {
-                    [] => {}
-                    [found] => {
-                        trace!(
-                            "[{short}@{specifier}] found {} in lockfile without options, keeping the version pin and dropping its artifact data",
-                            found.version
-                        );
-                        return Ok(Some(lockfile_tool_with_request_options(
-                            found,
-                            request_options,
-                        )));
-                    }
-                    _ => bail!(
-                        "lockfile contains multiple optionless resolutions for {short}@{specifier}"
-                    ),
+            let legacy = matching_request_bindings(lockfile.as_ref(), short, specifier, |tool| {
+                Ok(
+                    binding_options(tool)?.is_some_and(|(options, allow_fallback)| {
+                        allow_fallback && !options.is_empty() && tool.options.is_empty()
+                    }),
+                )
+            })?;
+            match legacy.as_slice() {
+                [] => {}
+                [found] => {
+                    trace!(
+                        "[{short}@{specifier}] found {} in lockfile without options, keeping the version pin and dropping its artifact data",
+                        found.version
+                    );
+                    return Ok(binding_options(found)?
+                        .map(|(options, _)| lockfile_tool_with_request_options(found, &options)));
                 }
+                _ => bail!(AmbiguousRequestBinding(format!(
+                    "lockfile contains multiple optionless resolutions for {short}@{specifier}"
+                ))),
             }
 
             // Mixed-format monorepo migration can temporarily place legacy
@@ -3828,6 +3858,21 @@ pub(crate) fn get_locked_version(
     }
 
     Ok(None)
+}
+
+fn matching_request_bindings<'a>(
+    lockfile: &'a Lockfile,
+    short: &str,
+    specifier: &str,
+    mut matches_options: impl FnMut(&LockfileTool) -> Result<bool>,
+) -> Result<Vec<&'a LockfileTool>> {
+    let mut matching = Vec::new();
+    for tool in lockfile.tools.get(short).into_iter().flatten() {
+        if tool.specifiers.contains(specifier) && matches_options(tool)? {
+            matching.push(tool);
+        }
+    }
+    Ok(matching)
 }
 
 /// Newest-first ordering for the lockfile entries that all satisfy one
@@ -4388,6 +4433,24 @@ mod tests {
             crate::toolset::ToolRequest::new(prototype.request.ba().clone(), request, source)
                 .unwrap();
         ToolVersion::new(request, version.to_string())
+    }
+
+    #[test]
+    fn test_tools_by_source_for_update_does_not_write_to_borrowed_owner() {
+        let owner = ToolSource::MiseToml(PathBuf::from("/repo/mise.toml"));
+        let mut runtime =
+            basic_tv_from_source("aqua:example/tool", "2", "2.0.0", ToolSource::Argument);
+        runtime
+            .request
+            .set_lockfile_scope(crate::toolset::tool_request::LockfileScope::Source(
+                owner.clone(),
+            ));
+        let tools_by_source = tools_by_source_for_update(&Toolset::default(), &[runtime]);
+        assert!(!tools_by_source.contains_key(&owner));
+        assert_eq!(
+            tools_by_source[&ToolSource::Argument]["tool"][0].version,
+            "2.0.0"
+        );
     }
 
     #[test]

--- a/src/plugins/core/rust.rs
+++ b/src/plugins/core/rust.rs
@@ -625,6 +625,8 @@ impl Backend for RustPlugin {
                     tv.request.options(),
                     tv.request.source().clone(),
                 )?;
+                oi.tool_request
+                    .set_lockfile_scope(tv.request.lockfile_scope().clone());
             }
             return Ok((oi.current.as_ref() != Some(&latest)).then_some(oi));
         }

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -7,6 +7,7 @@ use crate::cli::args::{BackendArg, ToolArg};
 use crate::config::{Config, ConfigMap};
 use crate::env_diff::EnvMap;
 use crate::errors::Error;
+use crate::toolset::tool_request::LockfileScope;
 use crate::toolset::tool_request_set::{
     configured_options_for_runtime_request, postinstall_tool_request,
 };
@@ -32,6 +33,7 @@ pub(crate) struct ToolsetBuilder {
     resolve_options: ResolveOptions,
     resolution_progress: bool,
     config_files: Option<ConfigMap>,
+    warn_overridden_lockfiles: bool,
 }
 
 impl ToolsetBuilder {
@@ -64,6 +66,11 @@ impl ToolsetBuilder {
         self
     }
 
+    pub(crate) fn with_overridden_lockfile_warnings(mut self) -> Self {
+        self.warn_overridden_lockfiles = true;
+        self
+    }
+
     /// Use custom config files instead of config.config_files
     pub(crate) fn with_config_files(mut self, config_files: ConfigMap) -> Self {
         self.config_files = Some(config_files);
@@ -84,14 +91,16 @@ impl ToolsetBuilder {
             self.load_runtime_args(&mut toolset)?;
         });
         measure!("toolset_builder::build::resolve", {
-            if let Err(err) = toolset
+            let result = toolset
                 .resolve_with_progress(config, &self.resolve_options, self.resolution_progress)
-                .await
-            {
+                .await;
+            if let Err(err) = result {
                 if Error::is_argument_err(&err) || Error::is_required_channel_resolution_err(&err) {
                     return Err(err);
                 }
                 warn!("failed to resolve toolset: {err}");
+            } else if self.warn_overridden_lockfiles && self.resolve_options.use_locked_version {
+                self.warn_overridden_lockfiles(config, &toolset);
             }
         });
 
@@ -149,6 +158,84 @@ impl ToolsetBuilder {
         Ok(())
     }
 
+    fn warn_overridden_lockfiles(&self, config: &Config, ts: &Toolset) {
+        let config_files = self.config_files.as_ref().unwrap_or(&config.config_files);
+        for arg in &self.args {
+            let Some(tvl) = ts.versions.get(&arg.ba) else {
+                continue;
+            };
+            for effective in &tvl.requests {
+                let Some(owner) = effective.lockfile_source() else {
+                    continue;
+                };
+                let Some(path) = owner.path() else {
+                    continue;
+                };
+                // Toolset resolution can warn about a failed list and still return Ok.
+                let Some(resolved) = tvl.versions.iter().find(|version| {
+                    version.request.version() == effective.version()
+                        && version.request.options() == effective.options()
+                }) else {
+                    continue;
+                };
+                if resolved.resolved_from_lockfile() {
+                    continue;
+                }
+                for cf in config_files
+                    .values()
+                    .skip_while(|cf| cf.get_path() != path)
+                    .skip(1)
+                {
+                    let has_match = (|| -> Result<bool> {
+                        let configured = cf.to_tool_request_set()?;
+                        let Some(requests) = configured.tools.get(&arg.ba) else {
+                            return Ok(false);
+                        };
+                        let mut request = match &arg.tvr {
+                            Some(request) => request.clone(),
+                            None => ToolRequest::new(
+                                arg.ba.clone(),
+                                &effective.version(),
+                                ToolSource::Argument,
+                            )?,
+                        };
+                        if let Some(options) =
+                            configured_options_for_runtime_request(requests, &request)
+                        {
+                            request.apply_config_options(options);
+                        }
+                        request.set_lockfile_scope(LockfileScope::Source(cf.source()));
+                        match request.lockfile_resolve(config) {
+                            Ok(pin) => Ok(pin.is_some()),
+                            Err(err)
+                                if err
+                                    .downcast_ref::<crate::lockfile::AmbiguousRequestBinding>()
+                                    .is_some() =>
+                            {
+                                Ok(true)
+                            }
+                            Err(err) => Err(err),
+                        }
+                    })();
+                    match has_match {
+                        Ok(true) => warn!(
+                            "Ignoring lockfile pins for {} from {} because {} overrides that tool and has no matching lock entry",
+                            effective,
+                            cf.source(),
+                            owner
+                        ),
+                        Ok(false) => {}
+                        Err(err) => debug!(
+                            "could not inspect overridden lockfile pins for {} from {}: {err:#}",
+                            effective,
+                            cf.source()
+                        ),
+                    }
+                }
+            }
+        }
+    }
+
     fn load_runtime_args(&self, ts: &mut Toolset) -> eyre::Result<()> {
         for (_, args) in self.args.iter().into_group_map_by(|arg| arg.ba.clone()) {
             let mut arg_ts = Toolset::new(ToolSource::Argument);
@@ -162,6 +249,17 @@ impl ToolsetBuilder {
                     configured_options_for_runtime_request(&configured, &tvr)
                 {
                     tvr.apply_config_options(config_options);
+                }
+                if self.resolve_options.use_locked_version {
+                    let scope = match configured.first() {
+                        Some(configured) if configured.source().path().is_some() => {
+                            LockfileScope::Source(configured.source().clone())
+                        }
+                        // Environment overrides retain their existing lookup policy.
+                        Some(_) => LockfileScope::Default,
+                        None => LockfileScope::NoOwner,
+                    };
+                    tvr.set_lockfile_scope(scope);
                 }
                 tvr
             };
@@ -314,5 +412,68 @@ mod tests {
         assert_eq!(requests[0].options().get("selected"), Some("config"));
         assert_eq!(requests[0].options().get("request_only"), Some("request"));
         assert_eq!(requests[0].options().get("inline_only"), Some("inline"));
+    }
+
+    #[tokio::test]
+    async fn runtime_args_keep_provenance_and_scope_lockfile_reads() {
+        crate::toolset::install_state::init().await.unwrap();
+        let source = ToolSource::MiseToml("/project/mise.toml".into());
+        for (argument, expected_version) in [("dummy@2", "2"), ("dummy", "latest")] {
+            for use_locked_version in [true, false] {
+                let ba = Arc::new(BackendArg::from("dummy"));
+                let mut ts = Toolset::new(source.clone());
+                ts.add_version(ToolRequest::new(ba.clone(), "latest", source.clone()).unwrap());
+                ToolsetBuilder::new()
+                    .with_args(&[argument.parse().unwrap()])
+                    .with_default_to_latest(true)
+                    .with_resolve_options(ResolveOptions {
+                        use_locked_version,
+                        ..Default::default()
+                    })
+                    .load_runtime_args(&mut ts)
+                    .unwrap();
+                let tvl = ts.versions.get(&ba).unwrap();
+                assert_eq!(tvl.requests[0].version(), expected_version);
+                assert_eq!(tvl.source, ToolSource::Argument);
+                assert_eq!(tvl.requests[0].source(), &ToolSource::Argument);
+                assert_eq!(
+                    tvl.requests[0].lockfile_scope(),
+                    &if use_locked_version {
+                        LockfileScope::Source(source.clone())
+                    } else {
+                        LockfileScope::Default
+                    }
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn runtime_args_without_config_do_not_borrow_stale_pins() {
+        crate::toolset::install_state::init().await.unwrap();
+        let ba = Arc::new(BackendArg::from("dummy"));
+        let direct = ToolRequest::new(ba.clone(), "1", ToolSource::Argument).unwrap();
+        assert_eq!(direct.lockfile_scope(), &LockfileScope::Default);
+
+        let mut ts = Toolset::default();
+        ToolsetBuilder::new()
+            .with_args(&["dummy@1".parse().unwrap()])
+            .load_runtime_args(&mut ts)
+            .unwrap();
+        let request = &ts.versions[&ba].requests[0];
+        assert_eq!(request.source(), &ToolSource::Argument);
+        assert_eq!(request.lockfile_source(), None);
+
+        let source = ToolSource::Environment("MISE_DUMMY_VERSION".into(), "2".into());
+        let mut ts = Toolset::new(source.clone());
+        ts.add_version(ToolRequest::new(ba.clone(), "2", source).unwrap());
+        ToolsetBuilder::new()
+            .with_args(&["dummy@1".parse().unwrap()])
+            .load_runtime_args(&mut ts)
+            .unwrap();
+        assert_eq!(
+            ts.versions[&ba].requests[0].lockfile_scope(),
+            &LockfileScope::Default
+        );
     }
 }

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -1006,6 +1006,7 @@ mod tests {
             let req = ToolRequest::System {
                 backend: ba,
                 source: ToolSource::Argument,
+                lockfile_scope: Default::default(),
                 options: Default::default(),
             };
             ToolVersion::new(req, version.into())

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -145,7 +145,9 @@ impl OutdatedInfo {
             let backend = oi.tool_request.ba().clone();
             let source = oi.tool_request.source().clone();
             let options = oi.tool_request.options();
+            let lockfile_scope = oi.tool_request.lockfile_scope().clone();
             oi.tool_request = ToolRequest::new_with_options(backend, &oi.latest, options, source)?;
+            oi.tool_request.set_lockfile_scope(lockfile_scope);
         }
         if oi
             .current
@@ -203,11 +205,13 @@ impl OutdatedInfo {
                         backend,
                         options,
                         source,
+                        lockfile_scope,
                     } => {
                         oi.tool_request = ToolRequest::Version {
                             backend,
                             options,
                             source,
+                            lockfile_scope,
                             version: format!("{prefix}{bumped_version}"),
                         };
                         Some(oi.tool_request.version())
@@ -217,11 +221,13 @@ impl OutdatedInfo {
                         backend,
                         options,
                         source,
+                        lockfile_scope,
                     } => {
                         oi.tool_request = ToolRequest::Prefix {
                             backend,
                             options,
                             source,
+                            lockfile_scope,
                             prefix: format!("{prefix}{bumped_version}"),
                         };
                         Some(oi.tool_request.version())
@@ -403,22 +409,26 @@ pub(crate) fn compute_config_bumps_for_paths(
                         backend,
                         options,
                         source,
+                        lockfile_scope,
                     } => ToolRequest::Version {
                         version: new_version.clone(),
                         backend,
                         options,
                         source,
+                        lockfile_scope,
                     },
                     ToolRequest::Prefix {
                         prefix: _,
                         backend,
                         options,
                         source,
+                        lockfile_scope,
                     } => ToolRequest::Prefix {
                         prefix: format!("{prefix}{bumped}"),
                         backend,
                         options,
                         source,
+                        lockfile_scope,
                     },
                     other => other,
                 };

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -27,6 +27,18 @@ use crate::{
     config::{Config, Settings},
 };
 
+/// Lockfile ownership is independent of the request's original provenance.
+#[derive(Debug, Default, Clone, Hash, PartialEq, Eq)]
+pub(crate) enum LockfileScope {
+    /// Preserve ordinary source-based reads, including merged reads for CLI requests.
+    #[default]
+    Default,
+    /// A runtime request borrows the effective configuration's lockfile.
+    Source(ToolSource),
+    /// An unconfigured runtime request must not adopt an unrelated pin.
+    NoOwner,
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub(crate) enum ToolRequest {
     Version {
@@ -34,12 +46,14 @@ pub(crate) enum ToolRequest {
         version: String,
         options: ResolvedToolOptions,
         source: ToolSource,
+        lockfile_scope: LockfileScope,
     },
     Prefix {
         backend: Arc<BackendArg>,
         prefix: String,
         options: ResolvedToolOptions,
         source: ToolSource,
+        lockfile_scope: LockfileScope,
     },
     Ref {
         backend: Arc<BackendArg>,
@@ -47,6 +61,7 @@ pub(crate) enum ToolRequest {
         ref_type: String,
         options: ResolvedToolOptions,
         source: ToolSource,
+        lockfile_scope: LockfileScope,
     },
     Sub {
         backend: Arc<BackendArg>,
@@ -54,16 +69,19 @@ pub(crate) enum ToolRequest {
         orig_version: String,
         options: ResolvedToolOptions,
         source: ToolSource,
+        lockfile_scope: LockfileScope,
     },
     Path {
         backend: Arc<BackendArg>,
         path: PathBuf,
         options: ResolvedToolOptions,
         source: ToolSource,
+        lockfile_scope: LockfileScope,
     },
     System {
         backend: Arc<BackendArg>,
         source: ToolSource,
+        lockfile_scope: LockfileScope,
         options: ResolvedToolOptions,
     },
 }
@@ -114,6 +132,7 @@ impl ToolRequest {
                     options,
                     backend,
                     source,
+                    lockfile_scope: LockfileScope::Default,
                 }
             }
             Some(("prefix", p)) => {
@@ -123,6 +142,7 @@ impl ToolRequest {
                     options,
                     backend,
                     source,
+                    lockfile_scope: LockfileScope::Default,
                 }
             }
             Some(("path", p)) => {
@@ -134,6 +154,7 @@ impl ToolRequest {
                     options,
                     backend,
                     source,
+                    lockfile_scope: LockfileScope::Default,
                 }
             }
             Some((p, v)) if p.starts_with("sub-") => {
@@ -146,6 +167,7 @@ impl ToolRequest {
                     orig_version: v.to_string(),
                     backend,
                     source,
+                    lockfile_scope: LockfileScope::Default,
                 }
             }
             None => {
@@ -154,6 +176,7 @@ impl ToolRequest {
                         options,
                         backend,
                         source,
+                        lockfile_scope: LockfileScope::Default,
                     }
                 } else {
                     validate_version_string(&s)?;
@@ -162,6 +185,7 @@ impl ToolRequest {
                         options,
                         backend,
                         source,
+                        lockfile_scope: LockfileScope::Default,
                     }
                 }
             }
@@ -183,6 +207,7 @@ impl ToolRequest {
             version: version.to_string(),
             options,
             source,
+            lockfile_scope: LockfileScope::Default,
         }
     }
 
@@ -195,6 +220,7 @@ impl ToolRequest {
             | Self::Sub { source: s, .. }
             | Self::System { source: s, .. } => *s = source,
         }
+        self.set_lockfile_scope(LockfileScope::Default);
         self.clone()
     }
     pub(crate) fn ba(&self) -> &Arc<BackendArg> {
@@ -250,6 +276,55 @@ impl ToolRequest {
             | Self::System { source, .. } => source,
         }
     }
+    pub(crate) fn lockfile_scope(&self) -> &LockfileScope {
+        match self {
+            Self::Version { lockfile_scope, .. }
+            | Self::Prefix { lockfile_scope, .. }
+            | Self::Ref { lockfile_scope, .. }
+            | Self::Path { lockfile_scope, .. }
+            | Self::Sub { lockfile_scope, .. }
+            | Self::System { lockfile_scope, .. } => lockfile_scope,
+        }
+    }
+
+    pub(crate) fn set_lockfile_scope(&mut self, scope: LockfileScope) {
+        match self {
+            Self::Version { lockfile_scope, .. }
+            | Self::Prefix { lockfile_scope, .. }
+            | Self::Ref { lockfile_scope, .. }
+            | Self::Path { lockfile_scope, .. }
+            | Self::Sub { lockfile_scope, .. }
+            | Self::System { lockfile_scope, .. } => *lockfile_scope = scope,
+        }
+    }
+
+    pub(crate) fn lockfile_source(&self) -> Option<&ToolSource> {
+        match self.lockfile_scope() {
+            LockfileScope::Default => Some(self.source()),
+            LockfileScope::Source(source) => Some(source),
+            LockfileScope::NoOwner => None,
+        }
+    }
+
+    /// Read dependency tables from the same owner as the runtime pin.
+    pub(crate) fn read_lockfile(&self, config: &Config) -> Result<lockfile::Lockfile> {
+        match self.lockfile_source() {
+            Some(source) => lockfile::read_lockfile_for_tool_source(config, source),
+            None => Ok(lockfile::Lockfile::default()),
+        }
+    }
+
+    pub(crate) fn tool_config_locked(&self, config: &Config, use_locked_version: bool) -> bool {
+        // A lockfile bypass must not inherit an additional owner's policy.
+        // Invocation-wide locked policy still uses the original source separately.
+        let source = if use_locked_version {
+            self.lockfile_source().unwrap_or(self.source())
+        } else {
+            self.source()
+        };
+        config.tool_config_locked(source)
+    }
+
     pub(crate) fn os(&self) -> &Option<Vec<String>> {
         &self.resolved_options().effective().os
     }
@@ -353,6 +428,7 @@ impl ToolRequest {
             ref_type,
             options: self.resolved_options().clone(),
             source: self.source().clone(),
+            lockfile_scope: self.lockfile_scope().clone(),
         }
     }
 
@@ -362,6 +438,7 @@ impl ToolRequest {
             path,
             options: self.resolved_options().clone(),
             source: self.source().clone(),
+            lockfile_scope: self.lockfile_scope().clone(),
         }
     }
 
@@ -541,14 +618,10 @@ impl ToolRequest {
         } else {
             (BTreeMap::new(), false)
         };
-        let path = match self.source() {
-            ToolSource::MiseToml(path) => Some(path),
-            _ => None,
-        };
         lockfile::get_locked_version(
             config,
             lockfile::LockedVersionQuery {
-                path: path.map(|p| p.as_path()),
+                request: self,
                 short: &self.ba().short,
                 specifier: &self.version(),
                 prefix,
@@ -834,7 +907,9 @@ impl Display for ToolRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::{ToolRequest, validate_ref_string, validate_version_string, version_sub};
+    use super::{
+        LockfileScope, ToolRequest, validate_ref_string, validate_version_string, version_sub,
+    };
     use crate::cli::args::{BackendArg, BackendResolution};
     use crate::toolset::{ToolSource, ToolVersionOptions};
     use pretty_assertions::assert_str_eq;
@@ -850,6 +925,35 @@ mod tests {
             Some(ToolVersionOptions::default()),
             BackendResolution::new(true),
         ))
+    }
+
+    #[test]
+    fn lockfile_scope_survives_conversion_until_source_changes() {
+        let owner = ToolSource::MiseToml("/project/mise.toml".into());
+        let destination = ToolSource::MiseToml("/project/mise.local.toml".into());
+        for selector in [
+            "latest",
+            "prefix:1",
+            "ref:main",
+            "sub-1:3",
+            "path:/tools/dummy",
+            "system",
+        ] {
+            let mut request = ToolRequest::new(test_ba(), selector, ToolSource::Argument).unwrap();
+            request.set_lockfile_scope(LockfileScope::Source(owner.clone()));
+            for mut converted in [
+                request.clone(),
+                request.to_ref("main".into(), "ref".into()),
+                request.to_path("/tools/dummy".into()),
+            ] {
+                assert_eq!(converted.source(), &ToolSource::Argument);
+                assert_eq!(converted.lockfile_source(), Some(&owner));
+                converted.set_source(destination.clone());
+                assert_eq!(converted.source(), &destination);
+                assert_eq!(converted.lockfile_source(), Some(&destination));
+                assert_eq!(converted.lockfile_scope(), &LockfileScope::Default);
+            }
+        }
     }
 
     #[tokio::test]
@@ -868,6 +972,8 @@ mod tests {
             .resolved_options_mut()
             .apply_overrides(&old_defaults, ToolOptionSource::Registry);
         let explicit = crate::toolset::parse_tool_options("variant=custom");
+        let owner = ToolSource::MiseToml("/project/mise.toml".into());
+        request.set_lockfile_scope(LockfileScope::Source(owner.clone()));
         request
             .resolved_options_mut()
             .apply_overrides(&explicit, ToolOptionSource::Request);
@@ -882,6 +988,8 @@ mod tests {
         );
         let resolved = ToolVersion::new(request, "1.58.1".to_string());
         assert_eq!(resolved.ba().full(), "packslip:github.com/jdx/hk");
+        assert_eq!(resolved.request.source(), &ToolSource::Argument);
+        assert_eq!(resolved.request.lockfile_source(), Some(&owner));
     }
 
     #[test]

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -119,18 +119,18 @@ impl ToolVersion {
         {
             return Ok(Self::from_lockfile(request.clone(), lt).with_before_date(opts.before_date));
         }
-        if matches!(
-            request,
-            ToolRequest::Prefix { .. } | ToolRequest::Ref { .. }
-        ) {
-            Self::ensure_unlocked_resolution_allowed(config, &request, &opts)?;
-        }
         let backend = request.ba().backend()?;
         if let Some(plugin) = backend.plugin()
             && !plugin.is_installed()
         {
             let tv = Self::new(request.clone(), request.version());
             return Ok(tv.with_before_date(opts.before_date));
+        }
+        if matches!(
+            request,
+            ToolRequest::Prefix { .. } | ToolRequest::Ref { .. }
+        ) {
+            Self::ensure_unlocked_resolution_allowed(config, &request, &opts)?;
         }
         let tv = match request.clone() {
             ToolRequest::Version { version: v, .. } => {

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -119,6 +119,12 @@ impl ToolVersion {
         {
             return Ok(Self::from_lockfile(request.clone(), lt).with_before_date(opts.before_date));
         }
+        if matches!(
+            request,
+            ToolRequest::Prefix { .. } | ToolRequest::Ref { .. }
+        ) {
+            Self::ensure_unlocked_resolution_allowed(config, &request, &opts)?;
+        }
         let backend = request.ba().backend()?;
         if let Some(plugin) = backend.plugin()
             && !plugin.is_installed()
@@ -357,6 +363,37 @@ impl ToolVersion {
         };
         Some(pathname.replace([':', '/'], "-"))
     }
+    fn ensure_unlocked_resolution_allowed(
+        config: &Config,
+        request: &ToolRequest,
+        opts: &ResolveOptions,
+    ) -> Result<()> {
+        let settings = Settings::get();
+        let tool_config_locked = request.tool_config_locked(config, opts.use_locked_version);
+        let invocation_locked = config.invocation_locked_for(request.source(), settings.locked);
+        if (invocation_locked || tool_config_locked)
+            && opts.use_locked_version
+            && settings.lockfile_enabled()
+            && !has_linked_version(request.ba())
+            && request
+                .lockfile_source()
+                .and_then(ToolSource::path)
+                .is_some()
+        {
+            let hint = if tool_config_locked && !invocation_locked {
+                "Run `mise lock` to update the lockfile, or disable `tool_config.locked`"
+            } else {
+                "Run `mise install` without --locked to update the lockfile"
+            };
+            bail!(
+                "{}@{} is not in the lockfile\nhint: {hint}",
+                request.ba().short,
+                request.version()
+            );
+        }
+        Ok(())
+    }
+
     async fn resolve_version(
         config: &Arc<Config>,
         request: ToolRequest,
@@ -387,26 +424,7 @@ impl ToolVersion {
         {
             return Ok(Self::from_lockfile(request.clone(), lt));
         }
-        let settings = Settings::get();
-        let tool_config_locked = config.tool_config_locked(request.source());
-        let invocation_locked = config.invocation_locked_for(request.source(), settings.locked);
-        if (invocation_locked || tool_config_locked)
-            && opts.use_locked_version
-            && settings.lockfile_enabled()
-            && !has_linked_version(request.ba())
-            && request.source().path().is_some()
-        {
-            let hint = if tool_config_locked && !invocation_locked {
-                "Run `mise lock` to update the lockfile, or disable `tool_config.locked`"
-            } else {
-                "Run `mise install` without --locked to update the lockfile"
-            };
-            bail!(
-                "{}@{} is not in the lockfile\nhint: {hint}",
-                request.ba().short,
-                request.version()
-            );
-        }
+        Self::ensure_unlocked_resolution_allowed(config, &request, opts)?;
 
         match v.split_once(':') {
             Some((ref_type @ ("ref" | "tag" | "branch" | "rev"), r)) => {
@@ -1059,9 +1077,13 @@ mod tests {
             "registry".to_string(),
             toml::Value::String("https://registry.example.test".to_string()),
         );
-        let request =
+        let mut request =
             ToolRequest::new_with_options(backend, "latest", options, ToolSource::Argument)
                 .unwrap();
+        let owner = ToolSource::MiseToml("/project/mise.toml".into());
+        request.set_lockfile_scope(crate::toolset::tool_request::LockfileScope::Source(
+            owner.clone(),
+        ));
         let lt = LockfileTool {
             version: "11.17.0".to_string(),
             backend: Some("npm:npm".to_string()),
@@ -1077,6 +1099,8 @@ mod tests {
         assert!(tv.locked);
         assert!(tv.resolved_from_lockfile());
         assert_eq!(tv.ba().full_without_opts(), "npm:npm");
+        assert_eq!(tv.request.source(), &ToolSource::Argument);
+        assert_eq!(tv.request.lockfile_source(), Some(&owner));
         assert_eq!(options.depends, Some(vec!["node".to_string()]));
         assert_eq!(
             options.install_env.get("NODE_OPTIONS"),

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -790,7 +790,7 @@ impl Toolset {
             force: opts.force,
             dry_run: opts.dry_run,
             locked: config.invocation_locked_for(tr.source(), opts.locked)
-                || config.tool_config_locked(tr.source()),
+                || tr.tool_config_locked(config, resolve_options.use_locked_version),
             before_date,
             dependency_context: OnceCell::new(),
         };


### PR DESCRIPTION
Runtime requests can lose the configuration file that owns a tool. Lockfile lookup then merges independent project/global pins and reports a false ambiguity, or selects a pin from a definition the project has overridden. This change preserves the effective config source for lock-aware runtime arguments and uses that source’s corresponding lockfile.

EDIT: pushed the separation—requests now keep where they came from and carry lockfile ownership separately. The original precedence fix is still covered, local install/use/upgrade regressions pass, and I’m keeping this draft until CI finishes.

## Reproducing case

The original failure involved `hk = "latest"` in both the project and global configuration, with version-1 lockfiles using `aqua:jdx/hk` and the same options:

| Source | Binding |
| --- | --- |
| Project `mise.toml` / `mise.lock` | `latest` → `1.58.1` |
| Global `config.toml` / `mise.lock` | `latest` → `1.57.0` |

From the project, `mise which hk --tool hk@latest` reported `lockfile contains multiple resolutions for hk@latest with the same options`, although ordinary config-scoped lookup selected 1.58.1. It now selects the project pin.

If the project still defines hk but has no matching lock entry, the global pin is ignored. Normal unlocked resolution proceeds, or locked mode reports a missing lock entry—even for read-only lookup of an already-installed tool. If the project does not define hk, the inherited definition and its lockfile remain available.

## Implementation and scope

We attempted to implement the agreed behavior with the smallest blast radius:

- Preserve the winning config source when the runtime builder applies arguments. Keep the requested selector and argument-level error reporting, and reuse existing source-to-lockfile mapping and locked-scope policy, including idiomatic version files.
- Interpret request bindings using the recorded backend, so a shorthand does not reject a valid project pin because backend discovery initially found another scope’s backend. Unavailable or disabled recorded backends are non-matches, so a stale candidate cannot block a valid pin or fall back to a cached shorthand backend.
- Reuse the missing-lock-entry check for prefix and ref requests, before they can return through an unlocked shortcut.
- Enable the targeted warning only for `mise which --tool`: when the effective source has no matching pin, inspect lower-precedence configs that actually define the tool and check their corresponding lockfiles. Matching effective pins and unrelated stale lockfile entries do not warn. Run this diagnostic only after successful toolset resolution so its errors cannot replace a returned resolution error.
- Retain intentional lockfile bypasses, including explicit `mise exec hk@latest`. Ambiguous bindings within the selected lockfile remain errors; ambiguity in an ignored source can produce the warning without failing the effective lookup.

The change reuses the existing config order and lockfile cache. It does not change lockfile formats, writers, migration, or shared-monorepo merge rules. Runtime behavior is documented in the lockfile guide.

## Validation

- 203 focused unit tests passed: 98 lockfile tests and 105 toolset tests
- Six focused e2e suites passed: request precedence, idiomatic version files, lockfile versions, backends, environment resolution, and explicit exec-latest bypass
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` passed
- Scoped safe hk checks passed, including formatting, Cargo check, shell checks, and documentation checks
- Verified the original `mise which hk --tool hk@latest` command in the affected dotfiles project: it selects 1.58.1

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lockfile resolution now follows the configuration that defines each tool.
  - Runtime requests honor matching lockfile pins, including dependency tables.
  - Version, prefix, and reference requests respect locked-mode requirements.
  - Explicit tool versions continue to override lockfile selections.
  - Warnings identify when an overriding configuration lacks a matching pin.

- **Bug Fixes**
  - Improved handling of inherited, environment-specific, aliased, and non-TOML configurations.
  - Clearer errors appear for ambiguous or missing lockfile entries.
  - Invalid or unavailable candidates no longer hide valid lockfile matches.

- **Documentation**
  - Added guidance on runtime resolution, lockfile overrides, warnings, and locked-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->