### PR TITLE
feat(fmt): sort lists whose order carries no meaning

### DIFF
--- a/docs/cli/fmt.md
+++ b/docs/cli/fmt.md
@@ -12,9 +12,13 @@ description: "Format mise TOML configuration"
 Format mise TOML configuration
 
 Sorts keys and normalizes whitespace using TOML 1.1 syntax, including multiline
-inline tables. By default, formats config files in the current directory;
-`--all` includes every loaded config. Use `--check` in CI or `--stdin` to format
-a supplied document without rewriting a file.
+inline tables. Lists whose order carries no meaning are sorted as well: task
+`sources` and `outputs`, `task_config.global_inputs` and `input_groups`, and
+`redactions`. File pattern lists sort by reach — `@group:` references, then
+globs, then literal paths — and a list is left as written when an entry
+excludes with `!` or carries a comment. By default, formats config files in
+the current directory; `--all` includes every loaded config. Use `--check`
+in CI or `--stdin` to format a supplied document without rewriting a file.
 
 ## Flags
 - **`-a --all`** — Format every config file mise currently loads, not just those in the current directory

--- a/e2e/cli/test_fmt
+++ b/e2e/cli/test_fmt
@@ -20,3 +20,34 @@ idiomatic_version_file_enable_tools = ["go", "ruby"]
 
 [env]
 TEST = "Hello World!"'
+
+# Lists whose order carries no meaning are sorted; file patterns sort by reach
+# (groups, globs, then literal paths), and a list that excludes with `!` keeps
+# its order.
+echo 'redactions = ["TOKEN", "API_KEY"]
+
+[task_config]
+global_inputs = ["mise.toml", "@group:lockfiles"]
+
+[task_config.input_groups]
+lockfiles = ["pnpm-lock.yaml", "Cargo.lock"]
+
+[tasks.build]
+sources = ["src/main.rs", "Cargo.toml", "@group:rust", "src/**/*.rs"]
+outputs = ["dist", "!dist/**/*.map"]
+' >mise.toml
+assert_fail "mise fmt --check" "mise ERROR Following config files are not properly formatted"
+
+mise fmt
+assert "mise fmt --check"
+assert "cat mise.toml" 'redactions = ["API_KEY", "TOKEN"]
+
+[task_config]
+global_inputs = ["@group:lockfiles", "mise.toml"]
+
+[task_config.input_groups]
+lockfiles = ["Cargo.lock", "pnpm-lock.yaml"]
+
+[tasks.build]
+sources = ["@group:rust", "src/**/*.rs", "Cargo.toml", "src/main.rs"]
+outputs = ["dist", "!dist/**/*.map"]'

--- a/man/man1/mise.1
+++ b/man/man1/mise.1
@@ -3854,9 +3854,13 @@ mise x \-C /path/to/project node@20 \-\- node ./app.js
 Format mise TOML configuration
 
 Sorts keys and normalizes whitespace using TOML 1.1 syntax, including multiline
-inline tables. By default, formats config files in the current directory;
-`\-\-all` includes every loaded config. Use `\-\-check` in CI or `\-\-stdin` to format
-a supplied document without rewriting a file.
+inline tables. Lists whose order carries no meaning are sorted as well: task
+`sources` and `outputs`, `task_config.global_inputs` and `input_groups`, and
+`redactions`. File pattern lists sort by reach — `@group:` references, then
+globs, then literal paths — and a list is left as written when an entry
+excludes with `!` or carries a comment. By default, formats config files in
+the current directory; `\-\-all` includes every loaded config. Use `\-\-check`
+in CI or `\-\-stdin` to format a supplied document without rewriting a file.
 .PP
 \fBUsage:\fR mise fmt [OPTIONS]
 .PP

