### PR TITLE
perf(oci): cache local tool layers across image builds

### DIFF
--- a/docs/cli/oci/build.md
+++ b/docs/cli/oci/build.md
@@ -35,6 +35,7 @@ Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 - **`-t --tag <TAG>`** — Tag to record in the image index (the org.opencontainers.image.ref.name annotation)
 - **`--mount-point <MOUNT_POINT>`** — Where to place tool installs inside the image (default: /mise)
 - **`--no-mise`** — Do not embed the currently-running mise binary at /usr/local/bin/mise
+- **`--no-cache`** — Rebuild tool layers without reading or writing the local layer cache
 - **`--owner <UID[:GID]>`** — UID[:GID] to assign to every tar entry in generated layers
 
   Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.

--- a/docs/cli/oci/push.md
+++ b/docs/cli/oci/push.md
@@ -42,7 +42,7 @@ Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 
   See `mise oci build --help` for details.
 - **`--mount-point <MOUNT_POINT>`** — Override in-image mount point (ignored with --image-dir)
-- **`--no-cache`** — Don't reuse tool layers from the previously pushed image
+- **`--no-cache`** — Rebuild tool layers without using the remote or local layer cache
 - **`--no-mise`** — Don't embed the mise binary (ignored with --image-dir)
 - **`--owner <UID[:GID]>`** — UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
 

--- a/docs/cli/oci/push.md
+++ b/docs/cli/oci/push.md
@@ -19,7 +19,7 @@ uploaded, so repeat pushes of mostly-unchanged toolsets are cheap.
 Tool layers whose tool, version, mount point, and file owner match the
 previously pushed image (or `--cache-from`) are reused without being
 rebuilt — those tools don't even need to be installed locally. Pass
-`--no-cache` to force a full local rebuild.
+`--no-cache` to rebuild tool layers without using the remote or local layer cache.
 
 Credentials are read from the same places docker and podman use:
 `$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,

--- a/docs/dev-tools/mise-oci.md
+++ b/docs/dev-tools/mise-oci.md
@@ -179,6 +179,24 @@ failures are retried with backoff (`http_retries` controls attempts).
 
 ### Layer reuse
 
+`oci build`, `oci run`, and `oci push` share a local cache of packaged tool
+layers. An unchanged tool only needs to be tarred and gzipped once, even when
+building separate images or using different output directories. Concurrent
+builds coordinate per cache entry, and each output layout receives its own
+complete copy of the locally cached layer.
+
+Local reuse hashes the files and their image paths, executable permissions,
+symlink targets, ownership, and relocated contents. Editing or reinstalling a
+tool invalidates its cache when the packaged content changes, even if the
+version, file size, and modification time stay the same. Cache hits still read
+and hash the installation; they avoid tar construction and gzip compression.
+The base image is not part of a tool layer's cache key.
+
+Pass `oci build --no-cache` or `oci push --no-cache` to bypass the local cache.
+`mise cache clear TOOL` removes that tool's cached layers; `mise cache clear`
+removes all cached layers. Cache entries live in the normal mise tool cache,
+so CI jobs can preserve them along with `MISE_CACHE_DIR`.
+
 When pushing an image whose base lives in the **same repository** as the
 destination, mise fetches the current base manifest and config but leaves its
 layer blobs in the registry. Mutable base tags are resolved on every push.
@@ -203,7 +221,7 @@ and packaged.
   mise oci push --cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$GIT_SHA
   ```
 
-- `--no-cache` disables reuse and rebuilds every layer from the local
+- `--no-cache` disables remote and local tool-layer reuse and rebuilds from local
   installs (docker-style escape hatch — reuse trusts that the
   registry's layer content matches its annotations, rather than
   rebuilding the exact bytes locally).

--- a/e2e/oci/test_oci_local_layer_cache
+++ b/e2e/oci/test_oci_local_layer_cache
@@ -52,3 +52,11 @@ assert_contains "cat changed-again.log" "layer from the local cache"
 mise cache clear jq
 mise oci build --from scratch --no-mise -o cleared >cleared.log 2>&1
 assert_not_contains "cat cleared.log" "layer from the local cache"
+
+# Missing installs fail before any system-package work is attempted.
+mise uninstall jq
+cat >>mise.toml <<'EOF'
+[bootstrap.packages]
+"apt:curl" = "latest"
+EOF
+assert_fail "mise oci build --from scratch --no-mise -o missing" "install path does not exist"

--- a/e2e/oci/test_oci_local_layer_cache
+++ b/e2e/oci/test_oci_local_layer_cache
@@ -54,9 +54,11 @@ mise oci build --from scratch --no-mise -o cleared >cleared.log 2>&1
 assert_not_contains "cat cleared.log" "layer from the local cache"
 
 # Missing installs fail before any system-package work is attempted.
-mise uninstall jq
+# Control: with the tool present, package processing must reject scratch.
 cat >>mise.toml <<'EOF'
 [bootstrap.packages]
 "apt:curl" = "latest"
 EOF
+assert_fail "mise oci build --from scratch --no-mise -o packages-control" "requires an apt-based base image"
+mise uninstall jq
 assert_fail "mise oci build --from scratch --no-mise -o missing" "install path does not exist"

