### PR TITLE
feat(dotfiles): support platform-specific destination variants

### DIFF
--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -218,7 +218,8 @@ variants = [
 ```
 
 A later configuration file can replace a destination-variant declaration by
-using the same key, even when it selects a different destination.
+using the same key, even when it selects a different destination. Invalid
+or non-matching local declarations leave the inherited entry active.
 
 Commands such as `status`, `diff`, `apply`, and `unapply` use the selected
 destination. Changing the selected destination does not remove a file

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -178,6 +178,53 @@ or remove previously created links.
 Directory copies keep existing target files when you delete or exclude their
 sources. Review and remove those leftover copies yourself.
 
+### Platform-specific destinations
+
+Use `variants` to deploy one source to different paths on different machines:
+
+```toml
+[dotfiles."vscode/settings.json"]
+source = "dotfiles/vscode/settings.json"
+mode = "copy"
+variants = [
+  { os = "macos", target = "~/Library/Application Support/Code/User/settings.json" },
+  { os = "linux", target = "~/.config/Code/User/settings.json" },
+  { os = "windows", target = "~/AppData/Roaming/Code/User/settings.json" },
+]
+```
+
+Destination variants work with `copy`, `symlink`, `symlink-each`, and
+`template`. They share the [tracking variant selectors](#variants): `os`
+(optionally with an architecture), `profile` (a mise environment selected
+with `-E` or `MISE_ENV`), and `default = true`. The most specific matching
+variant wins; ties are reported as invalid, and no match without a default
+skips the entry.
+
+A variant's `target` overrides the table key. When every variant supplies a
+`target`, the key can be a logical name, as above. Otherwise the key must
+be an absolute or home-relative target path. Every destination must be
+absolute or start with `~/`. Target overrides require an explicit `source`,
+which stays the same across machines and resolves relative to the config
+file. Omitting `target` uses the table key:
+
+```toml
+[dotfiles."~/.config/example/settings.json"]
+source = "dotfiles/example/settings.json"
+mode = "symlink"
+variants = [
+  { profile = "work", target = "~/.config/example-work/settings.json" },
+  { default = true },
+]
+```
+
+A later configuration file can replace a destination-variant declaration by
+using the same key, even when it selects a different destination.
+
+Commands such as `status`, `diff`, `apply`, and `unapply` use the selected
+destination. Changing the selected destination does not remove a file
+previously deployed elsewhere. Tracking variants continue to select separate
+history streams at the same path and do not accept `target` overrides.
+
 ### Templates
 
 ```toml

--- a/e2e/cli/test_dotfiles_destination_variants
+++ b/e2e/cli/test_dotfiles_destination_variants
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+mkdir -p dotfiles/bin
+printf '{"shared":true}\n' >dotfiles/settings.json
+echo 'answer = {{ 6 * 7 }}' >dotfiles/settings.tera
+echo script >dotfiles/bin/example
+
+cat >mise.toml <<'TOML'
+[dotfiles.settings]
+source = "dotfiles/settings.json"
+mode = "copy"
+variants = [
+  { os = "linux", target = "~/.config/code/settings.json" },
+  { os = "macos", target = "~/Library/Application Support/Code/User/settings.json" },
+]
+
+[dotfiles."~/.default-settings.json"]
+source = "dotfiles/settings.json"
+mode = "symlink"
+variants = [
+  { profile = "work", target = "~/.work-settings.json" },
+  { default = true },
+]
+
+[dotfiles.rendered]
+source = "dotfiles/settings.tera"
+mode = "template"
+variants = [{ os = ["linux", "macos"], target = "~/.rendered-settings" }]
+
+[dotfiles.bin]
+source = "dotfiles/bin"
+mode = "symlink-each"
+variants = [{ default = true, target = "~/.variant-bin" }]
+
+[dotfiles.skipped]
+source = "dotfiles/settings.json"
+mode = "copy"
+variants = [{ os = "windows", target = "~/.windows-settings.json" }]
+TOML
+
+assert_succeed "mise bootstrap dotfiles apply --yes"
+assert "cat ~/.config/code/settings.json" '{"shared":true}'
+assert "readlink ~/.default-settings.json" "$PWD/dotfiles/settings.json"
+assert "cat ~/.rendered-settings" "answer = 42"
+assert "readlink ~/.variant-bin/example" "$PWD/dotfiles/bin/example"
+assert_fail "test -e ~/.windows-settings.json"
+assert_fail "test -e ~/.work-settings.json"
+assert_succeed "MISE_ENV=work mise bootstrap dotfiles apply --yes"
+assert "readlink ~/.work-settings.json" "$PWD/dotfiles/settings.json"
+assert_contains "MISE_ENV=work mise bootstrap dotfiles status" ".work-settings.json"
+assert_not_contains "MISE_ENV=work mise bootstrap dotfiles status" ".default-settings.json"
+
+# Commands filter and operate on the resolved destination.
+echo changed >~/.config/code/settings.json
+assert_contains "mise bootstrap dotfiles diff ~/.config/code/settings.json" '+{"shared":true}'
+assert_succeed "mise bootstrap dotfiles apply ~/.config/code/settings.json --yes"
+assert_succeed "mise bootstrap dotfiles unapply ~/.config/code/settings.json --yes"
+assert_fail "test -e ~/.config/code/settings.json"
+
+# A local override of the logical declaration replaces the old destination.
+cat >mise.local.toml <<'TOML'
+[dotfiles.settings]
+source = "dotfiles/settings.json"
+mode = "copy"
+variants = [{ default = true, target = "~/.local-settings.json" }]
+TOML
+assert_succeed "mise bootstrap dotfiles apply --yes"
+assert "cat ~/.local-settings.json" '{"shared":true}'
+assert_fail "test -e ~/.config/code/settings.json"
+assert_not_contains "mise bootstrap dotfiles status" ".config/code/settings.json"
+
+# Ambiguous matches, invalid defaults, relative paths, and tracking target
+# overrides must not write a destination.
+cat >>mise.toml <<'TOML'
+[dotfiles.ambiguous]
+source = "dotfiles/settings.json"
+mode = "copy"
+variants = [
+  { os = "linux", target = "~/.ambiguous-one" },
+  { os = "linux", target = "~/.ambiguous-two" },
+]
+[dotfiles.invalid-default]
+source = "dotfiles/settings.json"
+mode = "copy"
+variants = [{ default = true, os = "linux", target = "~/.bad-default" }]
+[dotfiles.relative]
+source = "dotfiles/settings.json"
+mode = "copy"
+variants = [{ default = true, target = "relative.json" }]
+[dotfiles.no-source]
+mode = "copy"
+variants = [{ default = true, target = "~/.no-source" }]
+TOML
+cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
+[dotfiles."~/.tracked"]
+mode = "track"
+variants = [{ default = true, target = "~/.other-tracked" }]
+TOML
+assert_contains "mise bootstrap dotfiles status 2>&1" "ambiguous dotfile variants"
+assert_contains "mise bootstrap dotfiles status 2>&1" "variants allow only one default"
+assert_contains "mise bootstrap dotfiles status 2>&1" "variant target must be absolute"
+assert_contains "mise bootstrap dotfiles status 2>&1" "target overrides are not supported"
+assert_contains "mise bootstrap dotfiles status 2>&1" "destination variants require an explicit source"
+assert_fail "test -e ~/.ambiguous-one"
+assert_fail "test -e ~/.ambiguous-two"

--- a/e2e/cli/test_dotfiles_destination_variants
+++ b/e2e/cli/test_dotfiles_destination_variants
@@ -12,6 +12,7 @@ mode = "copy"
 variants = [
   { os = "linux", target = "~/.config/code/settings.json" },
   { os = "macos", target = "~/Library/Application Support/Code/User/settings.json" },
+  { os = "windows", target = 'C:\Users\example\settings.json' },
 ]
 
 [dotfiles."~/.default-settings.json"]
@@ -68,6 +69,41 @@ assert_succeed "mise bootstrap dotfiles apply --yes"
 assert "cat ~/.local-settings.json" '{"shared":true}'
 assert_fail "test -e ~/.config/code/settings.json"
 assert_not_contains "mise bootstrap dotfiles status" ".config/code/settings.json"
+
+# Invalid local overrides preserve the valid inherited declaration.
+cat >mise.local.toml <<'TOML'
+[dotfiles.settings]
+source = "dotfiles/settings.json"
+mode = "copy"
+variants = [{ default = true, target = "relative.json" }]
+TOML
+assert_contains "mise bootstrap dotfiles status 2>&1" ".config/code/settings.json"
+cat >mise.local.toml <<'TOML'
+[dotfiles.settings]
+source = "dotfiles/settings.json"
+mode = "unknown"
+variants = [{ default = true, target = "~/.invalid-override" }]
+TOML
+assert_contains "mise bootstrap dotfiles status 2>&1" ".config/code/settings.json"
+assert_not_contains "mise bootstrap dotfiles status 2>/dev/null" ".invalid-override"
+
+cat >mise.local.toml <<'TOML'
+[dotfiles.settings]
+source = "dotfiles/settings.json"
+mode = "copy"
+variants = [{ profile = "inactive", target = "~/.inactive-override" }]
+TOML
+assert_contains "mise bootstrap dotfiles status" ".config/code/settings.json"
+
+# Unsupported defaults cannot route deployment variants into history tracking.
+cat >mise.local.toml <<'TOML'
+[dotfiles.settings]
+source = "dotfiles/settings.json"
+variants = [{ default = true, target = "~/.default-mode-settings.json" }]
+TOML
+assert_contains "MISE_DOTFILES_DEFAULT_MODE=track mise bootstrap dotfiles status 2>&1" "unsupported mode 'track'"
+assert_succeed "MISE_DOTFILES_DEFAULT_MODE=track mise bootstrap dotfiles apply --yes"
+assert "readlink ~/.default-mode-settings.json" "$PWD/dotfiles/settings.json"
 
 # Ambiguous matches, invalid defaults, relative paths, and tracking target
 # overrides must not write a destination.

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4127,7 +4127,7 @@
     },
     "dotfiles": {
       "type": "object",
-      "description": "dotfiles applied with `mise dotfiles apply` or `mise bootstrap`, keyed by target path",
+      "description": "dotfiles applied with `mise dotfiles apply` or `mise bootstrap`, keyed by target path or a logical name when every variant overrides the target",
       "additionalProperties": {
         "oneOf": [
           {
@@ -4206,6 +4206,40 @@
               "comment": {
                 "type": "string",
                 "description": "comment prefix for edit marker lines; inferred from the file extension when omitted"
+              },
+              "variants": {
+                "type": "array",
+                "description": "OS/profile variants: history streams for track mode, or optional destinations for deployment modes",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "os": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ]
+                    },
+                    "profile": {
+                      "type": "string",
+                      "description": "mise environment selected with -E or MISE_ENV"
+                    },
+                    "default": {
+                      "type": "boolean"
+                    },
+                    "target": {
+                      "type": "string",
+                      "description": "deployment destination override; requires source and is not supported in track mode"
+                    }
+                  }
+                }
               }
             },
             "oneOf": [

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -200,6 +200,7 @@ impl<'de> Deserialize<'de> for FileVariant {
     }
 }
 
