### PR TITLE
feat(brew-cask): support structured set_permissions flight steps

### DIFF
--- a/docs/bootstrap/packages/brew.md
+++ b/docs/bootstrap/packages/brew.md
@@ -236,10 +236,12 @@ cleanup metadata, not install receipts. For casks with lifecycle hooks, mise
 fetches the sha256-verified cask Ruby source pinned by the API metadata and runs
 supported `preflight`/`postflight` hooks through its own Cask DSL shim, without
 delegating to Homebrew. mise also supports structured `preflight_steps` and
-`postflight_steps` for `move`/`remove` operations against `staged_path`, `run`
-operations using Homebrew's serialized command bases, arguments, environment,
-guards, and sudo setting, and `terminate_process` operations with
-Homebrew-compatible name/full matching, retries, notices, and failure policy.
+`postflight_steps` for `move`/`remove` operations against `staged_path`,
+`set_permissions` operations that `chmod` existing `staged_path` or `appdir`
+paths with Homebrew's recursive default, `run` operations using Homebrew's
+serialized command bases, arguments, environment, guards, and sudo setting, and
+`terminate_process` operations with Homebrew-compatible name/full matching,
+retries, notices, and failure policy.
 Structured `copy` and `symlink` steps support Homebrew path bases, templates,
 guards, source globs, replacement, and sudo behavior. External paths created by
 lifecycle steps are recorded in the mise receipt and restored if the install

--- a/src/system/packages/brew/cask/artifacts.rs
+++ b/src/system/packages/brew/cask/artifacts.rs
@@ -592,6 +592,48 @@ pub(super) fn parse_flight_step(cask: &Cask, kind: &str, value: &Value) -> Resul
                     .unwrap_or(false),
             })
         }