--- a/e2e/oci/test_oci_local_layer_cache
+++ b/e2e/oci/test_oci_local_layer_cache
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Local tool layers are reusable across independent, complete OCI layouts.
+export MISE_EXPERIMENTAL=1
+export SOURCE_DATE_EPOCH=1700000000
+
+cat >mise.toml <<'EOF'
+[tools]
+jq = "1.8.1"
+EOF
+mise install >/dev/null 2>&1
+
+mise oci build --from scratch --no-mise -o first >first.log 2>&1
+assert_not_contains "cat first.log" "layer from the local cache"
+mise oci build --from scratch --no-mise -o second >second.log 2>&1
+assert_contains "cat second.log" "layer from the local cache"
+assert "jq -r '.manifests[0].digest' second/index.json" "$(jq -r '.manifests[0].digest' first/index.json)"
+
+# Independently verify every referenced blob and uncompressed layer digest.
+python3 - <<'PY'
+import gzip
+import hashlib
+import json
+from pathlib import Path
+
+root = Path("second/blobs/sha256")
+
+def read(desc):
+    data = (root / desc["digest"].removeprefix("sha256:")).read_bytes()
+    assert len(data) == desc["size"]
+    assert "sha256:" + hashlib.sha256(data).hexdigest() == desc["digest"]
+    return data
+
+index = json.loads(Path("second/index.json").read_text())
+manifest = json.loads(read(index["manifests"][0]))
+config = json.loads(read(manifest["config"]))
+for layer, diff_id in zip(manifest["layers"], config["rootfs"]["diff_ids"], strict=True):
+    assert "sha256:" + hashlib.sha256(gzip.decompress(read(layer))).hexdigest() == diff_id
+PY
+
+mise oci build --from scratch --no-mise --no-cache -o uncached >uncached.log 2>&1
+assert_not_contains "cat uncached.log" "layer from the local cache"
+assert "jq -r '.manifests[0].digest' uncached/index.json" "$(jq -r '.manifests[0].digest' first/index.json)"
+
+# Mutating an installation at the same version invalidates the local cache.
+printf 'added content\n' >"$(mise where jq)/extra-file"
+mise oci build --from scratch --no-mise -o changed >changed.log 2>&1
+assert_not_contains "cat changed.log" "layer from the local cache"
+assert_succeed "test '$(jq -r '.manifests[0].digest' changed/index.json)' != '$(jq -r '.manifests[0].digest' first/index.json)'"
+mise oci build --from scratch --no-mise -o changed-again >changed-again.log 2>&1
+assert_contains "cat changed-again.log" "layer from the local cache"
+
+mise cache clear jq
+mise oci build --from scratch --no-mise -o cleared >cleared.log 2>&1
+assert_not_contains "cat cleared.log" "layer from the local cache"

--- a/e2e/oci/test_oci_push_registry
+++ b/e2e/oci/test_oci_push_registry
@@ -72,3 +72,9 @@ assert_contains "mise oci push --image-dir ./img $REGISTRY/e2e/devenv@$local_dig
 # reproducible rebuild produces identical blobs so nothing re-uploads ---
 assert_contains "mise oci push --from scratch --no-mise $REGISTRY/e2e/devenv:v2" \
   "0 blob(s) uploaded"
+
+# An independent destination with no remote cache reuses the locally built
+# tool layer, and all required blobs are uploaded to the new repository.
+mise oci push --from scratch --no-mise "$REGISTRY/e2e/other:v1" >local-cache.log 2>&1
+assert_contains "cat local-cache.log" "layer from the local cache"
+assert_succeed "mise x crane@latest -- crane validate --insecure --remote $REGISTRY/e2e/other:v1"

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -5022,6 +5022,9 @@ Where to place tool installs inside the image (default: /mise)
 \fB\-\-no\-mise\fR
 Do not embed the currently\-running mise binary at /usr/local/bin/mise
 .TP
+\fB\-\-no\-cache\fR
+Rebuild tool layers without reading or writing the local layer cache
+.TP
 \fB\-\-owner\fR \fI<UID[:GID]>\fR
 UID[:GID] to assign to every tar entry in generated layers
 
@@ -5085,7 +5088,7 @@ See `mise oci build \-\-help` for details.
 Override in\-image mount point (ignored with \-\-image\-dir)
 .TP
 \fB\-\-no\-cache\fR
-Don't reuse tool layers from the previously pushed image
+Rebuild tool layers without using the remote or local layer cache
 .TP
 \fB\-\-no\-mise\fR
 Don't embed the mise binary (ignored with \-\-image\-dir)

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -5053,7 +5053,7 @@ uploaded, so repeat pushes of mostly\-unchanged toolsets are cheap.
 Tool layers whose tool, version, mount point, and file owner match the
 previously pushed image (or `\-\-cache\-from`) are reused without being
 rebuilt — those tools don't even need to be installed locally. Pass
-`\-\-no\-cache` to force a full local rebuild.
+`\-\-no\-cache` to rebuild tool layers without using the remote or local layer cache.
 
 Credentials are read from the same places docker and podman use:
 `$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3498,6 +3498,7 @@ By default `mise oci build` only packages tools declared in the project's mise c
             arg <MOUNT_POINT>
         }
         flag --no-mise help="Do not embed the currently-running mise binary at /usr/local/bin/mise"
+        flag --no-cache help="Rebuild tool layers without reading or writing the local layer cache"
         flag --owner help="UID[:GID] to assign to every tar entry in generated layers" {
             long_help #"""
 UID[:GID] to assign to every tar entry in generated layers
@@ -3564,7 +3565,7 @@ See `mise oci build --help` for details.
         flag --mount-point help="Override in-image mount point (ignored with --image-dir)" {
             arg <MOUNT_POINT>
         }
-        flag --no-cache help="Don't reuse tool layers from the previously pushed image"
+        flag --no-cache help="Rebuild tool layers without using the remote or local layer cache"
         flag --no-mise help="Don't embed the mise binary (ignored with --image-dir)"
         flag --owner help="UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)" {
             long_help #"""

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -3528,7 +3528,7 @@ uploaded, so repeat pushes of mostly-unchanged toolsets are cheap.
 Tool layers whose tool, version, mount point, and file owner match the
 previously pushed image (or `--cache-from`) are reused without being
 rebuilt — those tools don't even need to be installed locally. Pass
-`--no-cache` to force a full local rebuild.
+`--no-cache` to rebuild tool layers without using the remote or local layer cache.
 
 Credentials are read from the same places docker and podman use:
 `$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,

