### PR TITLE
feat(task): support usage variables in sources and outputs

### DIFF
--- a/docs/tasks/task-configuration.md
+++ b/docs/tasks/task-configuration.md
@@ -467,6 +467,17 @@ outputs = ["target/debug/mycli"]
 Running the above executes `cargo build` only if `mise.toml`, `Cargo.toml`, or any ".rs" file in the `src` directory
 has changed since the last build.
 
+Both `sources` and `outputs` can use parsed [usage](#usage) arguments and flags. mise resolves these
+templates separately for each task invocation before checking freshness or the task cache:
+
+```mise-toml
+[tasks.compile]
+usage = 'arg "<target>"'
+run = "compile {{usage.target}} --output dist/{{usage.target}}"
+sources = ["src/{{usage.target}}/**"]
+outputs = ["dist/{{usage.target}}"]
+```
+
 Relative entries are resolved from the task directory (the task's `dir`, or the project root when it
 has none) and may use `..` to reach files above it, such as a `node_modules` directory shared at the
 root of a monorepo:

--- a/e2e/tasks/test_task_usage_paths
+++ b/e2e/tasks/test_task_usage_paths
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Task sources and outputs can depend on parsed usage arguments. Each argument
+# value must retain an independent freshness identity.
+cat <<'EOF' >mise.toml
+[tasks.generate]
+usage = 'arg "<name>"'
+sources = ["{{usage.name}}.in"]
+outputs = ["{{usage.name}}.out"]
+run = '''
+cat {{usage.name}}.in > {{usage.name}}.out
+echo {{usage.name}} >> runs.log
+'''
+
+[tasks.parent]
+depends = [{ task = "generate", args = ["three"] }]
+run = 'echo parent'
+EOF
+
+echo one >one.in
+echo two >two.in
+echo three >three.in
+
+mise run generate one
+mise run generate two
+mise run generate one
+assert "cat runs.log" "one
+two"
+
+echo changed >>one.in
+mise run generate one
+assert "cat runs.log" "one
+two
+one"
+
+# Transitive tasks must resolve their own usage-dependent paths before their
+# freshness checks run.
+mise run parent
+mise run parent
+assert "cat runs.log" "one
+two
+one
+three"
+
+# Environment and usage values can coexist in one output template.
+cat <<'EOF' >mise.toml
+[env]
+OUT_DIR = "dist"
+
+[tasks.child]
+usage = 'arg "<name>"'
+outputs = ["{{env.OUT_DIR}}/{{usage.name}}.txt"]
+run = 'mkdir -p "$OUT_DIR"; touch "$OUT_DIR/{{usage.name}}.txt"'
+
+[tasks.parent]
+depends = [{ task = "child", args = ["artifact"] }]
+EOF
+
+mise run parent
+assert "test -f dist/artifact.txt && echo present" "present"

--- a/e2e/tasks/test_task_usage_paths
+++ b/e2e/tasks/test_task_usage_paths
@@ -50,7 +50,7 @@ usage = 'arg "<name>"'
 env = { OUT_DIR = "default" }
 sources = ["{{env.OUT_DIR}}/{{usage.name}}.in"]
 outputs = ["{{env.OUT_DIR}}/{{usage.name}}.txt"]
-run = 'cat "$OUT_DIR/{{usage.name}}.in" > "$OUT_DIR/{{usage.name}}.txt"'
+run = 'cat "$OUT_DIR/{{usage.name}}.in" > "$OUT_DIR/{{usage.name}}.txt"; echo run >> child-runs.log'
 
 [tasks.parent]
 depends = [{ task = "child", args = ["artifact"], env = { OUT_DIR = "dist" } }]
@@ -59,8 +59,13 @@ EOF
 mkdir -p dist
 echo content >dist/artifact.in
 mise run parent
+mise run parent
 assert "test -f dist/artifact.txt && echo present" "present"
 assert "test ! -e default/artifact.txt && echo absent" "absent"
+assert "wc -l <child-runs.log" "1"
+echo changed >dist/artifact.in
+mise run parent
+assert "wc -l <child-runs.log" "2"
 
 # Literal text outside a Tera tag must not be mistaken for a usage reference.
 cat <<'EOF' >mise.toml

--- a/e2e/tasks/test_task_usage_paths
+++ b/e2e/tasks/test_task_usage_paths
@@ -55,8 +55,18 @@ sources = ["{{env.BASE_DIR}}/{{env.OUT_DIR}}/{{usage.name}}.in"]
 outputs = ["{{env.BASE_DIR}}/artifact.txt"]
 run = 'cat "$BASE_DIR/$OUT_DIR/{{usage.name}}.in" > "$BASE_DIR/artifact.txt"; echo run >> child-runs.log'
 
+[tasks.mixed-output]
+usage = 'arg "<name>"'
+env = { OUT_DIR = "default" }
+sources = ["{{env.BASE_DIR}}/{{env.OUT_DIR}}/{{usage.name}}.in"]
+outputs = ["{{env.BASE_DIR}}/{{env.OUT_DIR}}/{{usage.name}}.txt"]
+run = 'cat "$BASE_DIR/$OUT_DIR/{{usage.name}}.in" > "$BASE_DIR/$OUT_DIR/{{usage.name}}.txt"; echo run >> mixed-runs.log'
+
 [tasks.parent]
-depends = [{ task = "child", args = ["artifact"], env = { OUT_DIR = "dist" } }]
+depends = [
+  { task = "child", args = ["artifact"], env = { OUT_DIR = "dist" } },
+  { task = "mixed-output", args = ["artifact"], env = { OUT_DIR = "dist" } },
+]
 EOF
 
 mkdir -p workspace/dist
@@ -64,10 +74,13 @@ echo content >workspace/dist/artifact.in
 mise run parent
 mise run parent
 assert "test -f workspace/artifact.txt && echo present" "present"
+assert "test -f workspace/dist/artifact.txt && echo present" "present"
 assert "wc -l <child-runs.log" "1"
+assert "wc -l <mixed-runs.log" "1"
 echo changed >workspace/dist/artifact.in
 mise run parent
 assert "wc -l <child-runs.log" "2"
+assert "wc -l <mixed-runs.log" "2"
 
 # Literal text outside a Tera tag must not be mistaken for a usage reference.
 cat <<'EOF' >mise.toml

--- a/e2e/tasks/test_task_usage_paths
+++ b/e2e/tasks/test_task_usage_paths
@@ -45,25 +45,27 @@ three"
 # Environment and usage values can coexist in one output template. A
 # dependency-level env value must override the task's initial rendering env.
 cat <<'EOF' >mise.toml
+[env]
+BASE_DIR = "workspace"
+
 [tasks.child]
 usage = 'arg "<name>"'
 env = { OUT_DIR = "default" }
-sources = ["{{env.OUT_DIR}}/{{usage.name}}.in"]
-outputs = ["{{env.OUT_DIR}}/{{usage.name}}.txt"]
-run = 'cat "$OUT_DIR/{{usage.name}}.in" > "$OUT_DIR/{{usage.name}}.txt"; echo run >> child-runs.log'
+sources = ["{{env.BASE_DIR}}/{{env.OUT_DIR}}/{{usage.name}}.in"]
+outputs = ["{{env.BASE_DIR}}/artifact.txt"]
+run = 'cat "$BASE_DIR/$OUT_DIR/{{usage.name}}.in" > "$BASE_DIR/artifact.txt"; echo run >> child-runs.log'
 
 [tasks.parent]
 depends = [{ task = "child", args = ["artifact"], env = { OUT_DIR = "dist" } }]
 EOF
 
-mkdir -p dist
-echo content >dist/artifact.in
+mkdir -p workspace/dist
+echo content >workspace/dist/artifact.in
 mise run parent
 mise run parent
-assert "test -f dist/artifact.txt && echo present" "present"
-assert "test ! -e default/artifact.txt && echo absent" "absent"
+assert "test -f workspace/artifact.txt && echo present" "present"
 assert "wc -l <child-runs.log" "1"
-echo changed >dist/artifact.in
+echo changed >workspace/dist/artifact.in
 mise run parent
 assert "wc -l <child-runs.log" "2"
 

--- a/e2e/tasks/test_task_usage_paths
+++ b/e2e/tasks/test_task_usage_paths
@@ -42,19 +42,38 @@ two
 one
 three"
 
-# Environment and usage values can coexist in one output template.
+# Environment and usage values can coexist in one output template. A
+# dependency-level env value must override the task's initial rendering env.
 cat <<'EOF' >mise.toml
-[env]
-OUT_DIR = "dist"
-
 [tasks.child]
 usage = 'arg "<name>"'
+env = { OUT_DIR = "default" }
+sources = ["{{env.OUT_DIR}}/{{usage.name}}.in"]
 outputs = ["{{env.OUT_DIR}}/{{usage.name}}.txt"]
-run = 'mkdir -p "$OUT_DIR"; touch "$OUT_DIR/{{usage.name}}.txt"'
+run = 'cat "$OUT_DIR/{{usage.name}}.in" > "$OUT_DIR/{{usage.name}}.txt"'
 
 [tasks.parent]
-depends = [{ task = "child", args = ["artifact"] }]
+depends = [{ task = "child", args = ["artifact"], env = { OUT_DIR = "dist" } }]
 EOF
 
+mkdir -p dist
+echo content >dist/artifact.in
 mise run parent
 assert "test -f dist/artifact.txt && echo present" "present"
+assert "test ! -e default/artifact.txt && echo absent" "absent"
+
+# Literal text outside a Tera tag must not be mistaken for a usage reference.
+cat <<'EOF' >mise.toml
+[env]
+DOCS_DIR = "docs"
+
+[tasks.docs]
+sources = ["docs-input.txt"]
+outputs = ["{{env.DOCS_DIR}}/usage.md"]
+run = 'mkdir -p "$DOCS_DIR"; touch "$DOCS_DIR/usage.md"; echo run >> docs-runs.log'
+EOF
+
+touch docs-input.txt
+mise run docs
+mise run docs
+assert "wc -l <docs-runs.log" "1"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -697,20 +697,13 @@ impl Run {
         let fetcher = crate::task::task_fetcher::TaskFetcher::new(self.no_cache);
         fetcher.fetch_tasks(&config, &mut task_list).await?;
 
-        // Re-render dependency templates with parent task's usage arg/flag values.
-        // This enables patterns like: depends = ["child {{usage.app}}"]
+        // Re-render sources, outputs, and dependencies with this invocation's
+        // usage arg/flag values before resolving the execution graph.
         for task in &mut task_list {
-            let has_usage_deps = |raw: &Option<Vec<_>>| {
-                raw.as_ref()
-                    .is_some_and(|r| r.iter().any(crate::task::dep_has_usage_ref))
-            };
-            if has_usage_deps(&task.depends_raw)
-                || has_usage_deps(&task.depends_post_raw)
-                || has_usage_deps(&task.wait_for_raw)
-            {
+            if task.has_usage_runtime_templates() {
                 let usage_values = crate::task::parse_usage_values_from_task(&config, task).await?;
                 if !usage_values.is_empty() {
-                    task.render_depends_with_usage(&config, &usage_values)
+                    task.render_runtime_templates_with_usage(&config, &usage_values)
                         .await?;
                 }
             }

--- a/src/task/deps.rs
+++ b/src/task/deps.rs
@@ -1,7 +1,7 @@
 use crate::config::Settings;
 use crate::config::env_directive::EnvDirective;
 use crate::task::task_fetcher::TaskFetcher;
-use crate::task::{Task, TaskRunPhase, dep_has_usage_ref, parse_usage_values_from_task};
+use crate::task::{Task, TaskRunPhase, parse_usage_values_from_task};
 use crate::{config::Config, task::task_list::resolve_depends};
 use itertools::Itertools;
 use petgraph::Direction;
@@ -182,19 +182,13 @@ impl Deps {
                 fetcher.fetch_tasks(config, &mut tasks_to_fetch).await?;
                 a = tasks_to_fetch.into_iter().next().unwrap();
             }
-            // Re-render dependency templates with usage values (including defaults)
-            // so {{usage.*}} resolves.
-            let has_usage_deps = |raw: &Option<Vec<_>>| {
-                raw.as_ref()
-                    .is_some_and(|r| r.iter().any(dep_has_usage_ref))
-            };
-            if has_usage_deps(&a.depends_raw)
-                || has_usage_deps(&a.depends_post_raw)
-                || has_usage_deps(&a.wait_for_raw)
-            {
+            // Re-render runtime templates with usage values (including defaults)
+            // so {{usage.*}} resolves before graph construction and freshness checks.
+            if a.has_usage_runtime_templates() {
                 let usage_values = parse_usage_values_from_task(config, &a).await?;
                 if !usage_values.is_empty() {
-                    a.render_depends_with_usage(config, &usage_values).await?;
+                    a.render_runtime_templates_with_usage(config, &usage_values)
+                        .await?;
                 }
             }
             let a_idx = add_idx(&a, &mut graph);

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2863,7 +2863,9 @@ impl Task {
         let config_root = self.config_root.clone().unwrap_or_default();
         let mut tera = get_tera(Some(&config_root));
         let mut tera_ctx = self.tera_ctx(config).await?;
-        if has_usage_outputs && let Some(env) = &self.raw_outputs.original_env {
+        if (has_usage_sources || has_usage_outputs)
+            && let Some(env) = &self.raw_outputs.original_env
+        {
             tera_ctx.insert("env", env);
         }
         // Insert usage values into the tera context so templates like

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2641,10 +2641,11 @@ impl Task {
             .get_or_insert_with(|| self.sources.clone())
             .extend(other_raw_sources);
         self.sources.extend(other.sources);
-        if let Some(other_path_env) = other.raw_path_env {
-            self.raw_path_env
-                .get_or_insert_default()
-                .extend(other_path_env);
+        // This is a complete ambient snapshot, not an overlay delta. Keep the
+        // file task's environment when it has one so path rendering matches
+        // command execution; use the TOML task snapshot only as a fallback.
+        if self.raw_path_env.is_none() {
+            self.raw_path_env = other.raw_path_env;
         }
         if other.watch.is_some() {
             self.watch = other.watch;
@@ -3977,10 +3978,17 @@ mod tests {
             file_task.raw_path_env,
             Some(BTreeMap::from([
                 ("BASE".to_string(), "base".to_string()),
-                ("OVERLAY".to_string(), "overlay".to_string()),
-                ("SHARED".to_string(), "overlay".to_string()),
+                ("SHARED".to_string(), "base".to_string()),
             ]))
         );
+
+        let overlay_path_env = BTreeMap::from([("OVERLAY".to_string(), "overlay".to_string())]);
+        let mut task_without_path_env = Task::default();
+        task_without_path_env.merge_toml_overlay(Task {
+            raw_path_env: Some(overlay_path_env.clone()),
+            ..Default::default()
+        });
+        assert_eq!(task_without_path_env.raw_path_env, Some(overlay_path_env));
 
         let source_overlay = Task {
             sources: vec!["overlay-{{usage.name}}.txt".to_string()],

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -713,6 +713,10 @@ pub(crate) struct Task {
     pub interactive: bool,
     #[serde(default, deserialize_with = "deserialize_arr")]
     pub sources: Vec<String>,
+    /// Original unrendered source templates, preserved so they can be
+    /// re-rendered once task usage arguments are available.
+    #[serde(skip)]
+    pub raw_sources: Option<Vec<String>>,
     #[serde(default)]
     pub watch: Option<TaskWatchOptions>,
     #[serde(default)]
@@ -1715,7 +1719,7 @@ impl Task {
         let all_tasks = config.tasks_with_context(ctx.as_ref()).await?;
         let tasks = build_task_ref_map(all_tasks.iter());
         // Skip deps with unresolved {{usage.*}} references — they'll be resolved
-        // later when render_depends_with_usage() is called with actual arg values.
+        // later when render_runtime_templates_with_usage() is called with actual arg values.
         let depends = self
             .depends
             .iter()
@@ -2573,7 +2577,7 @@ impl Task {
         self.overlay_vars
             .extend(other.vars.0.into_iter().map(|d| (d, overlay_src.clone())));
         // Keep the *_raw (pre-render) snapshots in sync with the live deps
-        // so `render_depends_with_usage` re-renders the merged set rather
+        // so `render_runtime_templates_with_usage` re-renders the merged set rather
         // than silently dropping overlay deps. Prefer the overlay's raw
         // (unrendered) templates so `{{usage.*}}` refs survive re-rendering;
         // fall back to the rendered form if raw wasn't captured.
@@ -2641,6 +2645,9 @@ impl Task {
         }
         if other.raw_outputs.templates.is_some() {
             self.raw_outputs = other.raw_outputs;
+        }
+        if other.raw_sources.is_some() {
+            self.raw_sources = other.raw_sources;
         }
         if other.shell.is_some() {
             self.shell = other.shell;
@@ -2715,6 +2722,7 @@ impl Task {
         if !self.sources.is_empty() && self.outputs.is_empty() {
             self.outputs = TaskOutputs::Auto;
         }
+        self.raw_sources = Some(self.sources.clone());
         self.raw_outputs = self.outputs.raw_templates_without_env();
         // Save unrendered dependency templates so they can be re-rendered later
         // with parent task args available (for passing args to dependencies).
@@ -2745,6 +2753,7 @@ impl Task {
 
         let mut tera = get_tera(Some(config_root));
         let tera_ctx = self.tera_ctx(config).await?;
+        self.store_raw_render_inputs();
         for a in &mut self.aliases {
             if contains_template_syntax(a) {
                 *a = render_str(&mut tera, a, &tera_ctx)?;
@@ -2755,14 +2764,13 @@ impl Task {
             self.description = render_str(&mut tera, &self.description, &tera_ctx)?;
         }
         for s in &mut self.sources {
-            if contains_template_syntax(s) {
+            if contains_template_syntax(s) && !tera_tag_has_usage_ref(s) {
                 *s = render_str(&mut tera, s, &tera_ctx)?;
             }
         }
-        self.store_raw_render_inputs();
-        self.raw_outputs = self.outputs.render(&mut tera, &tera_ctx)?;
+        self.raw_outputs = self.outputs.render(&mut tera, &tera_ctx, true)?;
         // Render deps that don't contain {{usage.*}} references. Deps with usage
-        // references are deferred until render_depends_with_usage() is called with
+        // references are deferred until render_runtime_templates_with_usage() is called with
         // the actual arg values from CLI or parent dependency.
         render_task_deps(&mut self.depends, &mut tera, &tera_ctx, true)?;
         render_task_deps(&mut self.depends_post, &mut tera, &tera_ctx, true)?;
@@ -2808,10 +2816,28 @@ impl Task {
         Ok(())
     }
 
-    /// Re-render dependency templates with usage args/flags from the parent task.
-    /// This allows `depends = ["child {{usage.app}}"]` to resolve when the parent
-    /// task receives `--app=foo` from the CLI.
-    pub(crate) async fn render_depends_with_usage(
+    /// Re-render runtime templates with usage args/flags from this task invocation.
+    /// Sources and outputs must be resolved before freshness/cache checks, while
+    /// dependencies must be resolved before constructing the execution graph.
+    pub(crate) fn has_usage_runtime_templates(&self) -> bool {
+        let has_usage_deps = |raw: &Option<Vec<TaskDep>>| {
+            raw.as_ref()
+                .is_some_and(|deps| deps.iter().any(dep_has_usage_ref))
+        };
+        self.raw_sources
+            .as_ref()
+            .is_some_and(|sources| sources.iter().any(|source| tera_tag_has_usage_ref(source)))
+            || self
+                .raw_outputs
+                .templates
+                .as_ref()
+                .is_some_and(|outputs| outputs.iter().any(|output| tera_tag_has_usage_ref(output)))
+            || has_usage_deps(&self.depends_raw)
+            || has_usage_deps(&self.depends_post_raw)
+            || has_usage_deps(&self.wait_for_raw)
+    }
+
+    pub(crate) async fn render_runtime_templates_with_usage(
         &mut self,
         config: &Arc<Config>,
         usage_values: &IndexMap<String, tera::Value>,
@@ -2819,14 +2845,16 @@ impl Task {
         if usage_values.is_empty() {
             return Ok(());
         }
-        let has_usage_deps = |raw: &Option<Vec<_>>| {
-            raw.as_ref()
-                .is_some_and(|deps| deps.iter().any(dep_has_usage_ref))
-        };
-        if !has_usage_deps(&self.depends_raw)
-            && !has_usage_deps(&self.depends_post_raw)
-            && !has_usage_deps(&self.wait_for_raw)
-        {
+        let has_usage_sources = self
+            .raw_sources
+            .as_ref()
+            .is_some_and(|sources| sources.iter().any(|source| tera_tag_has_usage_ref(source)));
+        let has_usage_outputs = self
+            .raw_outputs
+            .templates
+            .as_ref()
+            .is_some_and(|outputs| outputs.iter().any(|output| tera_tag_has_usage_ref(output)));
+        if !self.has_usage_runtime_templates() {
             return Ok(());
         }
         let config_root = self.config_root.clone().unwrap_or_default();
@@ -2835,6 +2863,23 @@ impl Task {
         // Insert usage values into the tera context so templates like
         // {{usage.app}} resolve to the actual CLI arg value.
         tera_ctx.insert("usage", usage_values);
+
+        if has_usage_sources && let Some(raw) = &self.raw_sources {
+            self.sources = raw
+                .iter()
+                .map(|source| {
+                    if contains_template_syntax(source) {
+                        render_str(&mut tera, source, &tera_ctx)
+                    } else {
+                        Ok(source.clone())
+                    }
+                })
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+        }
+        if has_usage_outputs && let Some(raw) = &self.raw_outputs.templates {
+            self.outputs = TaskOutputs::Files(raw.clone());
+            self.raw_outputs = self.outputs.render(&mut tera, &tera_ctx, false)?;
+        }
 
         // Re-render from raw templates (not from already-rendered values).
         // Only restore from raw if the field is non-empty — skip_deps clears
@@ -3218,6 +3263,7 @@ impl Default for Task {
             trailing_args: vec![],
             interactive: false,
             sources: vec![],
+            raw_sources: None,
             watch: None,
             outputs: Default::default(),
             cache: Default::default(),

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2630,24 +2630,26 @@ impl Task {
         if other.output.is_some() {
             self.output = other.output;
         }
+        let other_raw_sources = other
+            .raw_sources
+            .clone()
+            .unwrap_or_else(|| other.sources.clone());
+        self.raw_sources
+            .get_or_insert_with(|| self.sources.clone())
+            .extend(other_raw_sources);
         self.sources.extend(other.sources);
         if other.watch.is_some() {
             self.watch = other.watch;
         }
         if !other.outputs.is_empty() {
             self.outputs = other.outputs;
+            self.raw_outputs = other.raw_outputs;
         }
         if other.cache.is_some() {
             self.cache = other.cache;
         }
         if other.rust_cache.is_some() {
             self.rust_cache = other.rust_cache;
-        }
-        if other.raw_outputs.templates.is_some() {
-            self.raw_outputs = other.raw_outputs;
-        }
-        if other.raw_sources.is_some() {
-            self.raw_sources = other.raw_sources;
         }
         if other.shell.is_some() {
             self.shell = other.shell;
@@ -2764,7 +2766,7 @@ impl Task {
             self.description = render_str(&mut tera, &self.description, &tera_ctx)?;
         }
         for s in &mut self.sources {
-            if contains_template_syntax(s) && !tera_tag_has_usage_ref(s) {
+            if contains_template_syntax(s) && !tera_template_has_usage_ref(s) {
                 *s = render_str(&mut tera, s, &tera_ctx)?;
             }
         }
@@ -2824,15 +2826,15 @@ impl Task {
             raw.as_ref()
                 .is_some_and(|deps| deps.iter().any(dep_has_usage_ref))
         };
-        self.raw_sources
-            .as_ref()
-            .is_some_and(|sources| sources.iter().any(|source| tera_tag_has_usage_ref(source)))
-            || self
-                .raw_outputs
-                .templates
-                .as_ref()
-                .is_some_and(|outputs| outputs.iter().any(|output| tera_tag_has_usage_ref(output)))
-            || has_usage_deps(&self.depends_raw)
+        self.raw_sources.as_ref().is_some_and(|sources| {
+            sources
+                .iter()
+                .any(|source| tera_template_has_usage_ref(source))
+        }) || self.raw_outputs.templates.as_ref().is_some_and(|outputs| {
+            outputs
+                .iter()
+                .any(|output| tera_template_has_usage_ref(output))
+        }) || has_usage_deps(&self.depends_raw)
             || has_usage_deps(&self.depends_post_raw)
             || has_usage_deps(&self.wait_for_raw)
     }
@@ -2845,21 +2847,25 @@ impl Task {
         if usage_values.is_empty() {
             return Ok(());
         }
-        let has_usage_sources = self
-            .raw_sources
-            .as_ref()
-            .is_some_and(|sources| sources.iter().any(|source| tera_tag_has_usage_ref(source)));
-        let has_usage_outputs = self
-            .raw_outputs
-            .templates
-            .as_ref()
-            .is_some_and(|outputs| outputs.iter().any(|output| tera_tag_has_usage_ref(output)));
+        let has_usage_sources = self.raw_sources.as_ref().is_some_and(|sources| {
+            sources
+                .iter()
+                .any(|source| tera_template_has_usage_ref(source))
+        });
+        let has_usage_outputs = self.raw_outputs.templates.as_ref().is_some_and(|outputs| {
+            outputs
+                .iter()
+                .any(|output| tera_template_has_usage_ref(output))
+        });
         if !self.has_usage_runtime_templates() {
             return Ok(());
         }
         let config_root = self.config_root.clone().unwrap_or_default();
         let mut tera = get_tera(Some(&config_root));
         let mut tera_ctx = self.tera_ctx(config).await?;
+        if has_usage_outputs && let Some(env) = &self.raw_outputs.original_env {
+            tera_ctx.insert("env", env);
+        }
         // Insert usage values into the tera context so templates like
         // {{usage.app}} resolve to the actual CLI arg value.
         tera_ctx.insert("usage", usage_values);
@@ -3192,7 +3198,7 @@ fn match_tasks_with_context(
                 if let Some(config_root) = &t.config_root {
                     let config_root = config_root.clone();
                     t.outputs
-                        .re_render_with_env(&t.raw_outputs.clone(), &td.env, &config_root)?;
+                        .re_render_with_env(&mut t.raw_outputs, &td.env, &config_root)?;
                 }
             }
             Ok(t)
@@ -3655,7 +3661,7 @@ fn render_task_deps(
     Ok(())
 }
 
-fn tera_template_has_usage_ref(s: &str) -> bool {
+pub(crate) fn tera_template_has_usage_ref(s: &str) -> bool {
     const TAGS: [(&str, &str); 2] = [("{{", "}}"), ("{%", "%}")];
     for (open, close) in TAGS {
         let mut rest = s;
@@ -3842,6 +3848,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
 
+    use crate::task::task_sources::{RawOutputTemplates, TaskOutputs};
     use crate::task::workspace;
     use crate::task::{RunEntry, Task, TaskRustCacheConfig, TaskWatchOptions};
     use crate::{config::Config, dirs};
@@ -3910,6 +3917,53 @@ mod tests {
         assert_eq!(
             file_task.config_sources(),
             vec![Path::new(".mise/tasks/build"), Path::new("mise.toml")]
+        );
+    }
+
+    #[test]
+    fn test_merge_toml_overlay_preserves_raw_paths() {
+        let base_sources = vec!["base.txt".to_string(), "{{usage.name}}.txt".to_string()];
+        let base_outputs = vec!["{{usage.name}}.out".to_string()];
+        let mut file_task = Task {
+            sources: base_sources.clone(),
+            raw_sources: Some(base_sources.clone()),
+            outputs: TaskOutputs::Files(base_outputs.clone()),
+            raw_outputs: RawOutputTemplates {
+                templates: Some(base_outputs.clone()),
+                original_env: None,
+            },
+            ..Default::default()
+        };
+        let metadata_only_overlay = Task {
+            raw_sources: Some(vec![]),
+            raw_outputs: RawOutputTemplates {
+                templates: Some(vec![]),
+                original_env: None,
+            },
+            ..Default::default()
+        };
+
+        file_task.merge_toml_overlay(metadata_only_overlay);
+
+        assert_eq!(file_task.sources, base_sources);
+        assert_eq!(file_task.raw_sources, Some(base_sources));
+        assert_eq!(file_task.outputs, TaskOutputs::Files(base_outputs.clone()));
+        assert_eq!(file_task.raw_outputs.templates, Some(base_outputs));
+
+        let source_overlay = Task {
+            sources: vec!["overlay-{{usage.name}}.txt".to_string()],
+            raw_sources: Some(vec!["overlay-{{usage.name}}.txt".to_string()]),
+            ..Default::default()
+        };
+        file_task.merge_toml_overlay(source_overlay);
+
+        assert_eq!(
+            file_task.raw_sources,
+            Some(vec![
+                "base.txt".to_string(),
+                "{{usage.name}}.txt".to_string(),
+                "overlay-{{usage.name}}.txt".to_string(),
+            ])
         );
     }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -717,6 +717,9 @@ pub(crate) struct Task {
     /// re-rendered once task usage arguments are available.
     #[serde(skip)]
     pub raw_sources: Option<Vec<String>>,
+    /// Effective environment for deferred source/output path templates.
+    #[serde(skip)]
+    pub(crate) raw_path_env: Option<BTreeMap<String, String>>,
     #[serde(default)]
     pub watch: Option<TaskWatchOptions>,
     #[serde(default)]
@@ -2756,6 +2759,9 @@ impl Task {
         let mut tera = get_tera(Some(config_root));
         let tera_ctx = self.tera_ctx(config).await?;
         self.store_raw_render_inputs();
+        self.raw_path_env = tera_ctx
+            .get("env")
+            .and_then(|value| serde::Deserialize::deserialize(value.clone()).ok());
         for a in &mut self.aliases {
             if contains_template_syntax(a) {
                 *a = render_str(&mut tera, a, &tera_ctx)?;
@@ -2864,7 +2870,7 @@ impl Task {
         let mut tera = get_tera(Some(&config_root));
         let mut tera_ctx = self.tera_ctx(config).await?;
         if (has_usage_sources || has_usage_outputs)
-            && let Some(env) = &self.raw_outputs.original_env
+            && let Some(env) = &self.raw_path_env
         {
             tera_ctx.insert("env", env);
         }
@@ -3199,8 +3205,12 @@ fn match_tasks_with_context(
                 t = t.with_dependency_env(&env_directives);
                 if let Some(config_root) = &t.config_root {
                     let config_root = config_root.clone();
-                    t.outputs
-                        .re_render_with_env(&mut t.raw_outputs, &td.env, &config_root)?;
+                    t.outputs.re_render_with_env(
+                        &mut t.raw_outputs,
+                        &mut t.raw_path_env,
+                        &td.env,
+                        &config_root,
+                    )?;
                 }
             }
             Ok(t)
@@ -3272,6 +3282,7 @@ impl Default for Task {
             interactive: false,
             sources: vec![],
             raw_sources: None,
+            raw_path_env: None,
             watch: None,
             outputs: Default::default(),
             cache: Default::default(),
@@ -3932,7 +3943,6 @@ mod tests {
             outputs: TaskOutputs::Files(base_outputs.clone()),
             raw_outputs: RawOutputTemplates {
                 templates: Some(base_outputs.clone()),
-                original_env: None,
             },
             ..Default::default()
         };
@@ -3940,7 +3950,6 @@ mod tests {
             raw_sources: Some(vec![]),
             raw_outputs: RawOutputTemplates {
                 templates: Some(vec![]),
-                original_env: None,
             },
             ..Default::default()
         };

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -2641,6 +2641,11 @@ impl Task {
             .get_or_insert_with(|| self.sources.clone())
             .extend(other_raw_sources);
         self.sources.extend(other.sources);
+        if let Some(other_path_env) = other.raw_path_env {
+            self.raw_path_env
+                .get_or_insert_default()
+                .extend(other_path_env);
+        }
         if other.watch.is_some() {
             self.watch = other.watch;
         }
@@ -3940,6 +3945,10 @@ mod tests {
         let mut file_task = Task {
             sources: base_sources.clone(),
             raw_sources: Some(base_sources.clone()),
+            raw_path_env: Some(BTreeMap::from([
+                ("BASE".to_string(), "base".to_string()),
+                ("SHARED".to_string(), "base".to_string()),
+            ])),
             outputs: TaskOutputs::Files(base_outputs.clone()),
             raw_outputs: RawOutputTemplates {
                 templates: Some(base_outputs.clone()),
@@ -3948,6 +3957,10 @@ mod tests {
         };
         let metadata_only_overlay = Task {
             raw_sources: Some(vec![]),
+            raw_path_env: Some(BTreeMap::from([
+                ("OVERLAY".to_string(), "overlay".to_string()),
+                ("SHARED".to_string(), "overlay".to_string()),
+            ])),
             raw_outputs: RawOutputTemplates {
                 templates: Some(vec![]),
             },
@@ -3960,6 +3973,14 @@ mod tests {
         assert_eq!(file_task.raw_sources, Some(base_sources));
         assert_eq!(file_task.outputs, TaskOutputs::Files(base_outputs.clone()));
         assert_eq!(file_task.raw_outputs.templates, Some(base_outputs));
+        assert_eq!(
+            file_task.raw_path_env,
+            Some(BTreeMap::from([
+                ("BASE".to_string(), "base".to_string()),
+                ("OVERLAY".to_string(), "overlay".to_string()),
+                ("SHARED".to_string(), "overlay".to_string()),
+            ]))
+        );
 
         let source_overlay = Task {
             sources: vec!["overlay-{{usage.name}}.txt".to_string()],

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1013,13 +1013,10 @@ impl TaskExecutor {
                         .map(|(k, v)| EnvDirective::Val(k.clone(), v.clone(), Default::default()))
                         .collect();
                     t = t.with_dependency_env(&env_directives);
-                    if let Some(config_root) = &t.config_root {
+                    if let Some(config_root) = t.config_root.clone() {
                         let env_map: IndexMap<String, String> = env.iter().cloned().collect();
-                        t.outputs.re_render_with_env(
-                            &t.raw_outputs.clone(),
-                            &env_map,
-                            config_root,
-                        )?;
+                        t.outputs
+                            .re_render_with_env(&mut t.raw_outputs, &env_map, &config_root)?;
                     } else {
                         trace!(
                             "re_render_with_env skipped: task {} has no config_root",

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1015,8 +1015,12 @@ impl TaskExecutor {
                     t = t.with_dependency_env(&env_directives);
                     if let Some(config_root) = t.config_root.clone() {
                         let env_map: IndexMap<String, String> = env.iter().cloned().collect();
-                        t.outputs
-                            .re_render_with_env(&mut t.raw_outputs, &env_map, &config_root)?;
+                        t.outputs.re_render_with_env(
+                            &mut t.raw_outputs,
+                            &mut t.raw_path_env,
+                            &env_map,
+                            &config_root,
+                        )?;
                     } else {
                         trace!(
                             "re_render_with_env skipped: task {} has no config_root",

--- a/src/task/task_sources.rs
+++ b/src/task/task_sources.rs
@@ -13,12 +13,11 @@ pub(crate) enum TaskOutputs {
     Auto,
 }
 
-/// Stores raw (pre-render) output templates and the original env context so they
-/// can be re-rendered when dependency env overrides are applied after initial rendering.
+/// Stores raw (pre-render) output templates so they can be re-rendered after
+/// dependency env overrides and usage arguments are available.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct RawOutputTemplates {
     pub templates: Option<Vec<String>>,
-    pub original_env: Option<std::collections::BTreeMap<String, String>>,
 }
 
 impl Default for TaskOutputs {
@@ -61,7 +60,6 @@ impl TaskOutputs {
         match self {
             TaskOutputs::Files(files) => RawOutputTemplates {
                 templates: Some(files.clone()),
-                original_env: None,
             },
             TaskOutputs::NoFiles | TaskOutputs::Auto => RawOutputTemplates::default(),
         }
@@ -89,9 +87,6 @@ impl TaskOutputs {
         match self {
             TaskOutputs::Files(files) => {
                 let raw = files.clone();
-                let original_env = ctx
-                    .get("env")
-                    .and_then(|v| serde::Deserialize::deserialize(v.clone()).ok());
                 for file in files.iter_mut() {
                     if contains_template_syntax(file)
                         && !(defer_usage && super::tera_template_has_usage_ref(file))
@@ -101,7 +96,6 @@ impl TaskOutputs {
                 }
                 Ok(RawOutputTemplates {
                     templates: Some(raw),
-                    original_env,
                 })
             }
             TaskOutputs::NoFiles | TaskOutputs::Auto => Ok(RawOutputTemplates::default()),
@@ -113,17 +107,18 @@ impl TaskOutputs {
     pub(crate) fn re_render_with_env(
         &mut self,
         raw: &mut RawOutputTemplates,
+        path_env: &mut Option<std::collections::BTreeMap<String, String>>,
         env: &indexmap::IndexMap<String, String>,
         config_root: &std::path::Path,
     ) -> eyre::Result<()> {
         // Keep the dependency-level environment for the later usage render of
         // both sources and outputs. Sources share this context because the env
         // override applies to the task invocation as a whole.
-        let mut env_map = raw.original_env.clone().unwrap_or_default();
+        let mut env_map = path_env.clone().unwrap_or_default();
         for (k, v) in env {
             env_map.insert(k.clone(), v.clone());
         }
-        raw.original_env = Some(env_map.clone());
+        *path_env = Some(env_map.clone());
         if let TaskOutputs::Files(files) = self
             && let Some(raw_templates) = raw.templates.clone()
         {

--- a/src/task/task_sources.rs
+++ b/src/task/task_sources.rs
@@ -84,6 +84,7 @@ impl TaskOutputs {
         &mut self,
         tera: &mut TeraEngine,
         ctx: &tera::Context,
+        defer_usage: bool,
     ) -> eyre::Result<RawOutputTemplates> {
         match self {
             TaskOutputs::Files(files) => {
@@ -92,7 +93,9 @@ impl TaskOutputs {
                     .get("env")
                     .and_then(|v| serde::Deserialize::deserialize(v.clone()).ok());
                 for file in files.iter_mut() {
-                    if contains_template_syntax(file) {
+                    if contains_template_syntax(file)
+                        && !(defer_usage && super::tera_tag_has_usage_ref(file))
+                    {
                         *file = render_str(tera, file, ctx)?;
                     }
                 }
@@ -132,7 +135,7 @@ impl TaskOutputs {
                 *files = raw_templates
                     .iter()
                     .map(|tmpl| {
-                        if contains_template_syntax(tmpl) {
+                        if contains_template_syntax(tmpl) && !super::tera_tag_has_usage_ref(tmpl) {
                             render_str(&mut tera, tmpl, &ctx)
                         } else {
                             Ok(tmpl.clone())

--- a/src/task/task_sources.rs
+++ b/src/task/task_sources.rs
@@ -94,7 +94,7 @@ impl TaskOutputs {
                     .and_then(|v| serde::Deserialize::deserialize(v.clone()).ok());
                 for file in files.iter_mut() {
                     if contains_template_syntax(file)
-                        && !(defer_usage && super::tera_tag_has_usage_ref(file))
+                        && !(defer_usage && super::tera_template_has_usage_ref(file))
                     {
                         *file = render_str(tera, file, ctx)?;
                     }
@@ -112,30 +112,33 @@ impl TaskOutputs {
     /// tera context. Used after dependency env overrides are applied.
     pub(crate) fn re_render_with_env(
         &mut self,
-        raw: &RawOutputTemplates,
+        raw: &mut RawOutputTemplates,
         env: &indexmap::IndexMap<String, String>,
         config_root: &std::path::Path,
     ) -> eyre::Result<()> {
         if let TaskOutputs::Files(files) = self
-            && let Some(raw_templates) = raw.templates.as_ref()
+            && let Some(raw_templates) = raw.templates.clone()
         {
+            // Preserve dependency-level overrides for the later usage render.
+            let mut env_map = raw.original_env.clone().unwrap_or_default();
+            for (k, v) in env {
+                env_map.insert(k.clone(), v.clone());
+            }
+            raw.original_env = Some(env_map.clone());
             if raw_templates
                 .iter()
                 .any(|tmpl| contains_template_syntax(tmpl))
             {
                 let mut tera = crate::tera::get_tera(Some(config_root));
                 let mut ctx = tera::Context::new();
-                // Start with original env from initial render, then overlay dependency env
-                let mut env_map = raw.original_env.clone().unwrap_or_default();
-                for (k, v) in env {
-                    env_map.insert(k.clone(), v.clone());
-                }
                 ctx.insert("env", &env_map);
                 ctx.insert("config_root", &config_root.to_string_lossy().to_string());
                 *files = raw_templates
                     .iter()
                     .map(|tmpl| {
-                        if contains_template_syntax(tmpl) && !super::tera_tag_has_usage_ref(tmpl) {
+                        if contains_template_syntax(tmpl)
+                            && !super::tera_template_has_usage_ref(tmpl)
+                        {
                             render_str(&mut tera, tmpl, &ctx)
                         } else {
                             Ok(tmpl.clone())

--- a/src/task/task_sources.rs
+++ b/src/task/task_sources.rs
@@ -116,15 +116,17 @@ impl TaskOutputs {
         env: &indexmap::IndexMap<String, String>,
         config_root: &std::path::Path,
     ) -> eyre::Result<()> {
+        // Keep the dependency-level environment for the later usage render of
+        // both sources and outputs. Sources share this context because the env
+        // override applies to the task invocation as a whole.
+        let mut env_map = raw.original_env.clone().unwrap_or_default();
+        for (k, v) in env {
+            env_map.insert(k.clone(), v.clone());
+        }
+        raw.original_env = Some(env_map.clone());
         if let TaskOutputs::Files(files) = self
             && let Some(raw_templates) = raw.templates.clone()
         {
-            // Preserve dependency-level overrides for the later usage render.
-            let mut env_map = raw.original_env.clone().unwrap_or_default();
-            for (k, v) in env {
-                env_map.insert(k.clone(), v.clone());
-            }
-            raw.original_env = Some(env_map.clone());
             if raw_templates
                 .iter()
                 .any(|tmpl| contains_template_syntax(tmpl))


### PR DESCRIPTION
## Summary
- defer usage-dependent `sources` and `outputs` until task arguments are parsed
- resolve those paths before graph construction, freshness checks, and artifact-cache key generation
- preserve existing deferred dependency rendering and document the new behavior

Implements the behavior proposed in https://github.com/jdx/mise/discussions/13034.

## Testing
- `mise run test:e2e e2e/tasks/test_task_usage_paths`
- `mise run test:e2e e2e/tasks/test_task_dep_args e2e/tasks/test_task_source_freshness`
- `mise run lint-fix`
- `cargo check --locked`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core task path resolution, freshness, and caching behavior; scope is bounded by deferred rendering and new e2e coverage but mistakes could cause wrong skip/run decisions.
> 
> **Overview**
> **Task `sources` and `outputs` can now use `{{usage.*}}` templates**, resolved per invocation (with existing dependency deferral) before the execution graph is built and before freshness/cache checks run.
> 
> Implementation **generalizes `render_depends_with_usage` into `render_runtime_templates_with_usage`**, with **`raw_sources`** and task-level **`raw_path_env`** so usage- and env-dependent path templates can be re-rendered after CLI/parent args are parsed and after dependency `env` overrides. Initial Tera render **skips** sources/outputs that contain usage refs; **`re_render_with_env`** now updates the shared path env snapshot and still defers usage placeholders. Overlay merge and dependency matching were adjusted to preserve raw templates.
> 
> Docs add a usage-based compile example; a new e2e test covers per-arg freshness, transitive deps, mixed `env`/`usage` paths, and dependency env overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 222a0856df2773884c300aa165db606c8d5883d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that task `sources` and `outputs` can reference parsed usage arguments and flags.
  * Added an example showing usage-based paths in task commands, sources, and outputs.

* **Bug Fixes**
  * Fixed freshness tracking for tasks whose sources or outputs depend on usage arguments.
  * Ensured usage-dependent paths resolve correctly before freshness checks, caching, and transitive task execution.
  * Preserved independent freshness results for different argument values.
  * Fixed usage-based paths when environment overrides are applied through task dependencies.
  * Prevented unnecessary reruns for tasks using environment-based output paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->