### PR TITLE
registry: add mpv (conda:mpv)

### DIFF
--- a/registry/mpv.toml
+++ b/registry/mpv.toml
@@ -3,3 +3,4 @@ bins = ["mpv"]
 description = "A free, open source, and cross-platform media player"
 test = { cmd = "mpv --version", expected = "mpv/MPlayer/mplayer2" }
 version_order = "source"
+os = ["linux", "macos"]

--- a/registry/mpv.toml
+++ b/registry/mpv.toml
@@ -1,0 +1,5 @@
+backends = ["conda:mpv"]
+bins = ["mpv"]
+description = "A free, open source, and cross-platform media player"
+test = { cmd = "mpv --version", expected = "mpv/MPlayer/mplayer2" }
+version_order = "source"

--- a/registry/mpv.toml
+++ b/registry/mpv.toml
@@ -1,6 +1,6 @@
 backends = ["conda:mpv"]
 bins = ["mpv"]
 description = "A free, open source, and cross-platform media player"
+os = ["linux", "macos"]
 test = { cmd = "mpv --version", expected = "mpv/MPlayer/mplayer2" }
 version_order = "source"
-os = ["linux", "macos"]


### PR DESCRIPTION
Add the mpv media player shorthand so users can run `mise use mpv` instead of the full backend spec.

- https://github.com/mpv-player/mpv
- Backend: conda:mpv (conda-forge; ships linux-64/aarch64 and osx-64/arm64 builds). The github: backend is not viable: stable releases carry source-only assets with no Linux binaries, and upstream publishes no official binaries.
- Registry: bins `mpv`, version_order `source` (same shape as the existing conda-backed ffmpeg entry), test `mpv --version` expecting `mpv/MPlayer/mplayer2` (stable across release and dev-build version strings).

## Popularity
- GitHub: ~30-36k stars, ~3k forks (mpv-player/mpv)
- Latest release: v0.41.0 (Dec 2025); prior v0.40.0, v0.39.0; roughly one release per year plus active master development
- Distribution: conda-forge (mpv, all four unix platforms), Homebrew (formula + cask), Arch Extra, Debian/Ubuntu, Winget/Scoop/Chocolatey; homepage https://mpv.io/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting the installed `mpv` media player through the `conda:mpv` backend.
  * Reports the installed `mpv` version using source-based version ordering for accurate comparisons.
  * Supports `mpv` installations on Linux and macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->