--- a/src/cli/oci/build.rs
+++ b/src/cli/oci/build.rs
@@ -82,6 +82,10 @@ pub(super) struct Build {
     #[usage(long)]
     no_mise: bool,
 
+    /// Rebuild tool layers without reading or writing the local layer cache
+    #[usage(long)]
+    no_cache: bool,
+
     /// UID[:GID] to assign to every tar entry in generated layers
     ///
     /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
@@ -107,6 +111,7 @@ impl Build {
             // must produce a complete, standalone image directory.
             reuse_from: None,
             push_destination: None,
+            no_cache: self.no_cache,
         };
         let out = perform_build(opts, self.include_global).await?;
 

--- a/src/cli/oci/push.rs
+++ b/src/cli/oci/push.rs
@@ -62,7 +62,7 @@ pub(super) struct Push {
     #[usage(long)]
     mount_point: Option<String>,
 
-    /// Don't reuse tool layers from the previously pushed image
+    /// Rebuild tool layers without using the remote or local layer cache
     #[usage(long)]
     no_cache: bool,
 
@@ -126,6 +126,7 @@ impl Push {
                     copy: vec![],
                     reuse_from: self.fetch_layer_cache().await?,
                     push_destination: Some(self.reference.clone()),
+                    no_cache: self.no_cache,
                 };
                 let built = perform_build(opts, self.include_global).await?;
                 reused_layers = built.tool_layers.iter().filter(|l| l.reused).count();

--- a/src/cli/oci/push.rs
+++ b/src/cli/oci/push.rs
@@ -17,7 +17,7 @@ use crate::oci::{BuildOptions, LayerOwner, registry};
 /// Tool layers whose tool, version, mount point, and file owner match the
 /// previously pushed image (or `--cache-from`) are reused without being
 /// rebuilt — those tools don't even need to be installed locally. Pass
-/// `--no-cache` to force a full local rebuild.
+/// `--no-cache` to rebuild tool layers without using the remote or local layer cache.
 ///
 /// Credentials are read from the same places docker and podman use:
 /// `$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,

--- a/src/cli/oci/run.rs
+++ b/src/cli/oci/run.rs
@@ -146,6 +146,7 @@ impl Run {
                     // every blob present — no remote reuse.
                     reuse_from: None,
                     push_destination: None,
+                    no_cache: false,
                 };
                 let built = perform_build(opts, self.include_global).await?;
                 info!("built image: {}", built.manifest_digest);

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -61,6 +61,8 @@ pub(crate) struct BuildOptions {
     /// Push destination; permits base blobs already in that repository to
     /// remain remote when no build step needs to unpack them.
     pub push_destination: Option<String>,
+    /// Bypass the local tool-layer cache (remote reuse is supplied separately).
+    pub no_cache: bool,
 }
 
 /// Cache key for tool-layer reuse. All four parts must match — a layer built
@@ -403,12 +405,28 @@ impl Builder {
                     Vec::new()
                 };
                 let relocation = layer::ToolRelocation::new(paths).with_pythons(pythons);
-                let blob = layer::build_relocated_tool_layer_from_dir(
-                    &tv.install_path(),
-                    &tv_prefix,
-                    owner,
-                    &relocation,
-                )
+                let blob = if self.opts.no_cache {
+                    layer::build_relocated_tool_layer_from_dir(
+                        &tv.install_path(),
+                        &tv_prefix,
+                        owner,
+                        &relocation,
+                    )
+                } else {
+                    layer::build_cached_tool_layer(
+                        &tv.install_path(),
+                        &tv_prefix,
+                        owner,
+                        &relocation,
+                        &tv.cache_path().join("oci-layers"),
+                    )
+                    .map(|(blob, hit)| {
+                        if hit {
+                            info!("oci: reusing {} layer from the local cache", tv.style());
+                        }
+                        blob
+                    })
+                }
                 .wrap_err_with(|| format!("building layer for {}", tv.style()))?;
                 ToolLayer::Built(blob)
             };

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -335,20 +335,6 @@ impl Builder {
                 n = built_tool_count
             );
         }
-        for (i, (_, tv)) in versions.iter().enumerate() {
-            if tool_reuse[i].is_some() {
-                continue; // layer comes from the cache image; no install needed
-            }
-            let install_path = tv.install_path();
-            if !install_path.is_dir() {
-                bail!(
-                    "{} install path does not exist: {}. Run `mise install` first.",
-                    tv.style(),
-                    install_path.display()
-                );
-            }
-        }
-
         // --- 3. System package layer (optional) ---
         let system_packages_layer = packages::build_system_packages_layer(
             &layout,
@@ -383,6 +369,21 @@ impl Builder {
                 );
                 ToolLayer::Reused(reused.clone())
             } else {
+                // Coordinate with install, link, and uninstall before inspecting
+                // the source. Hold through fingerprinting, packaging, and cache
+                // publication so a same-version reinstall cannot poison a key.
+                let _install_lock = crate::toolset::install_state::lock_tool_version(
+                    &tv.ba().short,
+                    &tv.tv_pathname(),
+                )?;
+                let install_path = tv.install_path();
+                if !install_path.is_dir() {
+                    bail!(
+                        "{} install path does not exist: {}. Run `mise install` first.",
+                        tv.style(),
+                        install_path.display()
+                    );
+                }
                 let is_pipx = tv.ba().backend_type() == BackendType::Pipx;
                 // Only pipx layers are expected to link into another tool's
                 // install. Other backends get their own mapping for shebang

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -335,6 +335,14 @@ impl Builder {
                 n = built_tool_count
             );
         }