+/// Validate selector combinations and destination syntax before selecting a variant.
 fn validate_file_variants(
     target: &str,
     source: Option<&str>,
@@ -711,6 +712,7 @@ pub(crate) fn files_from_config_files(config_files: &ConfigMap) -> Vec<FileReque
     files_from_config_files_with_tracking_roots(config_files, None)
 }
 
+/// Resolve deployment overrides while limiting history enrollment to trusted roots.
 fn files_from_config_files_with_tracking_roots(
     config_files: &ConfigMap,
     tracking_roots: Option<&[PathBuf]>,
@@ -794,6 +796,7 @@ fn files_from_config_files_with_tracking_roots(
     merged.into_values().collect()
 }
 
+/// Parse a whole-file declaration and reject unsupported encryption combinations.
 fn parse_file_entry(target: &str, value: toml::Value, config: &Path) -> Option<FileTomlEntry> {
     if value.as_table().is_some_and(|t| {
         t.get("encrypt").and_then(toml::Value::as_bool) == Some(true)
@@ -854,6 +857,7 @@ fn file_entry_from_toml(target_raw: &str, value: toml::Value) -> Option<FileToml
     }
 }
 
+/// Resolve one declaration, merging explicit tracking policies into earlier layers.
 fn merge_file_entry(
     target_raw: String,
     entry: FileTomlEntry,
@@ -1083,6 +1087,7 @@ fn merge_file_entry(
     }
 }
 
+/// Resolve the default deployment mode, warning and using symlinks for unsupported values.
 pub(crate) fn default_mode() -> FileMode {
     let settings = Settings::get();
     let mode = settings.dotfiles.default_mode.as_str();

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -177,12 +177,27 @@ pub(crate) fn clear_invalid_declarations() {
 }
 
 /// Deployment variants reuse tracking selectors without changing history streams.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
 pub(crate) struct FileVariant {
-    #[serde(default)]
     target: Option<String>,
-    #[serde(flatten)]
     selector: crate::system::history::select::Variant,
+}
+
+impl<'de> Deserialize<'de> for FileVariant {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Flattening Variant would bypass its deny_unknown_fields check. Remove
+        // our one additional field, then use the original strict selector parser.
+        let mut table = toml::Table::deserialize(deserializer)?;
+        let target = table
+            .remove("target")
+            .map(toml::Value::try_into)
+            .transpose()
+            .map_err(serde::de::Error::custom)?;
+        let selector = toml::Value::Table(table)
+            .try_into()
+            .map_err(serde::de::Error::custom)?;
+        Ok(Self { target, selector })
+    }
 }
 
 fn validate_file_variants(
@@ -205,11 +220,25 @@ fn validate_file_variants(
         bail!("target must be absolute or start with ~/");
     }
     for variant in variants {
-        if resolve_target_arg(variant.target.as_deref().unwrap_or(target)).is_relative() {
+        let destination = variant.target.as_deref().unwrap_or(target);
+        if !variant_target_is_absolute(destination) {
             bail!("variant target must be absolute or start with ~/");
         }
     }
     Ok(())
+}
+
+/// Inactive variants can contain another platform's absolute path syntax.
+/// The selected destination is still checked with native path rules before use.
+fn variant_target_is_absolute(target: &str) -> bool {
+    let bytes = target.as_bytes();
+    resolve_target_arg(target).is_absolute()
+        || target.starts_with('/')
+        || target.starts_with("\\\\")
+        || (bytes.len() >= 3
+            && bytes[0].is_ascii_alphabetic()
+            && bytes[1] == b':'
+            && matches!(bytes[2], b'/' | b'\\'))
 }
 
 /// One `[dotfiles]` whole-file entry as written in mise.toml.
@@ -692,23 +721,36 @@ fn files_from_config_files_with_tracking_roots(
     // A logical declaration must be overridden before selecting its destination:
     // otherwise a local override that changes the target would deploy both paths.
     let mut destination_declarations = IndexMap::new();
+    let mut resolved_declarations = HashMap::new();
     for (path, cf) in config_files {
+        let base = path.parent().unwrap_or(Path::new("."));
+        let origin = ResourceOrigin {
+            config: path.clone(),
+            config_root: cf.config_root(),
+            environment: crate::config::environments_for_config_path(path),
+            source: None,
+        };
         if let Some(dotfiles) = cf.dotfiles_config() {
             for (key, value) in dotfiles.0 {
-                let overrides_target = match file_entry_from_toml(&key, value) {
-                    Some(FileTomlEntry::Table { mode, variants, .. }) => {
-                        if mode.as_deref() == Some("track") {
-                            continue;
-                        }
-                        variants.is_some_and(|vs| vs.iter().any(|v| v.target.is_some()))
+                if value.get("mode").and_then(toml::Value::as_str) == Some("track") {
+                    continue;
+                }
+                let mut requests = IndexMap::new();
+                if let Some(entry) = parse_file_entry(&key, value, path) {
+                    let overrides_target = matches!(&entry,
+                        FileTomlEntry::Table { variants: Some(vs), .. }
+                            if vs.iter().any(|v| v.target.is_some()));
+                    merge_file_entry(key.clone(), entry, base, &origin, &mut requests);
+                    // An invalid or inactive declaration cannot suppress an
+                    // inherited request. Cache resolution so sources are walked once.
+                    if !requests.is_empty() {
+                        let (_, has_override) = destination_declarations
+                            .entry(resolve_target_arg(&key))
+                            .or_insert((path, false));
+                        *has_override |= overrides_target;
                     }
-                    Some(FileTomlEntry::Source(_)) => false,
-                    None => continue,
-                };
-                let (_, has_override) = destination_declarations
-                    .entry(resolve_target_arg(&key))
-                    .or_insert((path, false));
-                *has_override |= overrides_target;
+                }
+                resolved_declarations.insert((path, key), requests);
             }
         }
     }
@@ -742,36 +784,42 @@ fn files_from_config_files_with_tracking_roots(
                 );
                 continue;
             }
-            if value.as_table().is_some_and(|t| {
-                t.get("encrypt").and_then(toml::Value::as_bool) == Some(true)
-                    && ["content", "block", "line", "template"]
-                        .iter()
-                        .any(|key| t.contains_key(*key))
-            }) {
-                record_invalid(
-                    &target_raw,
-                    &origin.config,
-                    "encrypted dotfiles require an external source, not inline content or edits",
-                );
-                continue;
+            if let Some(requests) = resolved_declarations.remove(&(path, target_raw.clone())) {
+                merged.extend(requests);
+            } else if let Some(entry) = parse_file_entry(&target_raw, value, path) {
+                merge_file_entry(target_raw, entry, &base, &origin, &mut merged);
             }
-            let encryption_declared = value
-                .as_table()
-                .is_some_and(|table| table.contains_key("encrypt"));
-            let Some(entry) = file_entry_from_toml(&target_raw, value) else {
-                if encryption_declared {
-                    record_invalid(
-                        &target_raw,
-                        &origin.config,
-                        "invalid encryption declaration; encrypt must be a boolean on a whole-file entry",
-                    );
-                }
-                continue;
-            };
-            merge_file_entry(target_raw, entry, &base, &origin, &mut merged);
         }
     }
     merged.into_values().collect()
+}
+
+fn parse_file_entry(target: &str, value: toml::Value, config: &Path) -> Option<FileTomlEntry> {
+    if value.as_table().is_some_and(|t| {
+        t.get("encrypt").and_then(toml::Value::as_bool) == Some(true)
+            && ["content", "block", "line", "template"]
+                .iter()
+                .any(|key| t.contains_key(*key))
+    }) {
+        record_invalid(
+            target,
+            config,
+            "encrypted dotfiles require an external source, not inline content or edits",
+        );
+        return None;
+    }
+    let encryption_declared = value
+        .as_table()
+        .is_some_and(|table| table.contains_key("encrypt"));
+    let entry = file_entry_from_toml(target, value);
+    if entry.is_none() && encryption_declared {
+        record_invalid(
+            target,
+            config,
+            "invalid encryption declaration; encrypt must be a boolean on a whole-file entry",
+        );
+    }
+    entry
 }
 
 fn file_entry_from_toml(target_raw: &str, value: toml::Value) -> Option<FileTomlEntry> {
@@ -1039,9 +1087,12 @@ pub(crate) fn default_mode() -> FileMode {
     let settings = Settings::get();
     let mode = settings.dotfiles.default_mode.as_str();
     match FileMode::parse(mode) {
-        Some(mode) => mode,
-        None => {
-            warn!("dotfiles.default_mode: unknown mode '{mode}', using symlink");
+        Some(
+            mode
+            @ (FileMode::Symlink | FileMode::SymlinkEach | FileMode::Copy | FileMode::Template),
+        ) => mode,
+        _ => {
+            warn!("dotfiles.default_mode: unsupported mode '{mode}', using symlink");
             FileMode::Symlink
         }
     }
@@ -3391,7 +3442,8 @@ source = "dotfiles/settings.json"
 mode = "copy"
 variants = [
     { os = "macos", target = "~/Library/Application Support/Code/User/settings.json" },
-    { os = "linux", profile = "work", target = "~/.config/Code/User/settings.json" },
+    { os = "linux", profile = "work", target = "/etc/example/settings.json" },
+    { os = "windows", target = 'C:\Users\example\settings.json' },
 ]
 "#;
         let mut configs = ConfigMap::new();
@@ -3412,6 +3464,35 @@ variants = [
         );
         assert!(validate_incoming_files(&configs).is_err());
         Ok(())
+    }
+
+    #[test]
+    fn destination_variants_reject_unknown_fields_in_all_modes() {
+        for mode in ["copy", "track"] {
+            for field in ["oss", "profle", "targte"] {
+                let input = format!(
+                    r#"mode = "{mode}"
+variants = [{{ {field} = "linux" }}]"#
+                );
+                assert!(toml::from_str::<FileTomlEntry>(&input).is_err(), "{input}");
+            }
+        }
+    }
+
+    #[test]
+    fn destination_variant_paths_accept_foreign_absolute_syntax() {
+        for target in [
+            "~/settings.json",
+            "/etc/example/settings.json",
+            "C:/Users/example/settings.json",
+            r"C:\Users\example\settings.json",
+            r"\\server\share\settings.json",
+        ] {
+            assert!(variant_target_is_absolute(target), "{target}");
+        }
+        for target in ["settings.json", "./settings.json", "C:settings.json", ""] {
+            assert!(!variant_target_is_absolute(target), "{target}");
+        }
     }
 
     #[cfg(unix)]

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -176,7 +176,43 @@ pub(crate) fn clear_invalid_declarations() {
         .clear();
 }
 
-/// one `[dotfiles]` whole-file entry as written in mise.toml
+/// Deployment variants reuse tracking selectors without changing history streams.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct FileVariant {
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(flatten)]
+    selector: crate::system::history::select::Variant,
+}
+
+fn validate_file_variants(
+    target: &str,
+    source: Option<&str>,
+    mode: Option<&str>,
+    variants: &[FileVariant],
+) -> Result<()> {
+    let selectors: Vec<_> = variants.iter().map(|v| v.selector.clone()).collect();
+    crate::system::history::select::validate(&selectors)?;
+    if variants.iter().any(|v| v.target.is_some()) {
+        if mode == Some("track") {
+            bail!("target overrides are not supported with mode = \"track\"");
+        }
+        if source.is_none() {
+            bail!("destination variants require an explicit source");
+        }
+    }
+    if variants.is_empty() && resolve_target_arg(target).is_relative() {
+        bail!("target must be absolute or start with ~/");
+    }
+    for variant in variants {
+        if resolve_target_arg(variant.target.as_deref().unwrap_or(target)).is_relative() {
+            bail!("variant target must be absolute or start with ~/");
+        }
+    }
+    Ok(())
+}
+
+/// One `[dotfiles]` whole-file entry as written in mise.toml.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub(crate) enum FileTomlEntry {
@@ -202,9 +238,9 @@ pub(crate) enum FileTomlEntry {
         autosave: Option<bool>,
         #[serde(default)]
         encrypt: Option<bool>,
-        /// history: platform / profile streams for a tracked file
+        /// Platform / profile selectors, with optional deployment destinations
         #[serde(default)]
-        variants: Option<Vec<crate::system::history::select::Variant>>,
+        variants: Option<Vec<FileVariant>>,
         /// `false` disables an inherited declaration on this machine
         #[serde(default)]
         enabled: Option<bool>,
@@ -577,8 +613,8 @@ pub(crate) fn validate_incoming_files(config_files: &ConfigMap) -> Result<()> {
                     }
                 }
             }
-            if resolve_target_arg(&target).is_relative() {
-                bail!("dotfile target must be absolute or start with ~/: {target}");
+            if let FileTomlEntry::Source(_) = &entry {
+                validate_file_variants(&target, None, None, &[])?;
             }
             if let FileTomlEntry::Table {
                 source,
@@ -586,9 +622,16 @@ pub(crate) fn validate_incoming_files(config_files: &ConfigMap) -> Result<()> {
                 mode,
                 manifest,
                 exclude,
+                variants,
                 ..
             } = entry
             {
+                validate_file_variants(
+                    &target,
+                    source.as_deref(),
+                    mode.as_deref(),
+                    variants.as_deref().unwrap_or_default(),
+                )?;
                 if content.is_some() && (mode.is_some() || exclude.is_some() || manifest.is_some())
                 {
                     bail!(
@@ -646,6 +689,29 @@ fn files_from_config_files_with_tracking_roots(
     // keyed by the *expanded* target so "~/.gitconfig" in one config and
     // its absolute spelling in another are one entry, not two
     let mut merged: IndexMap<(PathBuf, bool), FileRequest> = IndexMap::new();
+    // A logical declaration must be overridden before selecting its destination:
+    // otherwise a local override that changes the target would deploy both paths.
+    let mut destination_declarations = IndexMap::new();
+    for (path, cf) in config_files {
+        if let Some(dotfiles) = cf.dotfiles_config() {
+            for (key, value) in dotfiles.0 {
+                let overrides_target = match file_entry_from_toml(&key, value) {
+                    Some(FileTomlEntry::Table { mode, variants, .. }) => {
+                        if mode.as_deref() == Some("track") {
+                            continue;
+                        }
+                        variants.is_some_and(|vs| vs.iter().any(|v| v.target.is_some()))
+                    }
+                    Some(FileTomlEntry::Source(_)) => false,
+                    None => continue,
+                };
+                let (_, has_override) = destination_declarations
+                    .entry(resolve_target_arg(&key))
+                    .or_insert((path, false));
+                *has_override |= overrides_target;
+            }
+        }
+    }
     // config_files is ordered local -> global; reverse for global -> local
     for (path, cf) in config_files.iter().rev() {
         let base = path.parent().unwrap_or(Path::new(".")).to_path_buf();
@@ -659,6 +725,13 @@ fn files_from_config_files_with_tracking_roots(
             continue;
         };
         for (target_raw, value) in dotfiles.0 {
+            if value.get("mode").and_then(toml::Value::as_str) != Some("track")
+                && destination_declarations
+                    .get(&resolve_target_arg(&target_raw))
+                    .is_some_and(|(winner, has_override)| *has_override && *winner != path)
+            {
+                continue;
+            }
             if tracking_roots.is_some_and(|roots| !track_layer_allowed(&origin, roots))
                 && value.get("mode").and_then(toml::Value::as_str) == Some("track")
             {
@@ -775,6 +848,13 @@ fn merge_file_entry(
     };
     let enabled = enabled.unwrap_or(true);
     let variants = variants.unwrap_or_default();
+    if let Err(err) =
+        validate_file_variants(&target_raw, source.as_deref(), mode.as_deref(), &variants)
+    {
+        record_invalid(&target_raw, &origin.config, err.to_string());
+        return;
+    }
+    let selectors: Vec<_> = variants.iter().map(|v| v.selector.clone()).collect();
     let policy_for = |mode: FileMode| {
         let defaults = FilePolicy::for_mode(mode);
         FilePolicy {
@@ -812,7 +892,7 @@ fn merge_file_entry(
             base: base.to_path_buf(),
             origin: origin.clone(),
             policy: policy_for(FileMode::Track),
-            variants,
+            variants: selectors,
             enabled,
         };
         // a later file of the same directory (`config.local.toml` after
@@ -826,14 +906,20 @@ fn merge_file_entry(
         }
         return;
     }
-    if !variants.is_empty() {
-        record_invalid(
-            &target_raw,
-            &origin.config,
-            "variants are only supported with mode = \"track\"",
-        );
-        return;
-    }
+    use crate::system::history::select::{self, Selection};
+    let target_raw = match select::select(&selectors, &select::active_environments()) {
+        Selection::Single => target_raw,
+        Selection::Variant(selected) => variants
+            .iter()
+            .find(|v| v.selector == selected)
+            .and_then(|v| v.target.clone())
+            .unwrap_or(target_raw),
+        Selection::NoMatch => return,
+        Selection::Ambiguous(_) => {
+            record_invalid(&target_raw, &origin.config, "ambiguous dotfile variants");
+            return;
+        }
+    };
     if source.is_some() && content.is_some() {
         warn!(
             "[dotfiles].\"{target_raw}\": source and content are mutually exclusive, ignoring entry"
@@ -3292,6 +3378,41 @@ fn link_path(source: &Path, target: &Path, allow_windows_symlink: bool) -> Resul
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn destination_variants_survive_incoming_config_preflight() -> Result<()> {
+        use crate::config::config_file::mise_toml::MiseToml;
+        use std::sync::Arc;
+
+        let path = dirs::HOME.join(".config/mise/config.toml");
+        let body = r#"
+[dotfiles.settings]
+source = "dotfiles/settings.json"
+mode = "copy"
+variants = [
+    { os = "macos", target = "~/Library/Application Support/Code/User/settings.json" },
+    { os = "linux", profile = "work", target = "~/.config/Code/User/settings.json" },
+]
+"#;
+        let mut configs = ConfigMap::new();
+        configs.insert(
+            path.clone(),
+            Arc::new(MiseToml::for_history_preflight(body, &path)?),
+        );
+        validate_incoming_files(&configs)?;
+
+        // Validate inactive destinations too, before accepting shared config.
+        let invalid = body.replace(
+            "~/Library/Application Support/Code/User/settings.json",
+            "relative/settings.json",
+        );
+        configs.insert(
+            path.clone(),
+            Arc::new(MiseToml::for_history_preflight(&invalid, &path)?),
+        );
+        assert!(validate_incoming_files(&configs).is_err());
+        Ok(())
+    }
 
     #[cfg(unix)]
     #[test]


### PR DESCRIPTION
A shared dotfiles source can now deploy to different destinations on different operating systems or mise environments. For example, one VS Code settings JSON can be copied to macOS's Application Support directory and Linux's `.config` directory.

```toml
[dotfiles.settings]
source = "dotfiles/vscode/settings.json"
mode = "copy"
variants = [
  { os = "macos", target = "~/Library/Application Support/Code/User/settings.json" },
  { os = "linux", target = "~/.config/Code/User/settings.json" },
]
```

Reuse the existing track-mode `os`, `profile`, and `default` selection rules for `copy`, `symlink`, `symlink-each`, and `template`. Destination overrides require an explicit source; the entry key supplies the destination when a variant omits `target`. Tracking continues to use separate history streams at the same path and rejects target overrides.

Resolve each deployment declaration once and merge only validated, active overrides, preserving inherited entries when a local declaration is invalid or inactive. Keep selector parsing strict, accept foreign absolute paths in inactive variants, and validate shared configuration during incoming preflight. Restrict default modes to the documented deployment modes so an unsupported track default cannot bypass tracking validation. Commands operate on the selected destination; selecting a new destination leaves previously deployed files in place. Includes documentation, schema support, and regression coverage.

Related: https://github.com/jdx/mise/discussions/13045

Validation:
- `mise run lint-fix`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` (via `mise x`)
- Focused unit tests for incoming-config preflight, foreign absolute paths, and unknown selector fields
- Linux e2e: destination variants, existing dotfile deployment, tracking, incoming enrollment, and encrypted tracking variants

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dotfile declarations now support platform-, architecture-, and profile-specific destination variants.
  - A single source can deploy to different paths across operating systems and profiles.
  - Variants work with copy, symlink, template, and symlink-each modes.
  - Status, diff, apply, and unapply use the selected destination.

- **Bug Fixes**
  - Invalid or inactive local overrides no longer suppress valid inherited declarations.
  - Ambiguous variants, invalid targets, and missing sources are now reported.
  - Unsupported track-mode defaults fall back to symlink behavior.

- **Documentation**
  - Added configuration guidance and examples for platform-specific destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how dotfile declarations merge and resolve targets at apply time; mistakes could deploy to the wrong path or leave stale files, though validation and e2e tests mitigate this.
> 
> **Overview**
> **Dotfile entries can now pick a deployment path per OS, architecture, or mise profile** by adding optional `target` on `variants`, alongside the existing `os`, `profile`, and `default` selectors. This works for `copy`, `symlink`, `symlink-each`, and `template`; **track mode still only uses variants for history streams and rejects `target` overrides.**
> 
> Config merging was reworked so declarations resolve once: the winning variant sets the path used by **status, diff, apply, and unapply**, logical table keys are allowed when every variant supplies `target`, and **invalid or non-matching local overrides no longer hide a valid inherited entry**. Validation covers ambiguous variants, relative targets, missing `source`, and foreign absolute paths in inactive variants during preflight. **`dotfiles.default_mode` no longer accepts `track`** as an implicit deployment mode.
> 
> Docs and JSON schema document the new `variants` / `target` fields; a Linux e2e script exercises apply, overrides, and error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad43912461b0fe3a05c7f5dc69eec69d7b08a4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->