### PR TITLE
feat(bootstrap): support pre-packages file phases

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -141,9 +141,12 @@ preflight prevents a missing input from leaving a partially provisioned host.
    [`[bootstrap.users]` and `[bootstrap.groups]`](/bootstrap/accounts.html).
 2. `mise bootstrap plugins apply` installs package manager plugins declared in
    [`[bootstrap.plugins]`](/bootstrap/packages/plugins.html).
+   Files and directories with [`phase = "pre-packages"`](/bootstrap/files.html#files-before-packages)
+   are then applied, before the `pre-packages` hook.
 3. Built-in managers install missing [`[bootstrap.packages]`](/bootstrap/packages/).
 4. `mise bootstrap files apply` converges
-   [`[bootstrap.files]` and `[bootstrap.directories]`](/bootstrap/files.html).
+   the remaining [`[bootstrap.files]` and `[bootstrap.directories]`](/bootstrap/files.html)
+   (the default `"post-packages"` phase).
 5. [`[bootstrap.services]`](/bootstrap/services.html) converges existing Linux
    systemd system units and user services on Linux, macOS, and Windows.
    User services with `requires_tools = true` wait until after tool installation.

--- a/docs/bootstrap/files.md
+++ b/docs/bootstrap/files.md
@@ -63,6 +63,46 @@ one privileged batch. Plans and file content are sent to narrowly scoped mise
 helpers over stdin, so file content does not appear in process arguments or
 logs.
 
+## Files before packages
+
+Set `phase = "pre-packages"` on files and directories needed by the package
+manager, such as repository definitions and signing keys:
+
+```toml
+[bootstrap.directories."/etc/apt/keyrings"]
+mode = "0755"
+phase = "pre-packages"
+
+[bootstrap.files."/etc/apt/keyrings/vendor.asc"]
+source = "./files/vendor.asc"
+phase = "pre-packages"
+
+[bootstrap.files."/etc/apt/sources.list.d/vendor.sources"]
+source = "./files/vendor.sources"
+phase = "pre-packages"
+
+[bootstrap.packages]
+"apt:vendor-tool" = "latest"
+```
+
+Provide the vendor's key and repository definition in the source files. Run
+`mise bootstrap --update` to refresh package metadata after applying the files;
+changing repository files does not automatically refresh metadata.
+
+Early files run after accounts and package manager plugins, before the
+`pre-packages` hook. The default phase is `"post-packages"`, which keeps files
+after built-in package installation. Each file is applied once per bootstrap
+run. Service notifications from both phases are collected for the services step.
+
+Declared parent directories must be created no later than their children and
+removed no earlier than their children. Conflicting phase declarations fail
+validation before bootstrap makes changes. Set a declared parent's phase to
+`"pre-packages"` when an early file needs it.
+
+`mise bootstrap files apply` still applies all declared files and directories.
+`mise bootstrap --only files` runs both file phases; `--skip files` skips both.
+`--only packages` does not apply files. Plans include each file's phase.
+
 ## Preview and inspect
 
 ```sh

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -15,7 +15,7 @@ Set up a machine from the current configuration
 Runs these phases in order, when configured and selected:
 
 1. Linux accounts, then package-manager plugins.
-2. The pre-packages hook, then packages handled by built-in managers.
+2. Pre-packages files/directories, the pre-packages hook, then packages handled by built-in managers.
 3. Privileged files/directories, system and user services, firewall, and Compose projects.
 4. Git repositories, then dotfiles, each with its pre/post hooks.
 5. Shell activation, macOS defaults and LaunchAgents, Linux user units, and user settings.

--- a/e2e/cli/test_bootstrap_compose
+++ b/e2e/cli/test_bootstrap_compose
@@ -147,3 +147,14 @@ assert_fail "mise bootstrap compose apply --dry-run --yes"
 assert_fail "mise bootstrap --dry-run --yes --skip files"
 assert_contains "mise bootstrap --dry-run --yes" "deferred-compose --project-directory"
 assert_fail "test -f $deferred_compose"
+
+# Phase ordering does not make Compose depend on skipped package changes.
+if [[ "$(uname -s)" == "Linux" ]] && command -v apt-get >/dev/null; then
+  cat >>mise.toml <<'EOF'
+[bootstrap.packages]
+"apt:mise-phase-test-nonexistent" = "latest"
+EOF
+  assert_contains "mise bootstrap --dry-run --yes --skip packages" "deferred-compose --project-directory"
+  assert_contains "mise bootstrap --dry-run --yes --only files,compose" "deferred-compose --project-directory"
+  assert_fail "mise bootstrap --dry-run --yes --only compose"
+fi

--- a/e2e/cli/test_bootstrap_file_phases
+++ b/e2e/cli/test_bootstrap_file_phases
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+early="$PWD/early/repository"
+late="$PWD/late"
+cat >mise.toml <<EOF
+[bootstrap.directories."$PWD/early"]
+phase = "pre-packages"
+mode = "0750"
+[bootstrap.files."$early"]
+content = "repository"
+phase = "pre-packages"
+[bootstrap.files."$late"]
+content = "service config"
+[bootstrap.hooks]
+pre-packages = "test -f '$early' && test ! -e '$late' && echo hook >> '$early'"
+post-packages = "test ! -e '$late'"
+EOF
+
+# Dry runs show both phases without writing files or running hooks.
+assert_contains "mise bootstrap --only files,packages --dry-run 2>&1" "system files (pre-packages)"
+assert_fail "test -e '$early'"
+assert_fail "test -e '$late'"
+
+# Early files exist before the hook; they are not reapplied in the late phase.
+assert_succeed "mise bootstrap --only files,packages --yes"
+assert_contains "cat '$early'" "hook"
+assert "cat '$late'" "service config"
+
+# Standalone file application converges both phases and is idempotent.
+assert_succeed "mise bootstrap files apply --yes"
+assert "cat '$early'" "repository"
+assert_contains "mise bootstrap files apply --yes 2>&1" "already converged"
+assert_succeed "mise bootstrap files status --json | jq -e 'all(.[]; .phase == \"pre-packages\" or .phase == \"post-packages\")'"
+assert_contains "mise bootstrap plan" "pre-packages"
+
+# Selecting packages does not implicitly apply files; selecting files runs both.
+cat >mise.toml <<EOF
+[bootstrap.files."$PWD/selected-early"]
+phase = "pre-packages"
+content = "early"
+[bootstrap.files."$PWD/selected-late"]
+phase = "post-packages"
+content = "late"
+EOF
+assert_succeed "mise bootstrap --only packages --yes"
+assert_fail "test -e '$PWD/selected-early'"
+assert_fail "test -e '$PWD/selected-late'"
+assert_succeed "mise bootstrap --skip files --yes"
+assert_fail "test -e '$PWD/selected-early'"
+assert_fail "test -e '$PWD/selected-late'"
+assert_succeed "mise bootstrap --only files --yes"
+assert "cat selected-early" "early"
+assert "cat selected-late" "late"
+
+# Conflicting phases fail preflight, before even unrelated early files change.
+cat >mise.toml <<EOF
+[bootstrap.files."$PWD/untouched"]
+content = "untouched"
+phase = "pre-packages"
+[bootstrap.directories."$PWD/parent"]
+phase = "post-packages"
+[bootstrap.files."$PWD/parent/child"]
+content = "child"
+phase = "pre-packages"
+EOF
+assert_fail "mise bootstrap --only files --yes" "adjust their phase declarations"
+assert_fail "mise bootstrap plan" "adjust their phase declarations"
+assert_fail "test -e '$PWD/untouched'"
+
+cat >mise.toml <<EOF
+[bootstrap.files."$PWD/invalid"]
+content = "invalid"
+phase = "before-everything"
+EOF
+assert_fail "mise bootstrap files apply --yes" "before-everything"
+
+# The planner and package metadata refresh put repository files first.
+# Package commands are only previewed; this never modifies host packages.
+if [[ "$(uname -s)" == "Linux" ]] && command -v apt-get >/dev/null; then
+  cat >mise.toml <<EOF
+[bootstrap.files."$PWD/package-config"]
+content = "config"
+[bootstrap.packages]
+"apt:mise-phase-test-nonexistent" = "latest"
+[bootstrap.files."$PWD/repo-input"]
+content = "repository"
+phase = "pre-packages"
+EOF
+  assert_succeed "mise bootstrap plan --json | jq -e '[.resources[].id.kind] == [\"file\", \"package\", \"file\"]'"
+  preview=$(mise bootstrap --only files,packages --update --dry-run)
+  if [[ $preview != *"would write file $PWD/repo-input"*"apt-get update"*"apt-get install"*"would write file $PWD/package-config"* ]]; then
+    echo "unexpected bootstrap order: $preview" >&2
+    exit 1
+  fi
+  assert_fail "test -e '$PWD/repo-input'"
+fi

--- a/e2e/cli/test_bootstrap_file_phases
+++ b/e2e/cli/test_bootstrap_file_phases
@@ -94,3 +94,17 @@ EOF
   fi
   assert_fail "test -e '$PWD/repo-input'"
 fi
+
+# Pending plugin packages belong after both file phases, even without built-ins.
+cat >mise.toml <<EOF
+[bootstrap.plugins]
+phase-test = "https://example.invalid/phase-test.git"
+[bootstrap.packages]
+"phase-test:vendor" = "latest"
+[bootstrap.files."$PWD/plugin-late"]
+content = "late"
+[bootstrap.files."$PWD/plugin-early"]
+content = "early"
+phase = "pre-packages"
+EOF
+assert_succeed "mise bootstrap plan --json | jq -e '[.resources[].id.kind] == [\"file\", \"file\", \"package\"]'"

--- a/e2e/config/test_schema_bootstrap_file_phases
+++ b/e2e/config/test_schema_bootstrap_file_phases
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+mise use -g node@24 npm:ajv-cli@5.0.0
+validate="mise x npm:ajv-cli@5.0.0 -- ajv validate --spec=draft2020 -s '$ROOT/schema/mise.json' -d phases.json"
+cat >phases.json <<'JSON'
+{"bootstrap":{"files":{"/etc/vendor.sources":{"source":"vendor.sources","phase":"pre-packages"}},"directories":{"/etc/vendor":{"phase":"post-packages"}}}}
+JSON
+assert_succeed "$validate"
+cat >phases.json <<'JSON'
+{"bootstrap":{"files":{"/etc/vendor.sources":{"content":"repo","phase":"invalid"}}}}
+JSON
+assert_fail "$validate"
+cat >phases.json <<'JSON'
+{"bootstrap":{"directories":{"/etc/vendor":{"phase":"invalid"}}}}
+JSON
+assert_fail "$validate"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -1187,7 +1187,7 @@ Set up a machine from the current configuration
 Runs these phases in order, when configured and selected:
 
 1. Linux accounts, then package\-manager plugins.
-2. The pre\-packages hook, then packages handled by built\-in managers.
+2. Pre\-packages files/directories, the pre\-packages hook, then packages handled by built\-in managers.
 3. Privileged files/directories, system and user services, firewall, and Compose projects.
 4. Git repositories, then dotfiles, each with its pre/post hooks.
 5. Shell activation, macOS defaults and LaunchAgents, Linux user units, and user settings.

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -448,7 +448,7 @@ Set up a machine from the current configuration
 Runs these phases in order, when configured and selected:
 
 1. Linux accounts, then package-manager plugins.
-2. The pre-packages hook, then packages handled by built-in managers.
+2. Pre-packages files/directories, the pre-packages hook, then packages handled by built-in managers.
 3. Privileged files/directories, system and user services, firewall, and Compose projects.
 4. Git repositories, then dotfiles, each with its pre/post hooks.
 5. Shell activation, macOS defaults and LaunchAgents, Linux user units, and user settings.

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3711,6 +3711,12 @@
       "minProperties": 1,
       "additionalProperties": false
     },
+    "bootstrap_file_phase": {
+      "type": "string",
+      "enum": ["pre-packages", "post-packages"],
+      "default": "post-packages",
+      "description": "When to apply the managed path during bootstrap; pre-packages runs before the pre-packages hook"
+    },
     "bootstrap_hook": {
       "description": "command or commands to run for a bootstrap phase",
       "oneOf": [
@@ -4268,6 +4274,88 @@
       "type": "object",
       "description": "machine-global bootstrapping (system packages, repos, macOS defaults, launchd agents, login shell)",
       "properties": {
+        "files": {
+          "type": "object",
+          "description": "Managed system files keyed by absolute target path",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "phase": {
+                "$ref": "#/$defs/bootstrap_file_phase"
+              },
+              "source": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              },
+              "owner": {
+                "type": "string"
+              },
+              "group": {
+                "type": "string"
+              },
+              "mode": {
+                "type": "string"
+              },
+              "template": {
+                "type": "boolean"
+              },
+              "state": {
+                "type": "string",
+                "enum": ["present", "absent"]
+              },
+              "replace": {
+                "type": "boolean"
+              },
+              "notify": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "directories": {
+          "type": "object",
+          "description": "Managed system directories keyed by absolute target path",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "phase": {
+                "$ref": "#/$defs/bootstrap_file_phase"
+              },
+              "owner": {
+                "type": "string"
+              },
+              "group": {
+                "type": "string"
+              },
+              "mode": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string",
+                "enum": ["present", "absent"]
+              },
+              "recursive": {
+                "type": "boolean"
+              },
+              "replace": {
+                "type": "boolean"
+              },
+              "notify": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
         "config_roots": {
           "deprecated": true,
           "type": "array",

--- a/src/cli/bootstrap.rs
+++ b/src/cli/bootstrap.rs
@@ -43,7 +43,7 @@ use crate::ui::table::MiseTable;
 /// Runs these phases in order, when configured and selected:
 ///
 /// 1. Linux accounts, then package-manager plugins.
-/// 2. The pre-packages hook, then packages handled by built-in managers.
+/// 2. Pre-packages files/directories, the pre-packages hook, then packages handled by built-in managers.
 /// 3. Privileged files/directories, system and user services, firewall, and Compose projects.
 /// 4. Git repositories, then dotfiles, each with its pre/post hooks.
 /// 5. Shell activation, macOS defaults and LaunchAgents, Linux user units, and user settings.
@@ -1476,6 +1476,34 @@ impl Bootstrap {
             apply_bootstrap_plugins(&config, self.dry_run).await?;
         }
 
+        if let Some((files, directories)) = &managed_system_files {
+            let mut files = files
+                .iter()
+                .filter(|file| file.phase == system::managed_files::ManagedFilePhase::PrePackages)
+                .cloned()
+                .collect::<Vec<_>>();
+            let mut directories = directories
+                .iter()
+                .filter(|directory| {
+                    directory.phase == system::managed_files::ManagedFilePhase::PrePackages
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if !files.is_empty() || !directories.is_empty() {
+                info!("bootstrap: system files (pre-packages)");
+                system::managed_files::inspect_requests(&mut files, &mut directories)?;
+                let report = system::managed_files::apply_with_accounts(
+                    &files,
+                    &directories,
+                    configured_accounts.as_ref(),
+                    allow_pending_accounts,
+                    self.dry_run,
+                    self.yes,
+                )?;
+                notified_services.extend(report.notified_services);
+            }
+        }
+
         if skip.contains(&BootstrapPart::Packages) {
             debug!("bootstrap: system packages skipped");
         } else {
@@ -1520,6 +1548,11 @@ impl Bootstrap {
                 .as_ref()
                 .expect("system files were preflighted when not skipped")
                 .clone();
+            files
+                .retain(|file| file.phase == system::managed_files::ManagedFilePhase::PostPackages);
+            directories.retain(|directory| {
+                directory.phase == system::managed_files::ManagedFilePhase::PostPackages
+            });
             system::managed_files::inspect_requests(&mut files, &mut directories)?;
             if files.is_empty() && directories.is_empty() {
                 debug!("bootstrap: no [bootstrap.files] or [bootstrap.directories] configured");
@@ -1533,7 +1566,7 @@ impl Bootstrap {
                     self.dry_run,
                     self.yes,
                 )?;
-                notified_services = report.notified_services;
+                notified_services.extend(report.notified_services);
             }
         }
 
@@ -2435,12 +2468,19 @@ impl BootstrapPlan {
         } else {
             let mut table = MiseTable::new(
                 false,
-                &["Action", "Resource", "Current", "Desired", "Config"],
+                &[
+                    "Action", "Resource", "Phase", "Current", "Desired", "Config",
+                ],
             );
             for resource in &output.resources {
                 table.add_row(vec![
                     resource.action.to_string(),
                     resource.id.to_string(),
+                    resource
+                        .phase
+                        .map(|phase| phase.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
                     resource.current.clone(),
                     resource.desired.clone(),
                     resource

--- a/src/system/managed_files.rs
+++ b/src/system/managed_files.rs
@@ -15,6 +15,8 @@ use crate::system::resources::{ResourceAction, ResourceId, ResourceOrigin, Resou
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub(crate) struct ManagedFileTomlConfig {
+    #[serde(default)]
+    pub phase: ManagedFilePhase,
     pub source: Option<String>,
     pub content: Option<String>,
     pub owner: Option<String>,
@@ -32,6 +34,8 @@ pub(crate) struct ManagedFileTomlConfig {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub(crate) struct ManagedDirectoryTomlConfig {
+    #[serde(default)]
+    pub phase: ManagedFilePhase,
     pub owner: Option<String>,
     pub group: Option<String>,
     pub mode: Option<String>,
@@ -45,6 +49,23 @@ pub(crate) struct ManagedDirectoryTomlConfig {
     pub notify: Vec<String>,
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ManagedFilePhase {
+    PrePackages,
+    #[default]
+    PostPackages,
+}
+
+impl ManagedFilePhase {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::PrePackages => "pre-packages",
+            Self::PostPackages => "post-packages",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum ManagedState {
@@ -55,6 +76,7 @@ pub(crate) enum ManagedState {
 
 #[derive(Clone, Debug)]
 pub(crate) struct ManagedFileRequest {
+    pub phase: ManagedFilePhase,
     pub path: PathBuf,
     pub content: Option<String>,
     pub owner: Option<String>,
@@ -69,6 +91,7 @@ pub(crate) struct ManagedFileRequest {
 
 #[derive(Clone, Debug)]
 pub(crate) struct ManagedDirectoryRequest {
+    pub phase: ManagedFilePhase,
     pub path: PathBuf,
     pub owner: Option<String>,
     pub group: Option<String>,
@@ -204,6 +227,7 @@ pub(crate) fn status_requests_from_config(
         .collect::<std::collections::HashMap<_, _>>();
     for (path, (file, base, origin)) in merged_files_from_config(config)? {
         let state = file.state;
+        let phase = file.phase;
         match ManagedFileRequest::from_toml(
             config,
             path.clone(),
@@ -228,7 +252,8 @@ pub(crate) fn status_requests_from_config(
                         "template rendered",
                         ResourceAction::Unknown,
                     )
-                    .with_origin(origin),
+                    .with_origin(origin)
+                    .with_file_phase(phase),
                 );
             }
             Err(error) => return Err(error),
@@ -494,6 +519,41 @@ fn validate_requests(
     for directory in directories {
         validate_present_ancestors(&directory.path, directory.state, &directory_states)?;
     }
+    for (path, state, phase) in files
+        .iter()
+        .map(|file| (&file.path, file.state, file.phase))
+        .chain(
+            directories
+                .iter()
+                .map(|dir| (&dir.path, dir.state, dir.phase)),
+        )
+    {
+        for parent in directories
+            .iter()
+            .filter(|dir| path != &dir.path && path.starts_with(&dir.path))
+        {
+            let invalid = match (state, parent.state) {
+                (ManagedState::Present, ManagedState::Present) => {
+                    phase == ManagedFilePhase::PrePackages
+                        && parent.phase == ManagedFilePhase::PostPackages
+                }
+                (ManagedState::Absent, ManagedState::Absent) => {
+                    phase == ManagedFilePhase::PostPackages
+                        && parent.phase == ManagedFilePhase::PrePackages
+                }
+                _ => false,
+            };
+            if invalid {
+                bail!(
+                    "managed path '{}' ({}) conflicts with ancestor '{}' ({}): parent directories must be created before children and removed after children; adjust their phase declarations",
+                    path.display(),
+                    phase.as_str(),
+                    parent.path.display(),
+                    parent.phase.as_str()
+                );
+            }
+        }
+    }
     Ok(())
 }
 
@@ -575,6 +635,7 @@ impl ManagedFileRequest {
         Ok(Self {
             path,
             content,
+            phase: config.phase,
             owner,
             group,
             mode,
@@ -587,7 +648,10 @@ impl ManagedFileRequest {
     }
 
     pub(crate) fn plan(&self) -> Result<ResourcePlan> {
-        plan_file(self).map(|plan| plan.with_origin(self.origin.clone()))
+        plan_file(self).map(|plan| {
+            plan.with_origin(self.origin.clone())
+                .with_file_phase(self.phase)
+        })
     }
 
     fn operation(&self) -> Result<Option<PrivilegedAction>> {
@@ -646,6 +710,7 @@ impl ManagedDirectoryRequest {
         }
         Ok(Self {
             path,
+            phase: config.phase,
             owner: nonempty("owner", config.owner)?,
             group: nonempty("group", config.group)?,
             mode: parse_mode(config.mode.as_deref(), 0o755)?,
@@ -659,7 +724,10 @@ impl ManagedDirectoryRequest {
     }
 
     pub(crate) fn plan(&self) -> Result<ResourcePlan> {
-        plan_directory(self).map(|plan| plan.with_origin(self.origin.clone()))
+        plan_directory(self).map(|plan| {
+            plan.with_origin(self.origin.clone())
+                .with_file_phase(self.phase)
+        })
     }
 
     fn operation(&self) -> Result<Option<PrivilegedAction>> {
@@ -1739,6 +1807,7 @@ mod tests {
 
     fn file(path: &str, state: ManagedState) -> ManagedFileRequest {
         ManagedFileRequest {
+            phase: ManagedFilePhase::default(),
             path: PathBuf::from(path),
             content: (state == ManagedState::Present).then(|| "content".to_string()),
             owner: None,
@@ -1759,6 +1828,7 @@ mod tests {
 
     fn directory(path: &str, state: ManagedState) -> ManagedDirectoryRequest {
         ManagedDirectoryRequest {
+            phase: ManagedFilePhase::default(),
             path: PathBuf::from(path),
             owner: None,
             group: None,
@@ -1783,6 +1853,26 @@ mod tests {
         assert!(absolute_target("/").is_err());
         assert!(absolute_target("/tmp/..").is_err());
         assert!(absolute_target("/tmp/../..").is_err());
+    }
+
+    #[test]
+    fn file_phases_respect_parent_creation_and_removal() {
+        let mut child = file("/etc/vendor/key", ManagedState::Present);
+        let mut parent = directory("/etc/vendor", ManagedState::Present);
+        child.phase = ManagedFilePhase::PrePackages;
+        assert!(validate_requests(&[child.clone()], &[parent.clone()]).is_err());
+        parent.phase = ManagedFilePhase::PrePackages;
+        assert!(validate_requests(&[child.clone()], &[parent.clone()]).is_ok());
+        child.phase = ManagedFilePhase::PostPackages;
+        assert!(validate_requests(&[child.clone()], &[parent.clone()]).is_ok());
+
+        child.state = ManagedState::Absent;
+        parent.state = ManagedState::Absent;
+        assert!(validate_requests(&[child.clone()], &[parent.clone()]).is_err());
+        child.phase = ManagedFilePhase::PrePackages;
+        assert!(validate_requests(&[child.clone()], &[parent.clone()]).is_ok());
+        parent.phase = ManagedFilePhase::PostPackages;
+        assert!(validate_requests(&[child], &[parent]).is_ok());
     }
 
     #[test]

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -136,6 +136,8 @@ pub(crate) struct ResourcePlan {
     pub origin: Option<ResourceOrigin>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub depends_on: Vec<ResourceId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<super::managed_files::ManagedFilePhase>,
 }
 
 impl ResourcePlan {
@@ -152,11 +154,17 @@ impl ResourcePlan {
             action,
             origin: None,
             depends_on: vec![],
+            phase: None,
         }
     }
 
     pub(crate) fn with_origin(mut self, origin: ResourceOrigin) -> Self {
         self.origin = Some(origin);
+        self
+    }
+
+    pub(crate) fn with_file_phase(mut self, phase: super::managed_files::ManagedFilePhase) -> Self {
+        self.phase = Some(phase);
         self
     }
 }
@@ -525,6 +533,17 @@ pub(crate) async fn plan(
     for resource in unavailable_files {
         plan.insert(resource)?;
     }
+    let builtin_packages = super::packages_from_config(config)
+        .into_iter()
+        .filter(|packages| !packages.manager.is_plugin())
+        .flat_map(|packages| {
+            let manager = packages.manager.name().to_string();
+            packages.requests.into_iter().map(move |request| {
+                ResourceId::new("package", format!("{manager}:{}", request.name))
+            })
+        })
+        .collect::<Vec<_>>();
+    add_file_phase_dependencies(&mut plan, &builtin_packages)?;
     let service_dependencies = plan
         .resources
         .keys()
@@ -618,6 +637,34 @@ pub(crate) async fn plan(
     // Validate dependency references and cycles even when callers only need JSON.
     plan.output()?;
     Ok(plan)
+}
+
+fn add_file_phase_dependencies(plan: &mut BootstrapPlan, packages: &[ResourceId]) -> Result<()> {
+    use super::managed_files::ManagedFilePhase;
+
+    let early = plan
+        .resources
+        .values()
+        .filter(|resource| resource.phase == Some(ManagedFilePhase::PrePackages))
+        .map(|resource| resource.id.clone())
+        .collect::<Vec<_>>();
+    let late = plan
+        .resources
+        .values()
+        .filter(|resource| resource.phase == Some(ManagedFilePhase::PostPackages))
+        .map(|resource| resource.id.clone())
+        .collect::<Vec<_>>();
+    for package in packages {
+        for file in &early {
+            plan.add_dependency(package, file.clone())?;
+        }
+    }
+    for file in &late {
+        for dependency in packages.iter().chain(&early) {
+            plan.add_dependency(file, dependency.clone())?;
+        }
+    }
+    Ok(())
 }
 
 fn add_account_dependencies(
@@ -735,6 +782,35 @@ fn package_resource_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn file_phases_order_resources_around_packages() {
+        use super::super::managed_files::ManagedFilePhase;
+
+        let mut plan = BootstrapPlan::default();
+        let late = ResourceId::new("file", "/etc/service.conf");
+        let package = ResourceId::new("package", "apt:vendor");
+        let early = ResourceId::new("file", "/etc/apt/sources.list.d/vendor.sources");
+        for (id, phase) in [
+            (late.clone(), Some(ManagedFilePhase::PostPackages)),
+            (package.clone(), None),
+            (early.clone(), Some(ManagedFilePhase::PrePackages)),
+        ] {
+            let mut resource = ResourcePlan::new(id, "missing", "present", ResourceAction::Create);
+            resource.phase = phase;
+            plan.insert(resource).unwrap();
+        }
+        add_file_phase_dependencies(&mut plan, std::slice::from_ref(&package)).unwrap();
+        let output = plan.output().unwrap();
+        assert_eq!(
+            output
+                .resources
+                .iter()
+                .map(|resource| &resource.id)
+                .collect::<Vec<_>>(),
+            [&early, &package, &late]
+        );
+    }
 
     #[cfg(unix)]
     #[test]

--- a/src/system/resources.rs
+++ b/src/system/resources.rs
@@ -136,6 +136,9 @@ pub(crate) struct ResourcePlan {
     pub origin: Option<ResourceOrigin>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub depends_on: Vec<ResourceId>,
+    /// Execution order only; these resources do not affect change prediction.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub order_after: Vec<ResourceId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phase: Option<super::managed_files::ManagedFilePhase>,
 }
@@ -154,6 +157,7 @@ impl ResourcePlan {
             action,
             origin: None,
             depends_on: vec![],
+            order_after: vec![],
             phase: None,
         }
     }
@@ -245,6 +249,16 @@ impl BootstrapPlan {
         Ok(BootstrapPlanOutput { resources, summary })
     }
 
+    fn add_ordering(&mut self, resource: &ResourceId, predecessor: ResourceId) -> Result<()> {
+        let Some(resource) = self.resources.get_mut(resource) else {
+            bail!("cannot order missing bootstrap resource '{resource}'");
+        };
+        if !resource.order_after.contains(&predecessor) {
+            resource.order_after.push(predecessor);
+        }
+        Ok(())
+    }
+
     fn ordered(&self) -> Result<Vec<&ResourcePlan>> {
         let mut incoming = self
             .resources
@@ -255,7 +269,7 @@ impl BootstrapPlan {
         let mut outgoing: HashMap<ResourceId, Vec<ResourceId>> = HashMap::new();
 
         for resource in self.resources.values() {
-            for dependency in &resource.depends_on {
+            for dependency in resource.depends_on.iter().chain(&resource.order_after) {
                 let Some(count) = incoming.get_mut(&resource.id) else {
                     unreachable!("every resource was added to incoming")
                 };
@@ -543,7 +557,7 @@ pub(crate) async fn plan(
             })
         })
         .collect::<Vec<_>>();
-    add_file_phase_dependencies(&mut plan, &builtin_packages)?;
+    add_file_phase_ordering(&mut plan, &builtin_packages)?;
     let service_dependencies = plan
         .resources
         .keys()
@@ -639,7 +653,7 @@ pub(crate) async fn plan(
     Ok(plan)
 }
 
-fn add_file_phase_dependencies(plan: &mut BootstrapPlan, packages: &[ResourceId]) -> Result<()> {
+fn add_file_phase_ordering(plan: &mut BootstrapPlan, packages: &[ResourceId]) -> Result<()> {
     use super::managed_files::ManagedFilePhase;
 
     let early = plan
@@ -656,12 +670,24 @@ fn add_file_phase_dependencies(plan: &mut BootstrapPlan, packages: &[ResourceId]
         .collect::<Vec<_>>();
     for package in packages {
         for file in &early {
-            plan.add_dependency(package, file.clone())?;
+            plan.add_ordering(package, file.clone())?;
         }
     }
     for file in &late {
         for dependency in packages.iter().chain(&early) {
-            plan.add_dependency(file, dependency.clone())?;
+            plan.add_ordering(file, dependency.clone())?;
+        }
+    }
+    // Installed and pending plugin managers both run after the file phases.
+    let plugin_packages = plan
+        .resources
+        .keys()
+        .filter(|id| id.kind == "package" && !packages.contains(id))
+        .cloned()
+        .collect::<Vec<_>>();
+    for package in plugin_packages {
+        for predecessor in early.iter().chain(&late).chain(packages) {
+            plan.add_ordering(&package, predecessor.clone())?;
         }
     }
     Ok(())
@@ -791,7 +817,9 @@ mod tests {
         let late = ResourceId::new("file", "/etc/service.conf");
         let package = ResourceId::new("package", "apt:vendor");
         let early = ResourceId::new("file", "/etc/apt/sources.list.d/vendor.sources");
+        let plugin = ResourceId::new("package", "custom:vendor");
         for (id, phase) in [
+            (plugin.clone(), None),
             (late.clone(), Some(ManagedFilePhase::PostPackages)),
             (package.clone(), None),
             (early.clone(), Some(ManagedFilePhase::PrePackages)),
@@ -800,7 +828,7 @@ mod tests {
             resource.phase = phase;
             plan.insert(resource).unwrap();
         }
-        add_file_phase_dependencies(&mut plan, std::slice::from_ref(&package)).unwrap();
+        add_file_phase_ordering(&mut plan, std::slice::from_ref(&package)).unwrap();
         let output = plan.output().unwrap();
         assert_eq!(
             output
@@ -808,7 +836,13 @@ mod tests {
                 .iter()
                 .map(|resource| &resource.id)
                 .collect::<Vec<_>>(),
-            [&early, &package, &late]
+            [&early, &package, &late, &plugin]
+        );
+        assert!(
+            output
+                .resources
+                .iter()
+                .all(|resource| resource.depends_on.is_empty())
         );
     }
 

--- a/src/system/services_common.rs
+++ b/src/system/services_common.rs
@@ -166,6 +166,12 @@ pub(crate) struct ServiceNotifications {
 }
 
 impl ServiceNotifications {
+    pub(crate) fn extend(&mut self, other: Self) {
+        for (service, sources) in other.sources {
+            self.sources.entry(service).or_default().extend(sources);
+        }
+    }
+
     pub(crate) fn notify_file(&mut self, path: &Path, services: &[String]) {
         self.notify(ResourceId::new("file", path.to_string_lossy()), services);
     }
@@ -320,4 +326,20 @@ pub(crate) fn validate_notifications(
 
 fn default_true() -> bool {
     true
+}
+
+#[cfg(test)]
+mod notification_tests {
+    use super::*;
+
+    #[test]
+    fn merges_notifications_from_both_file_phases() {
+        let mut early = ServiceNotifications::default();
+        early.notify_file(Path::new("/etc/early"), &["web".into()]);
+        let mut late = ServiceNotifications::default();
+        late.notify_file(Path::new("/etc/late"), &["web".into(), "worker".into()]);
+        early.extend(late);
+        assert_eq!(early.sources["web"].len(), 2);
+        assert_eq!(early.sources["worker"].len(), 1);
+    }
 }


### PR DESCRIPTION
Repository definitions and signing keys declared in `[bootstrap.files]` currently arrive after package installation. Add `phase = "pre-packages"` to managed files and directories so bootstrap can apply them after accounts/plugins and before the package hook and installation. Existing declarations default to `"post-packages"`.

```toml
[bootstrap.files."/etc/apt/sources.list.d/vendor.sources"]
source = "./files/vendor.sources"
phase = "pre-packages"
```

Both phases reuse managed-file convergence and privilege handling, apply each path once, and accumulate service notifications. Standalone `files apply` still handles all files; `--only`/`--skip` retain explicit selection semantics. Plans expose phases and package ordering, and preflight rejects conflicting parent/child phase declarations. Document `mise bootstrap --update` for package metadata refresh; repository-file changes do not trigger it automatically.

Addresses https://github.com/jdx/mise/discussions/13047.

Validation:
- `mise run build`
- `mise exec -- cargo test --all-features --bin mise file_phases`
- Focused e2e coverage for phase ordering, hook timing, idempotence, selection flags, preflight errors, apt refresh dry-run order, unprivileged files, and JSON schema validation
- `mise run lint-fix`

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bootstrap ordering and when privileged paths are written on disk, which can affect package installs and first-run provisioning; validation and tests reduce misconfiguration risk.
> 
> **Overview**
> Adds **`phase`** on `[bootstrap.files]` and `[bootstrap.directories]` (`pre-packages` | `post-packages`, default **`post-packages`**) so repo keys, apt sources, and similar paths can land **before** built-in package install instead of only afterward.
> 
> **Bootstrap** now runs a **pre-packages** file pass after accounts/plugins, then the pre-packages hook and packages; the existing file step applies only **post-packages** paths. Each path is applied once; service **`notify`** results from both passes are merged. **`mise bootstrap plan`** shows a Phase column and uses **`order_after`** so plans order early files → built-in packages → late files → plugin packages without treating that as hard dependencies (Compose still won’t wait on skipped package work).
> 
> **Preflight** rejects invalid phases and parent/child phase conflicts (parents must be created before early children and removed after late children). Schema, docs, CLI/man usage, and e2e cover ordering, flags (`--only`/`--skip files`), and apt-style workflows (metadata refresh still needs **`--update`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bbe568fb49429424f9b87cee3aa00ee59d263de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Managed files and directories support `pre-packages` and `post-packages` phases.
  - Pre-package resources run before built-in package installation; post-package resources run afterward.
  - Bootstrap plans show each resource’s phase and preserve service notifications from both phases.
  - File-phase settings are schema-validated, including supported values and parent/child ordering conflicts.
  - File application commands now consistently handle both phases according to `--only` and `--skip` options.

- **Documentation**
  - Updated bootstrap guides, CLI help, and man pages to explain phases, defaults, ordering, and command options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->