+        // Fail cheaply before unpacking a rootfs or installing system packages.
+        // The locked check below remains authoritative if the install changes.
+        for (i, (_, tv)) in versions.iter().enumerate() {
+            if tool_reuse[i].is_none() {
+                require_tool_install(tv)?;
+            }
+        }
+
         // --- 3. System package layer (optional) ---
         let system_packages_layer = packages::build_system_packages_layer(
             &layout,
@@ -372,18 +380,12 @@ impl Builder {
                 // Coordinate with install, link, and uninstall before inspecting
                 // the source. Hold through fingerprinting, packaging, and cache
                 // publication so a same-version reinstall cannot poison a key.
-                let _install_lock = crate::toolset::install_state::lock_tool_version(
+                let _install_lock = crate::toolset::install_state::lock_tool_version_with_notice(
                     &tv.ba().short,
                     &tv.tv_pathname(),
+                    &|| info!("oci: waiting for {} install lock", tv.style()),
                 )?;
-                let install_path = tv.install_path();
-                if !install_path.is_dir() {
-                    bail!(
-                        "{} install path does not exist: {}. Run `mise install` first.",
-                        tv.style(),
-                        install_path.display()
-                    );
-                }
+                require_tool_install(tv)?;
                 let is_pipx = tv.ba().backend_type() == BackendType::Pipx;
                 // Only pipx layers are expected to link into another tool's
                 // install. Other backends get their own mapping for shebang
@@ -936,6 +938,18 @@ impl Builder {
             history: vec![],
         })
     }
+}
+
+fn require_tool_install(tv: &ToolVersion) -> Result<()> {
+    let install_path = tv.install_path();
+    if !install_path.is_dir() {
+        bail!(
+            "{} install path does not exist: {}. Run `mise install` first.",
+            tv.style(),
+            install_path.display()
+        );
+    }
+    Ok(())
 }
 
 fn resolve_layer_owner(opts_owner: Option<LayerOwner>, oci: &OciConfig) -> LayerOwner {

--- a/src/oci/builder.rs
+++ b/src/oci/builder.rs
@@ -336,10 +336,11 @@ impl Builder {
             );
         }
         // Fail cheaply before unpacking a rootfs or installing system packages.
-        // The locked check below remains authoritative if the install changes.
+        // Confirm a missing path under the lock: a reinstall may temporarily
+        // remove it. The packaging check remains authoritative for present paths.
         for (i, (_, tv)) in versions.iter().enumerate() {
             if tool_reuse[i].is_none() {
-                require_tool_install(tv)?;
+                preflight_tool_install(tv)?;
             }
         }
 
@@ -380,11 +381,7 @@ impl Builder {
                 // Coordinate with install, link, and uninstall before inspecting
                 // the source. Hold through fingerprinting, packaging, and cache
                 // publication so a same-version reinstall cannot poison a key.
-                let _install_lock = crate::toolset::install_state::lock_tool_version_with_notice(
-                    &tv.ba().short,
-                    &tv.tv_pathname(),
-                    &|| info!("oci: waiting for {} install lock", tv.style()),
-                )?;
+                let _install_lock = lock_tool_install(tv)?;
                 require_tool_install(tv)?;
                 let is_pipx = tv.ba().backend_type() == BackendType::Pipx;
                 // Only pipx layers are expected to link into another tool's
@@ -940,6 +937,24 @@ impl Builder {
     }
 }
 