+        "set_permissions" => {
+            reject_unsupported_flight_fields(
+                cask,
+                kind,
+                "set_permissions step",
+                object,
+                &["type", "paths", "permissions", "non_recursive"],
+            )?;
+            let paths = object
+                .get("paths")
+                .and_then(Value::as_array)
+                .ok_or_else(|| {
+                    eyre!(
+                        "brew-cask:{}: unsupported {kind} set_permissions step metadata format",
+                        cask.token
+                    )
+                })?
+                .iter()
+                .map(|path| parse_permissions_flight_path(cask, kind, Some(path)))
+                .collect::<Result<Vec<_>>>()?;
+            let permissions = object
+                .get("permissions")
+                .and_then(Value::as_str)
+                .filter(|permissions| !permissions.is_empty())
+                .ok_or_else(|| {
+                    eyre!(
+                        "brew-cask:{}: unsupported {kind} set_permissions step permissions",
+                        cask.token
+                    )
+                })?;
+            // Homebrew serializes the DSL's `recursive: true` default as an
+            // absent `non_recursive`, so only an explicit `true` narrows it.
+            let recursive = !object
+                .get("non_recursive")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            Ok(FlightStep::SetPermissions {
+                paths,
+                permissions: permissions.to_string(),
+                recursive,
+            })
+        }
         "copy" => {
             reject_unsupported_flight_fields(
                 cask,
@@ -1082,6 +1124,55 @@ pub(super) fn parse_flight_path(
     if validate_flight_relative_path(path).is_err() {
         bail!(
             "brew-cask:{}: invalid {kind} {field} path {}",
+            cask.token,
+            path
+        )
+    }
+    Ok(FlightPath {
+        base,
+        path: path.to_string(),
+    })
+}
+
+/// `set_permissions` paths follow Homebrew's `remove` shape but may also
+/// name the installed app for `postflight_steps`, so `appdir` is accepted
+/// beside `staged_path`.
+pub(super) fn parse_permissions_flight_path(
+    cask: &Cask,
+    kind: &str,
+    value: Option<&Value>,
+) -> Result<FlightPath> {
+    let field = "paths";
+    let object = value.and_then(Value::as_object).ok_or_else(|| {
+        eyre!(
+            "brew-cask:{}: unsupported {kind} {field} metadata format",
+            cask.token
+        )
+    })?;
+    let base = match object.get("base").and_then(Value::as_str) {
+        Some("staged_path") => FlightPathBase::StagedPath,
+        Some("appdir") => FlightPathBase::AppDir,
+        Some(base) => bail!(
+            "brew-cask:{}: unsupported {kind} {field} base {}",
+            cask.token,
+            base
+        ),
+        None => bail!("brew-cask:{}: unsupported {kind} {field} base", cask.token),
+    };
+    let path = object
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| eyre!("brew-cask:{}: unsupported {kind} {field} path", cask.token))?;
+    if validate_flight_relative_path(path).is_err() {
+        bail!(
+            "brew-cask:{}: invalid {kind} {field} path {}",
+            cask.token,
+            path
+        )
+    }
+    if base == FlightPathBase::AppDir && is_flight_glob(path) {
+        bail!(
+            "brew-cask:{}: unsupported {kind} {field} glob outside staged_path {}",
             cask.token,
             path
         )

--- a/src/system/packages/brew/cask/artifacts.rs
+++ b/src/system/packages/brew/cask/artifacts.rs
@@ -624,10 +624,8 @@ pub(super) fn parse_flight_step(cask: &Cask, kind: &str, value: &Value) -> Resul
                 })?;
             // Homebrew serializes the DSL's `recursive: true` default as an
             // absent `non_recursive`, so only an explicit `true` narrows it.
-            let recursive = !object
-                .get("non_recursive")
-                .and_then(Value::as_bool)
-                .unwrap_or(false);
+            let recursive =
+                !parse_optional_flight_bool(cask, kind, object, "non_recursive", false)?;
             Ok(FlightStep::SetPermissions {
                 paths,
                 permissions: permissions.to_string(),

--- a/src/system/packages/brew/cask/flight.rs
+++ b/src/system/packages/brew/cask/flight.rs
@@ -658,9 +658,13 @@ pub(super) fn execute_flight_step(
             }
             let mut runner = CmdLineRunner::new("/bin/chmod");
             if *recursive {
+                runner = runner.arg("-R");
                 // Never follow symlinks out of the bundle, matching the
-                // module's other recursive mode changes.
-                runner = runner.arg("-R").arg("-P");
+                // module's other recursive mode changes. GNU chmod has no
+                // `-P` and already leaves symlinks alone during recursion.
+                if cfg!(target_os = "macos") {
+                    runner = runner.arg("-P");
+                }
             }
             runner = runner.arg("--").arg(permissions);
             for path in &existing {

--- a/src/system/packages/brew/cask/flight.rs
+++ b/src/system/packages/brew/cask/flight.rs
@@ -576,6 +576,7 @@ impl FlightStep {
         match self {
             Self::Move { .. } => "move",
             Self::Remove { .. } => "remove",
+            Self::SetPermissions { .. } => "set_permissions",
             Self::Copy { .. } => "copy",
             Self::Symlink { .. } => "symlink",
             Self::Run { .. } => "run",
@@ -634,6 +635,36 @@ pub(super) fn execute_flight_step(
                     }
                 }
             }
+        }
+        FlightStep::SetPermissions {
+            paths,
+            permissions,
+            recursive,
+        } => {
+            // Homebrew runs `chmod` on the paths that exist and skips the rest,
+            // never elevating. Staged paths are discarded with the stage on
+            // failure, and an appdir postflight change is not reversible in
+            // Homebrew either, so nothing is recorded for rollback.
+            let mut existing = Vec::new();
+            for path in paths {
+                for path in permissions_flight_paths(cask, path, staged_path, appdir)? {
+                    if path.exists() {
+                        existing.push(path);
+                    }
+                }
+            }
+            if existing.is_empty() {
+                return Ok(());
+            }
+            let mut runner = CmdLineRunner::new("/bin/chmod");
+            if *recursive {
+                runner = runner.arg("-R");
+            }
+            runner = runner.arg("--").arg(permissions);
+            for path in &existing {
+                runner = runner.arg(path);
+            }
+            runner.raw(true).execute()?;
         }
         FlightStep::Copy {
             source,
@@ -1009,6 +1040,31 @@ pub(super) fn flight_paths(staged_path: &Path, path: &FlightPath) -> Result<Vec<
     // Remove steps do not have a `source_glob` flag, so path globs are detected
     // from the path syntax instead.
     expand_staged_glob(staged_path, &path.path)
+}
+
+pub(super) fn permissions_flight_paths(
+    cask: &Cask,
+    path: &FlightPath,
+    staged_path: &Path,
+    appdir: &Path,
+) -> Result<Vec<PathBuf>> {
+    match path.base {
+        FlightPathBase::StagedPath if is_flight_glob(&path.path) => {
+            // Like remove steps, set_permissions has no glob flag; Homebrew
+            // globs the path syntax itself.
+            let pattern = expand_flight_template(cask, &path.path, staged_path, appdir);
+            expand_staged_glob(staged_path, &pattern)
+        }
+        FlightPathBase::StagedPath | FlightPathBase::AppDir => {
+            Ok(vec![resolve_flight_path_with_context(
+                cask,
+                path,
+                staged_path,
+                appdir,
+            )?])
+        }
+        _ => bail!("brew-cask: structured set_permissions must use staged_path or appdir"),
+    }
 }
 
 pub(super) fn expand_staged_glob(staged_path: &Path, pattern: &str) -> Result<Vec<PathBuf>> {

--- a/src/system/packages/brew/cask/flight.rs
+++ b/src/system/packages/brew/cask/flight.rs
@@ -658,7 +658,9 @@ pub(super) fn execute_flight_step(
             }
             let mut runner = CmdLineRunner::new("/bin/chmod");
             if *recursive {
-                runner = runner.arg("-R");
+                // Never follow symlinks out of the bundle, matching the
+                // module's other recursive mode changes.
+                runner = runner.arg("-R").arg("-P");
             }
             runner = runner.arg("--").arg(permissions);
             for path in &existing {

--- a/src/system/packages/brew/cask/mod.rs
+++ b/src/system/packages/brew/cask/mod.rs
@@ -197,6 +197,11 @@ enum FlightStep {
         paths: Vec<FlightPath>,
         recursive: bool,
     },
+    SetPermissions {
+        paths: Vec<FlightPath>,
+        permissions: String,
+        recursive: bool,
+    },
     Copy {
         source: FlightPath,
         target: FlightPath,

--- a/src/system/packages/brew/cask/tests.rs
+++ b/src/system/packages/brew/cask/tests.rs
@@ -3043,15 +3043,108 @@ fn structured_flight_steps_move_and_remove_staged_paths() -> Result<()> {
 }
 
 #[test]
+#[cfg(unix)]
+fn structured_set_permissions_step_changes_existing_staged_paths() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let staged = tmp.path();
+    let cache = staged.join("Blender.app/Contents/Resources/5.2/python/lib/__pycache__");
+    file::create_dir_all(&cache)?;
+    let compiled = cache.join("module.pyc");
+    file::write(&compiled, "pyc")?;
+    let read_only = std::fs::Permissions::from_mode(0o555);
+    std::fs::set_permissions(&compiled, read_only.clone())?;
+    std::fs::set_permissions(&cache, read_only)?;
+
+    execute_flight_steps(
+        &test_cask("blender", "5.2.1"),
+        &[FlightStep::SetPermissions {
+            paths: vec![
+                FlightPath {
+                    base: FlightPathBase::StagedPath,
+                    path: "*.app/**/__pycache__".to_string(),
+                },
+                FlightPath {
+                    base: FlightPathBase::StagedPath,
+                    path: "Missing.app".to_string(),
+                },
+            ],
+            permissions: "u+w".to_string(),
+            recursive: false,
+        }],
+        staged,
+        staged,
+        "preflight_steps",
+    )?;
+
+    assert_eq!(cache.metadata()?.permissions().mode() & 0o777, 0o755);
+    assert_eq!(
+        compiled.metadata()?.permissions().mode() & 0o777,
+        0o555,
+        "a non-recursive step leaves the directory contents alone"
+    );
+    assert!(!staged.join("Missing.app").exists());
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn structured_set_permissions_step_recurses_by_default() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let staged = tmp.path().join("stage");
+    let appdir = tmp.path().join("Applications");
+    let binary = appdir.join("Tool.app/Contents/MacOS/tool");
+    file::create_dir_all(binary.parent().unwrap())?;
+    file::write(&binary, "#!/bin/sh\n")?;
+    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o644))?;
+    file::create_dir_all(&staged)?;
+
+    execute_flight_steps(
+        &test_cask("tool", "1.0.0"),
+        &[FlightStep::SetPermissions {
+            paths: vec![FlightPath {
+                base: FlightPathBase::AppDir,
+                path: "Tool.app/Contents/MacOS".to_string(),
+            }],
+            permissions: "0755".to_string(),
+            recursive: true,
+        }],
+        &staged,
+        &appdir,
+        "postflight_steps",
+    )?;
+
+    assert_eq!(binary.metadata()?.permissions().mode() & 0o777, 0o755);
+    Ok(())
+}
+
+#[test]
+fn structured_set_permissions_step_skips_when_no_path_exists() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    execute_flight_steps(
+        &test_cask("tool", "1.0.0"),
+        &[FlightStep::SetPermissions {
+            paths: vec![FlightPath {
+                base: FlightPathBase::StagedPath,
+                path: "Missing-*".to_string(),
+            }],
+            permissions: "0755".to_string(),
+            recursive: true,
+        }],
+        tmp.path(),
+        tmp.path(),
+        "preflight_steps",
+    )
+}
+
+#[test]
 fn rejects_unsupported_structured_flight_steps() {
     let mut cask = test_cask("battle-net", "1.0.0");
     cask.artifacts = vec![
         serde_json::json!({
             "preflight_steps": [{
                 "steps": [{
-                    "type": "set_permissions",
-                    "paths": [{"base": "staged_path", "path": "Battle.net-Setup.app"}],
-                    "permissions": "a+x"
+                    "type": "set_ownership",
+                    "paths": [{"base": "staged_path", "path": "Battle.net-Setup.app"}]
                 }]
             }]
         }),
@@ -3059,7 +3152,113 @@ fn rejects_unsupported_structured_flight_steps() {
     ];
 
     let err = cask_artifacts(&cask).unwrap_err().to_string();
-    assert!(err.contains("unsupported preflight_steps step type set_permissions"));
+    assert!(err.contains("unsupported preflight_steps step type set_ownership"));
+}
+
+#[test]
+fn parses_structured_set_permissions_steps() -> Result<()> {
+    let mut cask = test_cask("blender", "5.2.1");
+    cask.artifacts = vec![
+        serde_json::json!({
+            "preflight_steps": [{
+                "steps": [{
+                    "type": "set_permissions",
+                    "paths": [{"base": "staged_path", "path": "*.app/**/__pycache__"}],
+                    "permissions": "u+w",
+                    "non_recursive": true
+                }]
+            }]
+        }),
+        serde_json::json!({"app": "Blender.app"}),
+        serde_json::json!({
+            "postflight_steps": [{
+                "steps": [{
+                    "type": "set_permissions",
+                    "paths": [{"base": "appdir", "path": "Blender.app/Contents/MacOS/Blender"}],
+                    "permissions": "0755"
+                }]
+            }]
+        }),
+    ];
+
+    let artifacts = cask_artifacts(&cask)?;
+    assert_eq!(
+        artifacts.preflight_steps,
+        vec![FlightStep::SetPermissions {
+            paths: vec![FlightPath {
+                base: FlightPathBase::StagedPath,
+                path: "*.app/**/__pycache__".to_string(),
+            }],
+            permissions: "u+w".to_string(),
+            recursive: false,
+        }]
+    );
+    assert_eq!(
+        artifacts.postflight_steps,
+        vec![FlightStep::SetPermissions {
+            paths: vec![FlightPath {
+                base: FlightPathBase::AppDir,
+                path: "Blender.app/Contents/MacOS/Blender".to_string(),
+            }],
+            permissions: "0755".to_string(),
+            recursive: true,
+        }]
+    );
+    Ok(())
+}
+
+#[test]
+fn rejects_malformed_structured_set_permissions_steps() {
+    for (steps, message) in [
+        (
+            serde_json::json!([{
+                "type": "set_permissions",
+                "paths": [{"base": "staged_path", "path": "Tool.app"}]
+            }]),
+            "unsupported preflight_steps set_permissions step permissions",
+        ),
+        (
+            serde_json::json!([{
+                "type": "set_permissions",
+                "paths": [{"base": "homebrew_prefix", "path": "bin/tool"}],
+                "permissions": "0755"
+            }]),
+            "unsupported preflight_steps paths base homebrew_prefix",
+        ),
+        (
+            serde_json::json!([{
+                "type": "set_permissions",
+                "paths": [{"base": "appdir", "path": "*.app"}],
+                "permissions": "0755"
+            }]),
+            "unsupported preflight_steps paths glob outside staged_path *.app",
+        ),
+        (
+            serde_json::json!([{
+                "type": "set_permissions",
+                "paths": [{"base": "staged_path", "path": "../Tool.app"}],
+                "permissions": "0755"
+            }]),
+            "invalid preflight_steps paths path ../Tool.app",
+        ),
+        (
+            serde_json::json!([{
+                "type": "set_permissions",
+                "paths": [{"base": "staged_path", "path": "Tool.app"}],
+                "permissions": "0755",
+                "sudo": true
+            }]),
+            "unsupported preflight_steps set_permissions step field sudo",
+        ),
+    ] {
+        let mut cask = test_cask("tool", "1.0.0");
+        cask.artifacts = vec![
+            serde_json::json!({"preflight_steps": [{"steps": steps}]}),
+            serde_json::json!({"app": "Tool.app"}),
+        ];
+        let err = cask_artifacts(&cask).unwrap_err().to_string();
+        assert!(err.contains(message), "{err}");
+    }
 }
 
 #[test]

--- a/src/system/packages/brew/cask/tests.rs
+++ b/src/system/packages/brew/cask/tests.rs
@@ -3096,6 +3096,10 @@ fn structured_set_permissions_step_recurses_by_default() -> Result<()> {
     file::create_dir_all(binary.parent().unwrap())?;
     file::write(&binary, "#!/bin/sh\n")?;
     std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o644))?;
+    let external = tmp.path().join("external");
+    file::write(&external, "outside")?;
+    std::fs::set_permissions(&external, std::fs::Permissions::from_mode(0o644))?;
+    file::make_symlink(&external, &binary.with_file_name("link"))?;
     file::create_dir_all(&staged)?;
 
     execute_flight_steps(
@@ -3114,6 +3118,11 @@ fn structured_set_permissions_step_recurses_by_default() -> Result<()> {
     )?;
 
     assert_eq!(binary.metadata()?.permissions().mode() & 0o777, 0o755);
+    assert_eq!(
+        external.metadata()?.permissions().mode() & 0o777,
+        0o644,
+        "a symlink inside the tree must not carry the change outside it"
+    );
     Ok(())
 }
 

--- a/src/system/packages/brew/cask/tests.rs
+++ b/src/system/packages/brew/cask/tests.rs
@@ -3259,6 +3259,15 @@ fn rejects_malformed_structured_set_permissions_steps() {
             }]),
             "unsupported preflight_steps set_permissions step field sudo",
         ),
