### PR TITLE
registry: add clipboard (github:Slackadays/Clipboard)

### DIFF
--- a/registry/clipboard.toml
+++ b/registry/clipboard.toml
@@ -1,0 +1,5 @@
+backends = ["github:Slackadays/Clipboard"]
+bins = ["cb"]
+description = "Cut, copy, and paste anything, anytime, anywhere"
+test = { cmd = "cb --help", expected = "Clipboard" }
+version_order = "source"


### PR DESCRIPTION
# Popularity
- GitHub: ~5.8k stars, ~176 forks (Slackadays/Clipboard)
- Latest release: 0.10.0 (2024-11-17); prior 0.9.1, 0.9.0.1, all with 12-14 assets covering linux/macos/windows
- Distribution: Alpine community, AUR, Winget (Slackadays.Clipboard), Flathub (app.getclipboard.Clipboard); homepage https://getclipboard.app/

# Info
- Backend: github:Slackadays/Clipboard (Tier 2; assets autodetected across linux/macos/windows; binary `cb`)
- Registry: bins `cb`, version_order `source` (tags include 4-part versions such as 0.9.0.1), test `cb --help` expecting `Clipboard`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Clipboard to the project registry.
  * Registered its GitHub source, `cb` command, description, help-output test, and source-based version ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->