+/// Coordinate source checks and packaging with installation transactions.
+fn lock_tool_install(tv: &ToolVersion) -> Result<fslock::LockFile> {
+    crate::toolset::install_state::lock_tool_version_with_notice(
+        &tv.ba().short,
+        &tv.tv_pathname(),
+        &|| info!("oci: waiting for {} install lock", tv.style()),
+    )
+}
+
+/// Check cheaply when present, but wait for a reinstall before reporting absence.
+fn preflight_tool_install(tv: &ToolVersion) -> Result<()> {
+    if !tv.install_path().is_dir() {
+        let _install_lock = lock_tool_install(tv)?;
+        require_tool_install(tv)?;
+    }
+    Ok(())
+}
+
 fn require_tool_install(tv: &ToolVersion) -> Result<()> {
     let install_path = tv.install_path();
     if !install_path.is_dir() {
@@ -1377,6 +1392,49 @@ fn cached_tool_path_entries(remote: &registry::RemoteImage, tool_root: &str) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn missing_install_preflight_waits_for_reinstall() {
+        use crate::toolset::{ToolRequest, ToolSource};
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let td = tempfile::tempdir().unwrap();
+        let version = td
+            .path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let backend =
+            crate::cli::args::BackendArg::new("node".to_string(), Some("core:node".to_string()));
+        let request =
+            ToolRequest::new_version_for_test(backend.into(), &version, ToolSource::Unknown);
+        let mut tv = ToolVersion::new(request, version);
+        tv.install_path = Some(td.path().join("install"));
+        let held = lock_tool_install(&tv).unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                started_tx.send(()).unwrap();
+                done_tx.send(preflight_tool_install(&tv)).unwrap();
+            });
+            started_rx.recv().unwrap();
+            let before_unlock = done_rx.recv_timeout(Duration::from_millis(100));
+            // Simulate the installer completing while holding its transaction lock.
+            std::fs::create_dir(tv.install_path()).unwrap();
+            drop(held);
+            assert!(matches!(
+                before_unlock,
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ));
+            done_rx
+                .recv_timeout(Duration::from_secs(10))
+                .unwrap()
+                .unwrap();
+        });
+    }
 
     fn layer(annotations: &[(&str, &str)], digest: &str) -> Descriptor {
         Descriptor {

--- a/src/oci/layer.rs
+++ b/src/oci/layer.rs
@@ -26,6 +26,9 @@ use jdx_tar::{Builder, EntryType, Header};
 use sha2::{Digest, Sha256};
 use walkdir::WalkDir;
 
+mod cache;
+pub(crate) use cache::build_cached_tool_layer;
+
 /// Host-to-image path mappings used while packaging an installed tool.
 ///
 /// Most tools are relocatable as-is, but virtual environments commonly embed

--- a/src/oci/layer/cache.rs
+++ b/src/oci/layer/cache.rs
@@ -1,0 +1,322 @@
+//! Cache the result of packaging a local tool, keyed by the actual layer inputs.
+//! Reading and hashing files is intentional: reinstalling or editing a tool at
+//! the same version must not reuse stale bytes. Hits skip tar construction and
+//! gzip compression. Each image still receives its own complete layer blob.
+
+use serde::{Deserialize, Serialize};
+
+use super::*;
+
+#[derive(Serialize, Deserialize)]
+struct CachedLayer {
+    digest: String,
+    diff_id: String,
+    size: u64,
+}
+
+pub(crate) fn build_cached_tool_layer(
+    src_dir: &Path,
+    target_prefix: &str,
+    owner: LayerOwner,
+    relocation: &ToolRelocation,
+    cache_dir: &Path,
+) -> Result<(LayerBlob, bool)> {
+    if !src_dir.is_dir() {
+        eyre::bail!("not a directory: {}", src_dir.display());
+    }
+    let entries = collect_sorted_entries(src_dir, false, owner, Some(relocation))?;
+    let key = fingerprint(&entries, target_prefix, owner, relocation)?;
+    let record_path = cache_dir.join(format!("{key}.json"));
+    let _lock = match crate::lock_file::LockFile::at(&cache_dir.join(format!("{key}.lock"))).lock()
+    {
+        Ok(lock) => lock,
+        Err(err) => {
+            debug!("could not lock OCI tool layer cache: {err:#}");
+            return Ok((
+                build_layer_from_entries(&entries, target_prefix, owner, Some(relocation))?,
+                false,
+            ));
+        }
+    };
+    match read_cached_layer(&record_path, cache_dir) {
+        Ok(Some(blob)) => return Ok((blob, true)),
+        Ok(None) => {}
+        Err(err) => debug!("ignoring invalid OCI tool layer cache: {err:#}"),
+    }
+
+    let blob = build_layer_from_entries(&entries, target_prefix, owner, Some(relocation))?;
+    // Do not publish under the old key if the installation changed while we
+    // were building. The next invocation will fingerprint its new contents.
+    let after = collect_sorted_entries(src_dir, false, owner, Some(relocation))?;
+    if fingerprint(&after, target_prefix, owner, relocation)? == key
+        && let Err(err) = write_cached_layer(&record_path, cache_dir, &blob)
+    {
+        debug!("could not cache OCI tool layer: {err:#}");
+    }
+    Ok((blob, false))
+}
+
+fn fingerprint(
+    entries: &[Entry],
+    prefix: &str,
+    owner: LayerOwner,
+    relocation: &ToolRelocation,
+) -> Result<String> {
+    let mut hash = Sha256::new();
+    // Bump the format when layer construction changes without a mise release.
+    field(&mut hash, b"mise-oci-tool-layer-v1");
+    field(&mut hash, env!("CARGO_PKG_VERSION").as_bytes());
+    field(&mut hash, std::env::consts::OS.as_bytes());
+    field(&mut hash, std::env::consts::ARCH.as_bytes());
+    field(&mut hash, prefix.as_bytes());
+    field(&mut hash, &owner.uid.to_le_bytes());
+    field(&mut hash, &owner.gid.to_le_bytes());
+    for entry in entries {
+        field(&mut hash, entry.rel.as_os_str().as_encoded_bytes());
+        field(&mut hash, &entry.mode.to_le_bytes());
+        match &entry.kind {
+            EntryKind::Dir => field(&mut hash, b"directory"),
+            EntryKind::Symlink(target) => {
+                field(&mut hash, b"symlink");
+                field(&mut hash, target.as_os_str().as_encoded_bytes());
+            }
+            EntryKind::File => {
+                field(&mut hash, b"file");
+                // Hash precisely the bytes the tar writer will use, including
+                // rewritten shebangs and Python virtual environment metadata.
+                let mut reader: Box<dyn Read> =
+                    match relocated_file_contents(entry, Some(relocation))? {
+                        Some(contents) => contents.reader,
+                        None => Box::new(std::fs::File::open(&entry.abs)?),
+                    };
+                let mut contents_hash = Sha256::new();
+                let mut buffer = [0; 64 * 1024];
+                loop {
+                    let n = reader.read(&mut buffer)?;
+                    if n == 0 {
+                        break;
+                    }
+                    contents_hash.update(&buffer[..n]);
+                }
+                field(&mut hash, &contents_hash.finalize());
+            }
+        }
+    }
+    Ok(hex_encode(&hash.finalize()))
+}
+
+fn field(hash: &mut Sha256, bytes: &[u8]) {
+    hash.update((bytes.len() as u64).to_le_bytes());
+    hash.update(bytes);
+}
+
+fn read_cached_layer(record_path: &Path, cache_dir: &Path) -> Result<Option<LayerBlob>> {
+    let record = match std::fs::read(record_path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    let record: CachedLayer = serde_json::from_slice(&record)?;
+    crate::oci::layout::validate_sha256_digest(&record.digest)?;
+    crate::oci::layout::validate_sha256_digest(&record.diff_id)?;
+    let bytes = std::fs::read(cache_dir.join(record.digest.trim_start_matches("sha256:")))?;
+    eyre::ensure!(
+        bytes.len() as u64 == record.size,
+        "cached OCI layer size mismatch"
+    );
+    let digest = format!("sha256:{}", hex_encode(&Sha256::digest(&bytes)));
+    eyre::ensure!(digest == record.digest, "cached OCI layer digest mismatch");
+    Ok(Some(LayerBlob {
+        digest,
+        diff_id: record.diff_id,
+        size: record.size,
+        bytes,
+    }))
+}
+
+fn write_cached_layer(record_path: &Path, cache_dir: &Path, blob: &LayerBlob) -> Result<()> {
+    crate::file::create_dir_all(cache_dir)?;
+    let blob_path = cache_dir.join(blob.digest.trim_start_matches("sha256:"));
+    // Atomic blob publication followed by atomic metadata publication lets
+    // concurrent builds share this cache without sharing an image index.
+    crate::file::write_atomic(blob_path, &blob.bytes)?;
+    crate::file::write_atomic(
+        record_path,
+        serde_json::to_vec(&CachedLayer {
+            digest: blob.digest.clone(),
+            diff_id: blob.diff_id.clone(),
+            size: blob.size,
+        })?,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_changes_invalidate_cache_even_with_preserved_size_and_mtime() {
+        let td = tempfile::tempdir().unwrap();
+        let src = td.path().join("tool");
+        let cache = td.path().join("cache");
+        std::fs::create_dir(&src).unwrap();
+        let path = src.join("file");
+        std::fs::write(&path, "first").unwrap();
+        let owner = LayerOwner::default();
+        let relocation = ToolRelocation::default();
+        let build =
+            || build_cached_tool_layer(&src, "mise/tool", owner, &relocation, &cache).unwrap();
+        let (first, hit) = build();
+        assert!(!hit);
+        let (second, hit) = build();
+        assert!(hit);
+        assert_eq!(first.bytes, second.bytes);
+        let mtime =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&path).unwrap());
+        std::fs::write(&path, "other").unwrap();
+        filetime::set_file_mtime(&path, mtime).unwrap();
+        let (changed, hit) = build();
+        assert!(!hit);
+        assert_ne!(first.digest, changed.digest);
+        assert!(build().1);
+        std::fs::remove_file(&path).unwrap();
+        assert!(!build().1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ownership_prefix_and_relocated_contents_have_separate_entries() {
+        use std::os::unix::fs::PermissionsExt;
+        let td = tempfile::tempdir().unwrap();
+        let src = td.path().join("tool");
+        let cache = td.path().join("cache");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(
+            src.join("launcher"),
+            format!("#!{}/bin/python\n", src.display()),
+        )
+        .unwrap();
+        std::fs::set_permissions(src.join("launcher"), std::fs::Permissions::from_mode(0o755))
+            .unwrap();
+        let original = ToolRelocation::new(vec![(src.clone(), "/mise/python".into())]);
+        let changed = ToolRelocation::new(vec![(src.clone(), "/other/python".into())]);
+        let mut digests = std::collections::HashSet::new();
+        for (prefix, owner, relocation) in [
+            ("mise/tool", LayerOwner::default(), &original),
+            ("other/tool", LayerOwner::default(), &original),
+            ("mise/tool", LayerOwner::new(1000, 1000), &original),
+            ("mise/tool", LayerOwner::default(), &changed),
+        ] {
+            let (blob, hit) =
+                build_cached_tool_layer(&src, prefix, owner, relocation, &cache).unwrap();
+            assert!(!hit);
+            assert!(digests.insert(blob.digest));
+            assert!(
+                build_cached_tool_layer(&src, prefix, owner, relocation, &cache)
+                    .unwrap()
+                    .1
+            );
+        }
+    }
+
+    #[test]
+    fn corrupt_or_missing_cached_blobs_are_rebuilt() {
+        let td = tempfile::tempdir().unwrap();
+        let src = td.path().join("tool");
+        let cache = td.path().join("cache");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("file"), "content").unwrap();
+        let relocation = ToolRelocation::default();
+        let build = || {
+            build_cached_tool_layer(
+                &src,
+                "mise/tool",
+                LayerOwner::default(),
+                &relocation,
+                &cache,
+            )
+            .unwrap()
+        };
+        let (first, _) = build();
+        let blob_path = cache.join(first.digest.trim_start_matches("sha256:"));
+        std::fs::write(&blob_path, vec![0; first.size as usize]).unwrap();
+        let (rebuilt, hit) = build();
+        assert!(!hit);
+        assert_eq!(rebuilt.bytes, first.bytes);
+        assert!(build().1);
+        std::fs::remove_file(blob_path).unwrap();
+        assert!(!build().1);
+    }
+
+    #[test]
+    fn concurrent_builds_package_the_same_inputs_once() {
+        let td = tempfile::tempdir().unwrap();
+        let src = td.path().join("tool");
+        let cache = td.path().join("cache");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("file"), "content").unwrap();
+        let barrier = std::sync::Barrier::new(4);
+        let results = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..4)
+                .map(|_| {
+                    scope.spawn(|| {
+                        barrier.wait();
+                        build_cached_tool_layer(
+                            &src,
+                            "mise/tool",
+                            LayerOwner::default(),
+                            &ToolRelocation::default(),
+                            &cache,
+                        )
+                        .unwrap()
+                    })
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|h| h.join().unwrap())
+                .collect::<Vec<_>>()
+        });
+        assert_eq!(results.iter().filter(|(_, hit)| !hit).count(), 1);
+        assert!(
+            results
+                .iter()
+                .all(|(blob, _)| blob.bytes == results[0].0.bytes)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executable_modes_and_symlink_targets_invalidate_cache() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+        let td = tempfile::tempdir().unwrap();
+        let src = td.path().join("tool");
+        let cache = td.path().join("cache");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("file"), "contents").unwrap();
+        std::fs::set_permissions(src.join("file"), std::fs::Permissions::from_mode(0o644)).unwrap();
+        symlink("file", src.join("link")).unwrap();
+        let relocation = ToolRelocation::default();
+        let build = || {
+            build_cached_tool_layer(
+                &src,
+                "mise/tool",
+                LayerOwner::default(),
+                &relocation,
+                &cache,
+            )
+            .unwrap()
+        };
+        let (original, _) = build();
+        assert!(build().1);
+        std::fs::set_permissions(src.join("file"), std::fs::Permissions::from_mode(0o755)).unwrap();
+        let (executable, hit) = build();
+        assert!(!hit);
+        assert_ne!(original.digest, executable.digest);
+        std::fs::remove_file(src.join("link")).unwrap();
+        symlink("elsewhere", src.join("link")).unwrap();
+        let (retargeted, hit) = build();
+        assert!(!hit);
+        assert_ne!(executable.digest, retargeted.digest);
+    }
+}