+        (
+            serde_json::json!([{
+                "type": "set_permissions",
+                "paths": [{"base": "staged_path", "path": "Tool.app"}],
+                "permissions": "0755",
+                "non_recursive": "true"
+            }]),
+            "preflight_steps non_recursive must be a boolean",
+        ),
     ] {
         let mut cask = test_cask("tool", "1.0.0");
         cask.artifacts = vec![


### PR DESCRIPTION
## Problem

`brew-cask:blender` fails before anything is staged:

```text
mise ERROR brew-cask:blender: unsupported preflight_steps step type set_permissions
```

Blender's cask makes every `__pycache__` directory in the bundle owner-writable in a structured preflight step before the app is moved:

```json
{"type": "set_permissions", "paths": [{"base": "staged_path", "path": "*.app/**/__pycache__"}], "permissions": "u+w", "non_recursive": true}
```

mise runs `move`, `remove`, `copy`, `symlink`, `run`, and `terminate_process` structured steps and rejects the rest. After `set_ownership`, `set_permissions` is the most-declared structured step mise still rejects: 17 casks carry 19 of them (blender, blender@lts, bitcoin-core, litecoin, ngrok, pd, ...), every one a `chmod` on `staged_path` or `appdir` paths with no sudo.

## Fix

Parse `set_permissions` into `FlightStep::SetPermissions { paths, permissions, recursive }` and run it the way Homebrew's `install_steps.rb` does: resolve the paths, drop the ones that do not exist, and run `/bin/chmod [-R -P] -- <permissions> <paths>` without elevating. On macOS `-P` matches the module's other recursive mode changes so a symlink inside a bundle never carries the change to its target; GNU chmod has no such flag and already skips symlinks during recursion. A non-boolean `non_recursive` is rejected at parse time. `recursive` defaults to true. Homebrew serializes the DSL default as an absent `non_recursive`, so only an explicit `true` narrows it.

- Paths accept `staged_path` and `appdir`, which covers every declaration in the index. A `staged_path` glob expands from the path syntax like a `remove` glob and stays inside the stage. An `appdir` glob is rejected at parse time.
- Nothing is recorded for rollback. Staged paths are discarded with the stage on failure, and Homebrew does not undo an appdir postflight chmod either.
- Unknown fields such as `sudo` still fail with the existing unsupported-field error, so a step that would need elevation is refused rather than run unprivileged.

The docs sentence listing supported structured steps names the new type. `set_ownership` stays unsupported; it needs `chown` under sudo plus macOS App Management permission, and the rejection test now uses it as its example.

## Tests

- `parses_structured_set_permissions_steps` covers blender's non-recursive preflight and an appdir postflight
- `rejects_malformed_structured_set_permissions_steps` covers a missing `permissions`, an unsupported base, an `appdir` glob, a parent-escaping path, a `sudo` field, and a non-boolean `non_recursive`
- `structured_set_permissions_step_changes_existing_staged_paths` asserts the glob match gains `u+w`, its contents stay untouched without `-R`, and a missing path is skipped
- `structured_set_permissions_step_recurses_by_default` asserts an appdir tree gets `0755` through `-R` and a symlink in that tree leaves its external target untouched
- `structured_set_permissions_step_skips_when_no_path_exists` asserts an empty match is a no-op

`cargo test --locked --bin mise -- system::packages::brew::cask`: 274 passed. `cargo clippy --locked --bin mise --tests -- -D warnings` and `cargo fmt --check` are clean.

End to end, `mise bootstrap packages apply brew-cask:blender` with this build and an isolated prefix, appdir, and data directory installs Blender 5.2.1: the preflight step runs over the matched `__pycache__` directories, the app lands in the appdir, and the `blender` command wrapper is linked in the prefix. The 2026.9.4 release stops at the unsupported step type error before staging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `set_permissions` steps in Homebrew cask workflows.
  - Permissions can be applied to staged or application paths, with recursive behavior enabled by default.
  - Supports permission modes, path validation, missing-path handling, and safe symlink processing.

- **Documentation**
  - Documented `set_permissions` alongside existing postflight operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->