### PR TITLE
registry: use github releases for linux arm32 tools

### DIFF
--- a/registry/bat.toml
+++ b/registry/bat.toml
@@ -1,8 +1,12 @@
 backends = [
+  { full = "github:sharkdp/bat", platforms = [
+    "linux-arm",
+  ] },
   "aqua:sharkdp/bat",
   "cargo:bat",
   "asdf:https://gitlab.com/wt0f/asdf-bat",
 ]
+bins = ["bat"]
 description = "A cat(1) clone with wings"
 test = { cmd = "bat --version", expected = "bat {{version}}" }
 version_order = "semver"

--- a/registry/coreutils.toml
+++ b/registry/coreutils.toml
@@ -1,4 +1,9 @@
-backends = ["aqua:uutils/coreutils"]
+backends = [
+  { full = "github:uutils/coreutils", platforms = [
+    "linux-arm",
+  ] },
+  "aqua:uutils/coreutils",
+]
 bins = ["coreutils"]
 description = "Cross-platform Rust rewrite of the GNU coreutils"
 version_order = "semver"

--- a/registry/dust.toml
+++ b/registry/dust.toml
@@ -1,4 +1,12 @@
-backends = ["aqua:bootandy/dust", "asdf:looztra/asdf-dust", "cargo:du-dust"]
+backends = [
+  { full = "github:bootandy/dust", platforms = [
+    "linux-arm",
+  ] },
+  "aqua:bootandy/dust",
+  "asdf:looztra/asdf-dust",
+  "cargo:du-dust",
+]
+bins = ["dust"]
 description = "A more intuitive version of du in rust"
 test = { cmd = "dust --version", expected = "Dust {{version}}" }
 version_order = "source"

--- a/registry/eza.toml
+++ b/registry/eza.toml
@@ -1,10 +1,14 @@
 backends = [
+  { full = "github:eza-community/eza", platforms = [
+    "linux-arm",
+  ] },
   { full = "aqua:eza-community/eza", platforms = [
     "linux",
   ] },
   "vfox:jdx/vfox-eza",
   "cargo:eza",
 ]
+bins = ["eza"]
 description = "A modern, maintained replacement for ls"
 test = { cmd = "eza --version", expected = "v{{version}}" }
 version_order = "semver"

--- a/registry/fd.toml
+++ b/registry/fd.toml
@@ -1,8 +1,12 @@
 backends = [
+  { full = "github:sharkdp/fd", platforms = [
+    "linux-arm",
+  ] },
   "aqua:sharkdp/fd",
   "asdf:https://gitlab.com/wt0f/asdf-fd",
   "cargo:fd-find",
 ]
+bins = ["fd"]
 description = "A simple, fast and user-friendly alternative to 'find'"
 test = { cmd = "fd --version", expected = "fd {{version}}" }
 version_order = "semver"

--- a/registry/fzf.toml
+++ b/registry/fzf.toml
@@ -1,4 +1,11 @@
-backends = ["aqua:junegunn/fzf", "asdf:kompiro/asdf-fzf"]
+backends = [
+  { full = "github:junegunn/fzf", platforms = [
+    "linux-arm",
+  ] },
+  "aqua:junegunn/fzf",
+  "asdf:kompiro/asdf-fzf",
+]
+bins = ["fzf"]
 description = ":cherry_blossom: A command-line fuzzy finder"
 test = { cmd = "fzf --version", expected = "{{version}}" }
 version_order = "semver"

--- a/registry/github-cli.toml
+++ b/registry/github-cli.toml
@@ -1,5 +1,12 @@
 aliases = ["gh"]
-backends = ["aqua:cli/cli", "asdf:bartlomiejdanek/asdf-github-cli"]
+backends = [
+  { full = "github:cli/cli", platforms = [
+    "linux-arm",
+  ] },
+  "aqua:cli/cli",
+  "asdf:bartlomiejdanek/asdf-github-cli",
+]
+bins = ["gh"]
 description = "GitHub’s official command line tool"
 test = { cmd = "gh --version", expected = "gh version {{version}}" }
 version_order = "semver"

--- a/registry/gopass.toml
+++ b/registry/gopass.toml
@@ -1,3 +1,10 @@
-backends = ["aqua:gopasspw/gopass", "asdf:trallnag/asdf-gopass"]
+backends = [
+  { full = "github:gopasspw/gopass", platforms = [
+    "linux-arm",
+  ] },
+  "aqua:gopasspw/gopass",
+  "asdf:trallnag/asdf-gopass",
+]
+bins = ["gopass"]
 description = "The slightly more awesome standard unix password manager for teams"
 version_order = "semver"