--- a/src/oci/layer/cache.rs
+++ b/src/oci/layer/cache.rs
@@ -27,8 +27,7 @@ pub(crate) fn build_cached_tool_layer(
     let entries = collect_sorted_entries(src_dir, false, owner, Some(relocation))?;
     let key = fingerprint(&entries, target_prefix, owner, relocation)?;
     let record_path = cache_dir.join(format!("{key}.json"));
-    let _lock = match crate::lock_file::LockFile::at(&cache_dir.join(format!("{key}.lock"))).lock()
-    {
+    let _lock = match crate::lock_file::LockFile::new(&record_path).lock() {
         Ok(lock) => lock,
         Err(err) => {
             debug!("could not lock OCI tool layer cache: {err:#}");
@@ -67,9 +66,9 @@ fn fingerprint(
     relocation: &ToolRelocation,
 ) -> Result<String> {
     let mut hash = Sha256::new();
-    // Bump the format when layer construction changes without a mise release.
+    // Bump the format whenever layer construction changes. Unrelated mise
+    // releases must not invalidate byte-identical tool layers.
     field(&mut hash, b"mise-oci-tool-layer-v1");
-    field(&mut hash, env!("CARGO_PKG_VERSION").as_bytes());
     field(&mut hash, std::env::consts::OS.as_bytes());
     field(&mut hash, std::env::consts::ARCH.as_bytes());
     field(&mut hash, prefix.as_bytes());
@@ -187,6 +186,13 @@ mod tests {
             || build_cached_tool_layer(&src, "mise/tool", owner, &relocation, &cache).unwrap();
         let (first, hit) = build();
         assert!(!hit);
+        assert!(std::fs::read_dir(&cache).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .path()
+                .extension()
+                .is_some_and(|ext| ext == "lock")
+        }));
         let (second, hit) = build();
         assert!(hit);
         assert_eq!(first.bytes, second.bytes);

--- a/src/oci/layer/cache.rs
+++ b/src/oci/layer/cache.rs
@@ -187,11 +187,11 @@ mod tests {
         let (first, hit) = build();
         assert!(!hit);
         assert!(std::fs::read_dir(&cache).unwrap().all(|entry| {
-            !entry
+            entry
                 .unwrap()
                 .path()
                 .extension()
-                .is_some_and(|ext| ext == "lock")
+                .is_none_or(|ext| ext != "lock")
         }));
         let (second, hit) = build();
         assert!(hit);

--- a/src/oci/layer/cache.rs
+++ b/src/oci/layer/cache.rs
@@ -47,10 +47,14 @@ pub(crate) fn build_cached_tool_layer(
     let blob = build_layer_from_entries(&entries, target_prefix, owner, Some(relocation))?;
     // Do not publish under the old key if the installation changed while we
     // were building. The next invocation will fingerprint its new contents.
-    let after = collect_sorted_entries(src_dir, false, owner, Some(relocation))?;
-    if fingerprint(&after, target_prefix, owner, relocation)? == key
-        && let Err(err) = write_cached_layer(&record_path, cache_dir, &blob)
-    {
+    let publish = || -> Result<()> {
+        let after = collect_sorted_entries(src_dir, false, owner, Some(relocation))?;
+        if fingerprint(&after, target_prefix, owner, relocation)? == key {
+            write_cached_layer(&record_path, cache_dir, &blob)?;
+        }
+        Ok(())
+    };
+    if let Err(err) = publish() {
         debug!("could not cache OCI tool layer: {err:#}");
     }
     Ok((blob, false))
@@ -126,9 +130,24 @@ fn read_cached_layer(record_path: &Path, cache_dir: &Path) -> Result<Option<Laye
     );
     let digest = format!("sha256:{}", hex_encode(&Sha256::digest(&bytes)));
     eyre::ensure!(digest == record.digest, "cached OCI layer digest mismatch");
+    let mut decoder = flate2::read::GzDecoder::new(bytes.as_slice());
+    let mut hash = Sha256::new();
+    let mut buffer = [0; 64 * 1024];
+    loop {
+        let n = decoder.read(&mut buffer)?;
+        if n == 0 {
+            break;
+        }
+        hash.update(&buffer[..n]);
+    }
+    let diff_id = format!("sha256:{}", hex_encode(&hash.finalize()));
+    eyre::ensure!(
+        diff_id == record.diff_id,
+        "cached OCI layer diff ID mismatch"
+    );
     Ok(Some(LayerBlob {
         digest,
-        diff_id: record.diff_id,
+        diff_id,
         size: record.size,
         bytes,
     }))
@@ -246,6 +265,40 @@ mod tests {
         assert!(build().1);
         std::fs::remove_file(blob_path).unwrap();
         assert!(!build().1);
+    }
+
+    #[test]
+    fn corrupt_diff_id_rebuilds_the_cached_layer() {
+        let td = tempfile::tempdir().unwrap();
+        let src = td.path().join("tool");
+        let cache = td.path().join("cache");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("file"), "content").unwrap();
+        let build = || {
+            build_cached_tool_layer(
+                &src,
+                "mise/tool",
+                LayerOwner::default(),
+                &ToolRelocation::default(),
+                &cache,
+            )
+            .unwrap()
+        };
+        let (first, _) = build();
+        let record_path = std::fs::read_dir(&cache)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .find(|path| path.extension().is_some_and(|ext| ext == "json"))
+            .unwrap();
+        let mut record: CachedLayer =
+            serde_json::from_slice(&std::fs::read(&record_path).unwrap()).unwrap();
+        record.diff_id = format!("sha256:{}", "0".repeat(64));
+        std::fs::write(record_path, serde_json::to_vec(&record).unwrap()).unwrap();
+        let (rebuilt, hit) = build();
+        assert!(!hit);
+        assert_eq!(rebuilt.diff_id, first.diff_id);
+        assert_eq!(rebuilt.bytes, first.bytes);
+        assert!(build().1);
     }
 
     #[test]


### PR DESCRIPTION
Building several images with overlapping tools currently tars and gzips each tool for every image, even when the installations are unchanged. `oci build`, `oci run`, and `oci push` now share a local tool-layer cache, so separate output layouts and first-time pushes can reuse packaged tool bytes.

The cache hashes the actual packaged inputs: file contents, paths, executable permissions, symlink targets, ownership, and relocated contents. Hits still read and hash the installation but skip tar construction and gzip compression. Same-version edits and reinstalls are detected without trusting timestamps. Per-entry locks prevent concurrent builds from packaging identical inputs twice; atomic publication and blob verification allow recovery from interrupted or corrupt cache writes.

Local layouts remain complete. `oci build --no-cache` bypasses the cache, and push's existing `--no-cache` bypasses both local and remote tool caches. Entries live in each tool's normal mise cache and are removed by `mise cache clear TOOL`.

Stacked on #13055; together they address [discussion #13054](https://github.com/jdx/mise/discussions/13054).

Validation: all 84 OCI unit tests; local-cache, real-registry push, and remote-layer-reuse end-to-end tests; workspace/all-features/all-targets Clippy with `-D warnings`; `mise run lint-fix`. CLI documentation, usage, completions, and man page regenerated.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OCI image byte production and caching semantics (including push `--no-cache` behavior), but fingerprints and blob validation limit stale-layer risk; install locking reduces race failures during concurrent installs.
> 
> **Overview**
> Adds a **shared local cache** for OCI tool layers so `oci build`, `oci run`, and `oci push` can reuse tar/gzip work across different output layouts and registry destinations when installations are unchanged. Cache keys fingerprint packaged inputs (paths, file bytes including relocated shebangs, modes, symlinks, ownership, mount prefix)—not mtimes— with per-entry locking, atomic writes, and verification so concurrent builds and corrupt entries recover safely.
> 
> **CLI:** `mise oci build` gains **`--no-cache`**; **`oci push --no-cache`** now skips **both** remote registry reuse and the local cache (docs/help updated). **`mise cache clear`** clears entries under each tool’s `oci-layers` cache dir.
> 
> **Build pipeline:** Non-remote tool layers call `build_cached_tool_layer` unless bypassed; install-path checks use tool install locks so same-version reinstalls don’t race packaging. E2E covers reuse, `--no-cache`, content invalidation, cache clear, and push to a fresh repo using locally cached layers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bca6dbcb56a7c4135d967e9eac0d228de824e378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added local OCI tool-layer caching for `oci build`, `oci run`, and `oci push`, including cache reuse, validation, invalidation, and concurrency support.
  - Added `--no-cache` to `mise oci build` to bypass local layer caching.
  - Updated `mise oci push --no-cache` to bypass both remote and local layer caches.

- **Documentation**
  - Documented cache behavior, invalidation, storage, concurrency, and cache-clearing commands.

- **Tests**
  - Added coverage for cache reuse, invalidation, corruption recovery, concurrency, and registry pushes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->