--- a/mise.usage.kdl
+++ b/mise.usage.kdl
@@ -2448,9 +2448,13 @@ cmd fmt help="Format mise TOML configuration" effect=write {
 Format mise TOML configuration
 
 Sorts keys and normalizes whitespace using TOML 1.1 syntax, including multiline
-inline tables. By default, formats config files in the current directory;
-`--all` includes every loaded config. Use `--check` in CI or `--stdin` to format
-a supplied document without rewriting a file.
+inline tables. Lists whose order carries no meaning are sorted as well: task
+`sources` and `outputs`, `task_config.global_inputs` and `input_groups`, and
+`redactions`. File pattern lists sort by reach — `@group:` references, then
+globs, then literal paths — and a list is left as written when an entry
+excludes with `!` or carries a comment. By default, formats config files in
+the current directory; `--all` includes every loaded config. Use `--check`
+in CI or `--stdin` to format a supplied document without rewriting a file.
 """#
     flag "-a --all" help="Format every config file mise currently loads, not just those in the current directory"
     flag "-c --check" help="Check whether the configs are formatted without rewriting them; exits 1 if any are not"

--- a/src/cli/fmt.rs
+++ b/src/cli/fmt.rs
@@ -244,10 +244,17 @@ fn is_sortable(array: &Array, order: SetOrder) -> bool {
 /// every entry around it meaningful: `sources` and `outputs` are evaluated in
 /// order and the last matching entry wins.
 ///
-/// `\!` escapes a literal `!` and so does not exclude, but a template can
-/// render into either and is treated as if it excludes.
+/// Exclusion is decided on the rendered entry, by the leading `!` that
+/// [`crate::task::task_source_checker::source_glob_patterns`] looks for, so
+/// only what comes first matters. `\!` escapes a literal `!` and does not
+/// exclude. An entry that *opens* with a template tag can render into either
+/// and is treated as if it excludes; one that opens with a literal still
+/// begins with that literal once rendered, so an embedded tag cannot turn it
+/// into an exclusion. Whitespace-control tags (`{{-`) strip what precedes
+/// them, so the leading whitespace is trimmed before the tag is looked for.
 fn may_exclude(entry: &str) -> bool {
-    entry.starts_with('!') || entry.starts_with("{{") || entry.starts_with("{%")
+    let head = entry.trim_start();
+    head.starts_with('!') || head.starts_with("{{") || head.starts_with("{%")
 }
 
 /// Whether a span of decor holds a comment rather than only whitespace.
@@ -376,6 +383,36 @@ outputs = ["target/debug/b", "target/debug/a"]
         );
         assert!(
             toml.contains(r#"outputs = ["target/debug/a", "target/debug/b"]"#),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn sorts_sources_whose_template_cannot_open_the_entry() {
+        // A literal prefix survives rendering, so an embedded tag can never
+        // turn the entry into an exclusion and the list stays a set.
+        let toml = fmt(r#"
+[tasks.build]
+sources = ["src/b.rs", "src/{{ vars.dir }}/**", "Cargo.toml"]
+"#);
+
+        assert!(
+            toml.contains(r#"sources = ["src/{{ vars.dir }}/**", "Cargo.toml", "src/b.rs"]"#),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn keeps_the_order_of_sources_opening_with_a_whitespace_control_tag() {
+        // `{{-` strips what precedes it, so this renders to whatever the tag
+        // yields and could still begin with `!`.
+        let toml = fmt(r#"
+[tasks.build]
+sources = [" {{- vars.pattern }}", "Cargo.toml"]
+"#);
+
+        assert!(
+            toml.contains(r#"sources = [" {{- vars.pattern }}", "Cargo.toml"]"#),
             "{toml}"
         );
     }

--- a/src/cli/fmt.rs
+++ b/src/cli/fmt.rs
@@ -95,6 +95,8 @@ impl Fmt {
     }
 }
 
+/// Put the document's top-level keys and its unordered lists into a canonical
+/// order. Whitespace and layout are left to [`format`].
 fn sort(toml: String) -> Result<String> {
     let mut doc: DocumentMut = toml.parse()?;
     let order = |k: String| match k.as_str() {
@@ -157,6 +159,7 @@ enum SetOrder {
     FilePatterns,
 }
 
+/// Put every array named in [`UNORDERED_SETS`] into its canonical order.
 fn sort_unordered_sets(doc: &mut DocumentMut) {
     for (path, order) in UNORDERED_SETS {
         visit_arrays(doc.as_table_mut(), path, &mut |array| {
@@ -187,6 +190,8 @@ fn visit_arrays(table: &mut dyn TableLike, path: &[&str], visit: &mut impl FnMut
     }
 }
 
+/// Sort one array, leaving it as written when reordering could change what
+/// it means.
 fn sort_set(array: &mut Array, order: SetOrder) {
     if !is_sortable(array, order) {
         return;
@@ -194,6 +199,8 @@ fn sort_set(array: &mut Array, order: SetOrder) {
     array.sort_by(|a, b| sort_key(a, order).cmp(&sort_key(b, order)));
 }
 
+/// Where `value` sorts: its rank first, then the entry itself to break ties
+/// within a rank.
 fn sort_key(value: &Value, order: SetOrder) -> (u8, &str) {
     let entry = value.as_str().unwrap_or_default();
     match order {
@@ -216,10 +223,14 @@ fn pattern_rank(entry: &str) -> u8 {
 /// Whether reordering `array` is guaranteed to preserve its meaning.
 ///
 /// Entries that are not plain strings are left alone because their order may
-/// carry meaning this function cannot see, and so is an entry carrying a
-/// comment: once entries move, there is no way to tell which one a comment
-/// was written about.
+/// carry meaning this function cannot see. A comment blocks the sort for the
+/// same reason: once entries move there is no way to tell which one it was
+/// written about. A comment that follows the last entry lives in the array's
+/// trailing decor rather than on a value, so it is checked separately.
 fn is_sortable(array: &Array, order: SetOrder) -> bool {
+    if has_comment(Some(array.trailing())) {
+        return false;
+    }
     array.iter().all(|value| {
         value.as_str().is_some_and(|entry| match order {
             SetOrder::Lexical => true,
@@ -239,6 +250,7 @@ fn may_exclude(entry: &str) -> bool {
     entry.starts_with('!') || entry.starts_with("{{") || entry.starts_with("{%")
 }
 
+/// Whether a span of decor holds a comment rather than only whitespace.
 fn has_comment(raw: Option<&RawString>) -> bool {
     raw.and_then(RawString::as_str)
         .is_some_and(|decor| decor.contains('#'))
@@ -446,6 +458,37 @@ sources = ["{{ arg(name = 'src') }}", "Cargo.toml"]
 sources = [
   "src/b.rs", # this comment must not end up describing another entry
   "src/a.rs",
+]
+"#);
+
+        let b = toml.find("src/b.rs").unwrap();
+        let a = toml.find("src/a.rs").unwrap();
+        assert!(b < a, "entries moved out from under a comment:\n{toml}");
+    }
+
+    #[test]
+    fn keeps_the_order_of_a_set_whose_last_entry_carries_a_comment() {
+        let toml = fmt(r#"
+[tasks.build]
+sources = [
+  "src/b.rs",
+  "src/a.rs", # this comment must not end up describing another entry
+]
+"#);
+
+        let b = toml.find("src/b.rs").unwrap();
+        let a = toml.find("src/a.rs").unwrap();
+        assert!(b < a, "entries moved out from under a comment:\n{toml}");
+    }
+
+    #[test]
+    fn keeps_the_order_of_a_set_followed_by_a_dangling_comment() {
+        let toml = fmt(r#"
+[tasks.build]
+sources = [
+  "src/b.rs",
+  "src/a.rs",
+  # a note about the list, or about the entry above it
 ]
 "#);
 

--- a/src/cli/fmt.rs
+++ b/src/cli/fmt.rs
@@ -1,16 +1,21 @@
 use crate::Result;
-use crate::config::ALL_TOML_CONFIG_FILES;
+use crate::config::{ALL_TOML_CONFIG_FILES, TASK_INPUT_GROUP_PREFIX, is_glob_pattern};
 use crate::{config, dirs, file};
 use eyre::bail;
 use std::io::{self, Read, Write};
 use taplo::formatter::Options;
+use toml_edit::{Array, DocumentMut, RawString, TableLike, Value};
 
 /// Format mise TOML configuration
 ///
 /// Sorts keys and normalizes whitespace using TOML 1.1 syntax, including multiline
-/// inline tables. By default, formats config files in the current directory;
-/// `--all` includes every loaded config. Use `--check` in CI or `--stdin` to format
-/// a supplied document without rewriting a file.
+/// inline tables. Lists whose order carries no meaning are sorted as well: task
+/// `sources` and `outputs`, `task_config.global_inputs` and `input_groups`, and
+/// `redactions`. File pattern lists sort by reach — `@group:` references, then
+/// globs, then literal paths — and a list is left as written when an entry
+/// excludes with `!` or carries a comment. By default, formats config files in
+/// the current directory; `--all` includes every loaded config. Use `--check`
+/// in CI or `--stdin` to format a supplied document without rewriting a file.
 #[derive(Debug, usage_rs::Args)]
 #[usage(
     verbatim_doc_comment,
@@ -91,7 +96,7 @@ impl Fmt {
 }
 
 fn sort(toml: String) -> Result<String> {
-    let mut doc: toml_edit::DocumentMut = toml.parse()?;
+    let mut doc: DocumentMut = toml.parse()?;
     let order = |k: String| match k.as_str() {
         "min_version" => 0,
         "env_file" => 1,
@@ -111,7 +116,132 @@ fn sort(toml: String) -> Result<String> {
         _ => 9,
     };
     doc.sort_values_by(|a, _, b, _| order(a.to_string()).cmp(&order(b.to_string())));
+    sort_unordered_sets(&mut doc);
     Ok(doc.to_string())
+}
+
+/// Arrays whose entries form a set: reordering them cannot change what mise
+/// does, so `mise fmt` can put them in a canonical order.
+///
+/// Paths are matched key by key from the document root, and `*` matches any
+/// single key. Order-sensitive lists are deliberately absent: `env_file`,
+/// `env_path`, and the `_.path`/`_.source` directives establish precedence,
+/// `tools.*` treats the first version as the primary one,
+/// `task_config.includes` fixes task discovery order, and
+/// `depends`/`depends_post`/`wait_for` are often grouped by hand.
+///
+/// `mise fmt` only ever sees whole config files, so tasks are always nested
+/// under `tasks`; a standalone task TOML file listed in
+/// `task_config.includes` is not formatted and needs no path of its own.
+const UNORDERED_SETS: &[(&[&str], SetOrder)] = &[
+    (&["redactions"], SetOrder::Lexical),
+    (&["task_config", "global_inputs"], SetOrder::FilePatterns),
+    (
+        &["task_config", "input_groups", "*"],
+        SetOrder::FilePatterns,
+    ),
+    (&["tasks", "*", "sources"], SetOrder::FilePatterns),
+    (&["tasks", "*", "outputs"], SetOrder::FilePatterns),
+    (&["task_templates", "*", "sources"], SetOrder::FilePatterns),
+    (&["task_templates", "*", "outputs"], SetOrder::FilePatterns),
+];
+
+#[derive(Clone, Copy)]
+enum SetOrder {
+    /// Sort entries lexically.
+    Lexical,
+    /// Sort by how broadly an entry reaches — `@group:` references, then
+    /// globs, then the literal paths those globs broaden — and lexically
+    /// within each rank. Reading a list top to bottom then narrows from the
+    /// inputs a task inherits down to the individual files it names.
+    FilePatterns,
+}
+
+fn sort_unordered_sets(doc: &mut DocumentMut) {
+    for (path, order) in UNORDERED_SETS {
+        visit_arrays(doc.as_table_mut(), path, &mut |array| {
+            sort_set(array, *order);
+        });
+    }
+}
+
+/// Call `visit` on every array the document holds at `path`, where a `*`
+/// segment matches any key. Tables and inline tables are both walked, so a
+/// task written as `[tasks.build]`, as `build = { .. }`, or with dotted keys
+/// is reached the same way.
+fn visit_arrays(table: &mut dyn TableLike, path: &[&str], visit: &mut impl FnMut(&mut Array)) {
+    let Some((segment, rest)) = path.split_first() else {
+        return;
+    };
+    for (key, item) in table.iter_mut() {
+        if *segment != "*" && key.get() != *segment {
+            continue;
+        }
+        if rest.is_empty() {
+            if let Some(array) = item.as_array_mut() {
+                visit(array);
+            }
+        } else if let Some(child) = item.as_table_like_mut() {
+            visit_arrays(child, rest, visit);
+        }
+    }
+}
+
+fn sort_set(array: &mut Array, order: SetOrder) {
+    if !is_sortable(array, order) {
+        return;
+    }
+    array.sort_by(|a, b| sort_key(a, order).cmp(&sort_key(b, order)));
+}
+
+fn sort_key(value: &Value, order: SetOrder) -> (u8, &str) {
+    let entry = value.as_str().unwrap_or_default();
+    match order {
+        SetOrder::Lexical => (0, entry),
+        SetOrder::FilePatterns => (pattern_rank(entry), entry),
+    }
+}
+
+/// How broadly a file pattern reaches, lowest first.
+fn pattern_rank(entry: &str) -> u8 {
+    if entry.starts_with(TASK_INPUT_GROUP_PREFIX) {
+        0
+    } else if is_glob_pattern(entry) {
+        1
+    } else {
+        2
+    }
+}
+
+/// Whether reordering `array` is guaranteed to preserve its meaning.
+///
+/// Entries that are not plain strings are left alone because their order may
+/// carry meaning this function cannot see, and so is an entry carrying a
+/// comment: once entries move, there is no way to tell which one a comment
+/// was written about.
+fn is_sortable(array: &Array, order: SetOrder) -> bool {
+    array.iter().all(|value| {
+        value.as_str().is_some_and(|entry| match order {
+            SetOrder::Lexical => true,
+            SetOrder::FilePatterns => !may_exclude(entry),
+        }) && !has_comment(value.decor().prefix())
+            && !has_comment(value.decor().suffix())
+    })
+}
+
+/// Whether `entry` excludes the files it matches, which makes the position of
+/// every entry around it meaningful: `sources` and `outputs` are evaluated in
+/// order and the last matching entry wins.
+///
+/// `\!` escapes a literal `!` and so does not exclude, but a template can
+/// render into either and is treated as if it excludes.
+fn may_exclude(entry: &str) -> bool {
+    entry.starts_with('!') || entry.starts_with("{{") || entry.starts_with("{%")
+}
+
+fn has_comment(raw: Option<&RawString>) -> bool {
+    raw.and_then(RawString::as_str)
+        .is_some_and(|decor| decor.contains('#'))
 }
 
 fn format(toml: String) -> Result<String> {
@@ -142,4 +272,245 @@ fn format(toml: String) -> Result<String> {
     );
 
     Ok(tmp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Run the same pipeline `mise fmt` writes back to a config file.
+    fn fmt(toml: &str) -> String {
+        format(sort(toml.to_string()).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn sorts_groups_then_globs_then_literal_paths() {
+        let toml = fmt(r#"
+[tasks.build]
+sources = ["Cargo.toml", "src/**/*.rs", "@group:rust", "@group:lock"]
+"#);
+
+        assert!(
+            toml.contains(
+                r#"sources = ["@group:lock", "@group:rust", "src/**/*.rs", "Cargo.toml"]"#
+            ),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn ranks_every_glob_metacharacter_ahead_of_a_literal_path() {
+        let toml = fmt(r#"
+[tasks.build]
+sources = ["a.rs", "b?.rs", "c[0-9].rs", "d{x,y}.rs", "e*.rs"]
+"#);
+
+        assert!(
+            toml.contains(r#""b?.rs", "c[0-9].rs", "d{x,y}.rs", "e*.rs", "a.rs""#),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn sorts_the_task_input_sets_outside_tasks() {
+        let toml = fmt(r#"
+redactions = ["TOKEN", "API_KEY"]
+
+[task_config]
+global_inputs = ["mise.toml", "@group:lockfiles", ".tool-versions"]
+
+[task_config.input_groups]
+lockfiles = ["pnpm-lock.yaml", "Cargo.lock"]
+"#);
+
+        assert!(
+            toml.contains(r#"redactions = ["API_KEY", "TOKEN"]"#),
+            "{toml}"
+        );
+        assert!(
+            toml.contains(r#"global_inputs = ["@group:lockfiles", ".tool-versions", "mise.toml"]"#),
+            "{toml}"
+        );
+        assert!(
+            toml.contains(r#"lockfiles = ["Cargo.lock", "pnpm-lock.yaml"]"#),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn sorts_a_task_written_as_an_inline_table() {
+        let toml = fmt(r#"
+[tasks]
+build = { run = "cargo build", sources = ["src/b.rs", "src/a.rs"] }
+"#);
+
+        assert!(
+            toml.contains(r#"sources = ["src/a.rs", "src/b.rs"]"#),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn sorts_a_task_template() {
+        let toml = fmt(r#"
+[task_templates.rust]
+sources = ["Cargo.toml", "src/**/*.rs"]
+outputs = ["target/debug/b", "target/debug/a"]
+"#);
+
+        assert!(
+            toml.contains(r#"sources = ["src/**/*.rs", "Cargo.toml"]"#),
+            "{toml}"
+        );
+        assert!(
+            toml.contains(r#"outputs = ["target/debug/a", "target/debug/b"]"#),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn sorts_sources_that_escape_a_literal_exclamation_mark() {
+        let toml = fmt(r#"
+[tasks.build]
+sources = ["src/b.rs", "\\!important.txt"]
+"#);
+
+        assert!(
+            toml.contains(r#"sources = ["\\!important.txt", "src/b.rs"]"#),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn formatting_a_sorted_set_again_changes_nothing() {
+        let once = fmt(r#"
+redactions = ["TOKEN", "API_KEY"]
+
+[task_config]
+global_inputs = ["mise.toml", "@group:lockfiles"]
+
+[task_config.input_groups]
+lockfiles = ["pnpm-lock.yaml", "Cargo.lock"]
+
+[tasks.build]
+outputs = ["dist/bundle.js", "dist/bundle.css"]
+sources = ["src/b.ts", "@group:lockfiles", "src/**/*.ts", "src/a.ts"]
+"#);
+
+        assert_eq!(fmt(&once), once);
+    }
+
+    #[test]
+    fn keeps_the_order_of_sources_that_exclude() {
+        let toml = fmt(r#"
+[tasks.build]
+sources = ["src/**/*.ts", "!src/**/*.test.ts", "src/keep.test.ts"]
+"#);
+
+        assert!(
+            toml.contains(r#"sources = ["src/**/*.ts", "!src/**/*.test.ts", "src/keep.test.ts"]"#),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn keeps_the_order_of_outputs_that_exclude() {
+        let toml = fmt(r#"
+[tasks.build]
+outputs = ["dist", "!dist/**/*.map"]
+"#);
+
+        assert!(
+            toml.contains(r#"outputs = ["dist", "!dist/**/*.map"]"#),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn keeps_the_order_of_sources_that_start_with_a_template() {
+        let toml = fmt(r#"
+[tasks.build]
+sources = ["{{ arg(name = 'src') }}", "Cargo.toml"]
+"#);
+
+        assert!(
+            toml.contains(r#"sources = ["{{ arg(name = 'src') }}", "Cargo.toml"]"#),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn keeps_the_order_of_a_set_that_carries_a_comment() {
+        let toml = fmt(r#"
+[tasks.build]
+sources = [
+  "src/b.rs", # this comment must not end up describing another entry
+  "src/a.rs",
+]
+"#);
+
+        let b = toml.find("src/b.rs").unwrap();
+        let a = toml.find("src/a.rs").unwrap();
+        assert!(b < a, "entries moved out from under a comment:\n{toml}");
+    }
+
+    #[test]
+    fn keeps_the_order_of_lists_whose_order_has_meaning() {
+        let toml = fmt(r#"
+env_file = [".env.local", ".env"]
+
+[env]
+_.path = ["./node_modules/.bin", "./bin"]
+
+[tools]
+node = ["22", "20"]
+
+[tasks.build]
+depends = ["render", "build:deps"]
+"#);
+
+        assert!(
+            toml.contains(r#"env_file = [".env.local", ".env"]"#),
+            "{toml}"
+        );
+        assert!(
+            toml.contains(r#"_.path = ["./node_modules/.bin", "./bin"]"#),
+            "{toml}"
+        );
+        assert!(toml.contains(r#"node = ["22", "20"]"#), "{toml}");
+        assert!(
+            toml.contains(r#"depends = ["render", "build:deps"]"#),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn keeps_an_outputs_table_intact() {
+        let toml = fmt(r#"
+[tasks.build]
+outputs = { auto = true }
+sources = ["src/b.rs", "src/a.rs"]
+"#);
+
+        assert!(toml.contains("auto = true"), "{toml}");
+        assert!(
+            toml.contains(r#"sources = ["src/a.rs", "src/b.rs"]"#),
+            "{toml}"
+        );
+    }
+
+    #[test]
+    fn sorts_the_sources_of_a_task_named_after_a_sorted_key() {
+        let toml = fmt(r#"
+[tasks.sources]
+depends = ["b", "a"]
+sources = ["src/b.rs", "src/a.rs"]
+"#);
+
+        assert!(toml.contains(r#"depends = ["b", "a"]"#), "{toml}");
+        assert!(
+            toml.contains(r#"sources = ["src/a.rs", "src/b.rs"]"#),
+            "{toml}"
+        );
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3625,7 +3625,9 @@ impl ResolvedTaskEnvironment {
     }
 }
 
-const TASK_INPUT_GROUP_PREFIX: &str = "@group:";
+/// Prefix that marks a `sources` or `global_inputs` entry as a reference to a
+/// named input group rather than a file pattern.
+pub(crate) const TASK_INPUT_GROUP_PREFIX: &str = "@group:";
 
 #[derive(Clone, Debug, Default)]
 struct ResolvedTaskInputs {
@@ -5133,7 +5135,7 @@ async fn resolve_git_url_to_path(git_url: &str) -> Result<TaskFileArtifact> {
 }
 
 /// Check if a pattern contains glob metacharacters
-fn is_glob_pattern(pattern: &str) -> bool {
+pub(crate) fn is_glob_pattern(pattern: &str) -> bool {
     // Check for unescaped glob metacharacters: *, ?, [, ], {, }
     // Note: This is a simple check that may have false positives with escaped chars,
     // but glob() will handle those correctly


### PR DESCRIPTION
`mise fmt` leaves every array as written, so lists that are really sets drift into whatever order entries were appended in. This sorts them into a canonical order.

## What gets sorted

| Path | Order |
| --- | --- |
| `tasks.*.sources`, `tasks.*.outputs` | by reach |
| `task_templates.*.sources`, `task_templates.*.outputs` | by reach |
| `task_config.global_inputs`, `task_config.input_groups.*` | by reach |
| `redactions` | lexical |

"By reach" means `@group:` references, then globs, then the literal paths those globs broaden, sorting lexically within each rank. Reading a list top to bottom then narrows from the inputs a task inherits down to the individual files it names:

```toml
[tasks.build]
sources = ["@group:rust", "src/**/*.rs", "Cargo.toml", "build.rs"]
```

Glob detection reuses `config::is_glob_pattern` rather than growing a second definition of what a glob is.

## What is deliberately left alone

Only lists whose order provably carries no meaning are touched. `env_file`, `env_path` and the `_.path`/`_.source` directives establish precedence; `tools.*` treats the first version as the primary one; `task_config.includes` fixes task discovery order; and `depends`/`depends_post`/`wait_for` are often grouped by hand. None of them are sorted.

Two guards protect the lists that *are* in scope:

- **Exclusions.** The docs are explicit that `sources` and `outputs` entries "are evaluated in order, and the latest matching entry wins", so a `!` entry makes every neighbour's position meaningful. A list is left exactly as written when any entry starts with `!`, matching mise's own `starts_with('!')` test — `\!` escapes a literal `!` and does not block the sort. An entry that *starts* with template syntax is treated the same way, since it can render into either.
- **Comments.** Once entries move there is no way to tell which one a comment was written about, so an entry carrying a comment blocks the sort for that list.

The sort is a total order and stable, so it is idempotent and `--check` is stable. Duplicates are preserved rather than deduplicated, which would be a semantic change.

Input groups are still experimental; sorting a `@group:` entry is inert without the flag, so this needs no experimental gate of its own.

## Testing

- 14 unit tests in `src/cli/fmt.rs` covering each rank, every glob metacharacter, inline-table and dotted-key tasks, `outputs = { auto = true }`, idempotence, and each guard.
- `e2e/cli/test_fmt` extended with a config exercising all four sorted paths plus an excluding `outputs`.
- `mise run render` produces no diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mise fmt` now sorts order-insensitive lists, including redactions, task inputs, input groups, sources, and outputs.
  * File-pattern lists are ordered by reach: groups, globs, then literal paths.
  * Lists containing exclusions, comments, or dynamic patterns retain their original order.

* **Documentation**
  * Updated CLI help, manual pages, and documentation to explain the new formatting behavior and exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->