--- a/registry/jq.toml
+++ b/registry/jq.toml
@@ -1,4 +1,11 @@
-backends = ["aqua:jqlang/jq", "asdf:mise-plugins/asdf-jq"]
+backends = [
+  { full = "github:jqlang/jq", platforms = [
+    "linux-arm",
+  ], options = { asset_pattern = "jq-linux-armhf", version_prefix = "jq-" } },
+  "aqua:jqlang/jq",
+  "asdf:mise-plugins/asdf-jq",
+]
+bins = ["jq"]
 description = "Command-line JSON processor"
 test = { cmd = "jq --version", expected = "jq-{{version}}" }
 version_order = "source"

--- a/registry/ripgrep.toml
+++ b/registry/ripgrep.toml
@@ -1,5 +1,8 @@
 aliases = ["rg"]
 backends = [
+  { full = "github:BurntSushi/ripgrep", platforms = [
+    "linux-arm",
+  ] },
   "aqua:BurntSushi/ripgrep",
   "asdf:https://gitlab.com/wt0f/asdf-ripgrep",
   "cargo:ripgrep",

--- a/registry/ruff.toml
+++ b/registry/ruff.toml
@@ -1,4 +1,11 @@
-backends = ["aqua:astral-sh/ruff", "asdf:simhem/asdf-ruff"]
+backends = [
+  { full = "github:astral-sh/ruff", platforms = [
+    "linux-arm",
+  ] },
+  "aqua:astral-sh/ruff",
+  "asdf:simhem/asdf-ruff",
+]
+bins = ["ruff"]
 description = "An extremely fast Python linter and code formatter, written in Rust"
 idiomatic_files = [
   { path = "ruff.toml", version_regex = '''(?m)^\s*required-version\s*=\s*["']?([><=~^]*v?[0-9][0-9A-Za-z.+<>=~^,*-]*)''' },

--- a/registry/starship.toml
+++ b/registry/starship.toml
@@ -1,8 +1,12 @@
 backends = [
+  { full = "github:starship/starship", platforms = [
+    "linux-arm",
+  ] },
   "aqua:starship/starship",
   "asdf:gr1m0h/asdf-starship",
   "cargo:starship",
 ]
+bins = ["starship"]
 description = "The minimal, blazing-fast, and infinitely customizable prompt for any shell"
 test = { cmd = "starship --version", expected = "starship {{version}}" }
 version_order = "semver"

--- a/registry/zoxide.toml
+++ b/registry/zoxide.toml
@@ -1,4 +1,11 @@
-backends = ["aqua:ajeetdsouza/zoxide", "cargo:zoxide"]
+backends = [
+  { full = "github:ajeetdsouza/zoxide", platforms = [
+    "linux-arm",
+  ] },
+  "aqua:ajeetdsouza/zoxide",
+  "cargo:zoxide",
+]
+bins = ["zoxide"]
 description = "A smarter cd command. Supports all major shells"
 test = { cmd = "zoxide --version", expected = "zoxide {{version}}" }
 version_order = "semver"

--- a/schema/mise-registry-tool.json
+++ b/schema/mise-registry-tool.json
@@ -41,11 +41,11 @@
     },
     "platform": {
       "type": "string",
-      "pattern": "^(freebsd|linux|macos|openbsd|windows)-(x64|arm64|x86|loongarch64|riscv64)$"
+      "pattern": "^(freebsd|linux|macos|openbsd|windows)-(x64|arm64|arm|x86|loongarch64|riscv64)$"
     },
     "optionPlatform": {
       "type": "string",
-      "pattern": "^(freebsd|linux|macos|darwin|openbsd|windows)-(x64|amd64|x86_64|arm64|aarch64|x86|loongarch64|riscv64)$"
+      "pattern": "^(freebsd|linux|macos|darwin|openbsd|windows)-(x64|amd64|x86_64|arm64|aarch64|arm|x86|loongarch64|riscv64)$"
     },
     "platformSelector": {
       "description": "OS, architecture, or platform this backend supports.",
@@ -55,7 +55,7 @@
         },
         {
           "type": "string",
-          "enum": ["x64", "arm64", "x86", "loongarch64", "riscv64"]
+          "enum": ["x64", "arm64", "arm", "x86", "loongarch64", "riscv64"]
         },
         {
           "$ref": "#/$defs/platform"

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -1844,6 +1844,31 @@ mod tests {
         }
     }
 
+    #[test]
+    fn explicit_arm32_lock_platforms_are_validated_and_deduplicated() {
+        let mut cmd = lock_cmd(&[]);
+        cmd.platform = vec![
+            "linux-arm-musl".to_string(),
+            "linux-arm".to_string(),
+            "linux-arm".to_string(),
+        ];
+        let temp = tempfile::tempdir().unwrap();
+        let platforms = cmd
+            .determine_target_platforms(&temp.path().join("mise.lock"))
+            .unwrap();
+        assert_eq!(
+            platforms.iter().map(Platform::to_key).collect::<Vec<_>>(),
+            ["linux-arm", "linux-arm-musl"]
+        );
+        assert!(platforms.iter().all(|platform| platform.arch == "arm"));
+
+        cmd.platform = vec!["linux-arm-invalid".to_string()];
+        assert!(
+            cmd.determine_target_platforms(&temp.path().join("mise.lock"))
+                .is_err()
+        );
+    }
+
     fn lockfile_with_dummy() -> Lockfile {
         let mut lockfile = Lockfile::default();
         lockfile.set_platform_info(

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -84,9 +84,9 @@ impl Platform {
 
         // Validate architecture
         match self.arch.as_str() {
-            "x64" | "arm64" | "x86" | "loongarch64" | "riscv64" => {}
+            "x64" | "arm64" | "arm" | "x86" | "loongarch64" | "riscv64" => {}
             _ => bail!(
-                "Unsupported architecture '{}'. Supported: x64, arm64, x86, loongarch64, riscv64",
+                "Unsupported architecture '{}'. Supported: x64, arm64, arm, x86, loongarch64, riscv64",
                 self.arch
             ),
         }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1023,23 +1023,23 @@ backends = [
 
     #[test]
     fn baked_registry_infers_bins_from_preferred_aqua_backend() {
-        let tool = baked_registry().get("jq").unwrap();
-        assert_eq!(tool.bins, &["jq"]);
+        let tool = baked_registry().get("yq").unwrap();
+        assert_eq!(tool.bins, &["yq"]);
     }
 
     #[test]
     fn floating_registry_reuses_baked_inferred_bins() {
         let registry = registry_from_sources(BTreeMap::from([(
-            "jq".to_string(),
+            "yq".to_string(),
             r#"
-backends = ["aqua:jqlang/jq"]
+backends = ["aqua:mikefarah/yq"]
 version_order = "source"
 "#
             .to_string(),
         )]))
         .unwrap();
 
-        assert_eq!(registry.get("jq").unwrap().bins, &["jq"]);
+        assert_eq!(registry.get("yq").unwrap().bins, &["yq"]);
     }
 
     fn registry_archive(entries: &[(&str, &str)]) -> tempfile::NamedTempFile {
@@ -1399,6 +1399,59 @@ idiomatic_files = [{ path = ".example-version", parser = "shell" }]
                 !backend_matches_platform(&[selector], &settings),
                 "{os}-{arch} should not match {selector}"
             );
+        }
+    }
+
+    #[test]
+    fn arm32_tools_use_github_without_changing_other_platforms() {
+        use super::*;
+
+        for (name, repo) in [
+            ("eza", "eza-community/eza"),
+            ("fd", "sharkdp/fd"),
+            ("starship", "starship/starship"),
+            ("bat", "sharkdp/bat"),
+            ("ripgrep", "BurntSushi/ripgrep"),
+            ("fzf", "junegunn/fzf"),
+            ("zoxide", "ajeetdsouza/zoxide"),
+            ("coreutils", "uutils/coreutils"),
+            ("github-cli", "cli/cli"),
+            ("jq", "jqlang/jq"),
+            ("ruff", "astral-sh/ruff"),
+            ("dust", "bootandy/dust"),
+            ("gopass", "gopasspw/gopass"),
+        ] {
+            let tool = BAKED_REGISTRY.get(name).unwrap();
+            let binary = match name {
+                "github-cli" => "gh",
+                "ripgrep" => "rg",
+                _ => name,
+            };
+            assert_eq!(
+                tool.bins,
+                &[binary],
+                "{name} must retain executable metadata"
+            );
+            for (os, arch) in [("linux", "arm"), ("linux", "arm64"), ("linux", "x64")] {
+                let settings = settings_for(os, arch);
+                let backend = tool
+                    .backends
+                    .iter()
+                    .find(|backend| backend_matches_platform(backend.platforms, &settings))
+                    .unwrap();
+                let kind = if arch == "arm" { "github" } else { "aqua" };
+                assert_eq!(
+                    backend.full,
+                    format!("{kind}:{repo}"),
+                    "{name} on {os}-{arch}"
+                );
+            }
+            for (os, arch) in [("macos", "arm64"), ("windows", "x64"), ("linux", "x86")] {
+                assert!(!backend_matches_platform(
+                    tool.backends[0].platforms,
+                    &settings_for(os, arch)
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
On Linux ARM32, the Aqua entries for 13 tools render asset names that upstream does not publish, even though compatible release binaries exist. Route those shorthands through the GitHub backend on `linux-arm`: eza, fd, starship, bat, ripgrep, fzf, zoxide, coreutils, gh, jq, ruff, dust, and gopass. Other platforms retain their existing backends.

For example, fd now selects `fd-v10.5.0-arm-unknown-linux-gnueabihf.tar.gz` instead of requesting `fd-v10.5.0-arm-unknown-linux-musl.tar.gz`. jq explicitly selects `jq-linux-armhf` and uses its `jq-` release-tag prefix. The registry schema and runtime platform validator now accept `arm`, including explicit `mise lock --platform linux-arm` and `linux-arm-musl` targets. Executable names previously inferred from Aqua are declared explicitly so shims and lazy installation retain their metadata.

Aqua's maintainer explicitly declined ARM32 support and closed the equivalent registry fix: https://github.com/aquaproj/aqua-registry/pull/59421#issuecomment-5467803072. This therefore belongs in mise's platform-specific backend declarations.

Reported in https://github.com/jdx/mise/discussions/12996#discussioncomment-18378495. Neovim's independent wrong-architecture fallback is addressed in https://github.com/mise-plugins/vfox-neovim/pull/6. Explicit `aqua:` requests continue to use Aqua metadata.

## Validation

- ARM32 routing and explicit lock-target tests pass (2 tests); platform tests pass (14 tests). The lock regression covers validation, deduplication, and invalid-qualifier rejection.

- `cargo test --locked --bin mise registry::tests`: 57 tests pass, including platform routing, preserved executable metadata, and baked/floating registry coverage. The existing inference tests now use the unchanged Aqua-first yq entry.

- Cross-platform installs on macOS arm64 with `MISE_OS=linux MISE_ARCH=arm MISE_LIBC=gnu`, isolated data/config directories, and the declared GitHub backends/options: all 13 downloaded and extracted successfully. `file` identified every installed executable as 32-bit ARM ELF. Binaries were not executed on ARM hardware.
- Versions: eza 0.23.5, fd 10.5.0, starship 1.26.0, bat 0.26.1, ripgrep 15.2.0, fzf 0.74.3, zoxide 0.10.0, coreutils 0.11.0, gh 2.100.0, jq 1.8.2, ruff 0.16.6, dust 1.2.5, gopass 1.17.2.
- jq version listing returns 1.0 through 1.8.2 with the configured prefix.
- Scoped `hk check --safe --files0-from ... --format json` passes, including `cargo check --all-features`, formatting, TOML/schema validation, and JSON-schema compilation. The build used the installed OpenSSL via `OPENSSL_DIR` and `OPENSSL_NO_VENDOR=1`.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install source and asset resolution for 13 widely used tools on linux-arm only; mistakes could break ARM32 installs or binary metadata, but other platforms are unchanged and covered by new routing tests.
> 
> **Overview**
> **Routes 13 common CLI tools on `linux-arm` through GitHub release assets** instead of Aqua, which does not publish usable ARM32 binaries for these packages. Each affected registry entry adds a **platform-scoped `github:` backend** (`platforms = ["linux-arm"]`) ahead of the existing Aqua/ASDF/Cargo fallbacks; **linux-arm64, linux-x64, macOS, and Windows keep their prior backend selection.**
> 
> **jq** is special-cased on ARM32 with GitHub options (`asset_pattern = "jq-linux-armhf"`, `version_prefix = "jq-"`). The registry JSON schema now accepts **`arm`** as a platform/arch selector. Tools that previously relied on Aqua to infer executable names get **explicit `bins`** so shims and lazy install metadata stay correct when GitHub is preferred on ARM32.
> 
> Tests assert per-tool routing (GitHub on `linux-arm`, Aqua on other Linux arches), scoped platform matching, and switch bin-inference coverage to **yq** because **jq** now declares `bins` explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23fddeef33f01e31a231f03575ae4bc91087e2e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Linux ARM (32-bit) installation support for bat, coreutils, dust, eza, fd, fzf, GitHub CLI, gopass, jq, ripgrep, ruff, starship, and zoxide.
  - Linux ARM uses GitHub-based downloads while existing installation options remain available on other platforms.

- **Compatibility**
  - Platform configuration now recognizes `arm` as a supported architecture.

- **Tests**
  - Added coverage for backend selection across ARM32, ARM64, x64, and unsupported platforms.
  - Added validation and deduplication coverage for explicit ARM platform selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
