### PR TITLE
fix(http): make shared extraction opt-in

### DIFF
--- a/docs/dev-tools/backends/http.md
+++ b/docs/dev-tools/backends/http.md
@@ -526,23 +526,57 @@ bin_path = "bin"
 3. If no `bin/` directory exists, search subdirectories for `bin/` directories
 4. If no `bin/` directories are found, use the root of the extracted directory
 
-## Caching Behavior
+### `shared_extraction`
 
-The HTTP backend caches downloads to save disk space and speed up installation:
+By default, each HTTP installation contains its own extracted files. Set
+`shared_extraction = true` to share extracted content between normal user
+installations with identical artifacts and extraction options:
+
+```toml
+[tools."http:my-tool"]
+version = "1.0.0"
+url = "https://example.com/releases/my-tool-v1.0.0.tar.gz"
+shared_extraction = true
+```
+
+Sharing saves disk space when several tools use the same artifact and avoids
+repeated extraction. A download may still be needed to identify its content.
+Changes made to shared files, including by a `postinstall` hook, affect every
+installation using that entry.
+
+Explicit `mise install --system`, `mise install --shared`, and `mise
+install-into` destinations always contain their own files, even with this
+option enabled.
+
+## Installation and Cleanup
+
+New HTTP installations contain their files directly in the installation
+directory, like other tools. `mise uninstall` and `mise prune` remove those
+files when they remove the version. Multiple installations of the same artifact
+have separate copies.
+
+Existing installations that link into `http-tarballs` continue to work. To
+replace one with an independent installation, reinstall it with `mise install
+--force <tool>` without `shared_extraction = true`. Changing the option alone
+does not replace an already installed version.
+
+::: warning Shared extraction storage
+Legacy installations and tools using `shared_extraction = true` depend on files
+in `$MISE_DATA_DIR/http-tarballs/`. Neither `mise prune` nor `mise cache prune`
+automatically reclaims these entries after uninstalling a tool. Reinstalling
+also leaves existing entries intact because other installations may use them.
+Do not delete this directory while any installation still depends on it.
+:::
+
+## Caching Behavior
 
 ### Cache Location
 
-For normal user installations, downloaded and extracted files are cached in
-`$MISE_DATA_DIR/http-tarballs/` instead of being stored separately for each tool
-installation. By default:
+With `shared_extraction = true`, extracted files are stored in
+`$MISE_DATA_DIR/http-tarballs/` instead of separately in each installation:
 
 - **Linux**: `~/.local/share/mise/http-tarballs/`
 - **macOS**: `~/.local/share/mise/http-tarballs/`
-
-Explicit `mise install --system`, `mise install --shared`, and `mise
-install-into` installations are extracted directly into their destination.
-They do not use this persistent extraction cache, so the resulting installation
-is self-contained and does not link to the installing user's home directory.
 
 ### Cache Key Generation
 
@@ -565,22 +599,14 @@ Example cache directory structure:
 
 ### Symlinked Installations
 
-Normal user installations are symlinks to the cached extracted content:
+Installations opting into sharing link to the cached extracted content:
 
 ```bash
 ~/.local/share/mise/installs/http-my-tool/1.0.0 → ~/.local/share/mise/http-tarballs/71f774...
 ```
 
-This approach provides several benefits:
-
-- **Space efficiency**: Normal user installs share identical tarballs across tools
-- **Faster installations**: Reusing extracted content avoids repeated extraction; a download may still be needed to identify its content
-- **Consistency**: The same file and extraction options reuse the same cached content
-
-System, shared, and install-into destinations contain real files rather than
-these symlinks. This avoids leaving hidden cache entries behind after an
-uninstall and keeps shared installations independent of a specific user's data
-directory.
+For a raw file with `bin_path`, the link is inside the installation directory.
+For this layout, Windows copies the file instead of symlinking it.
 
 ### Cache Metadata
 
@@ -598,10 +624,9 @@ Each cache entry includes a `metadata.json` file with information about the cach
 
 ### Cache Management
 
-Normal HTTP installations store their cache in
-`$MISE_DATA_DIR/http-tarballs/`. It is intentionally outside `MISE_CACHE_DIR`,
+Shared extraction storage is intentionally outside `MISE_CACHE_DIR`,
 so `mise cache clear` does not remove content that installed symlinks still
 reference.
 
-System, shared, and install-into destinations do not create a persistent HTTP
-extraction cache.
+Default installations and explicit system, shared, and install-into destinations
+do not create persistent HTTP extraction entries.

--- a/docs/dev-tools/backends/http.md
+++ b/docs/dev-tools/backends/http.md
@@ -583,7 +583,7 @@ With `shared_extraction = true`, extracted files are stored in
 Cache keys are derived from the file content so that identical downloads are shared across tools:
 
 1. **File content**: mise calculates a Blake3 hash of the downloaded file, independently of its expected verification checksum.
-2. **Extraction options**: options that change the extracted result, including root stripping, renaming, and relevant format or launcher choices, also affect the key.
+2. **Extraction options**: options that change the extracted result, including the effective filename for raw and compressed binaries, root stripping, renaming, and relevant format or launcher choices, also affect the key.
 
 Example cache directory structure:
 

--- a/e2e-win/backend/http_raw_bin_path.Tests.ps1
+++ b/e2e-win/backend/http_raw_bin_path.Tests.ps1
@@ -1,12 +1,10 @@
 Describe 'backend_http_raw_bin_path' {
-    # A raw binary declared with `bin_path` is the one shape of `http:` install
+    # A raw binary opting into shared extraction with `bin_path` is the shape
     # that `create_install_symlink` links file-to-file. On Windows that used to
     # go through `junction::create`, which builds a *directory* reparse point:
     # it succeeds, and leaves a link that cannot be resolved.
     #
-    # `http_binary_clean.Tests.ps1` covers the same binary without `bin_path`,
-    # which takes the other branch and links the install directory instead - so
-    # the broken combination was the one thing untested here.
+    # `http_binary_clean.Tests.ps1` covers the default independent installation.
     #
     # `bin` is set so the installed filename is decided outright rather than by
     # the name-cleaning heuristics, which keeps a failure here pointing at the
@@ -26,7 +24,7 @@ Describe 'backend_http_raw_bin_path' {
 
         @"
 [tools]
-"http:docker-compose-binpath" = { version = "2.29.1", url = "https://github.com/docker/compose/releases/download/v{version}/docker-compose-windows-x86_64.exe", bin = "docker-compose.exe", bin_path = "bin" }
+"http:docker-compose-binpath" = { version = "2.29.1", url = "https://github.com/docker/compose/releases/download/v{version}/docker-compose-windows-x86_64.exe", bin = "docker-compose.exe", bin_path = "bin", shared_extraction = true }
 "@ | Set-Content -Path (Join-Path $script:TestRoot "mise.toml")
     }
 

--- a/e2e-win/backend/http_raw_bin_path.Tests.ps1
+++ b/e2e-win/backend/http_raw_bin_path.Tests.ps1
@@ -4,7 +4,8 @@ Describe 'backend_http_raw_bin_path' {
     # go through `junction::create`, which builds a *directory* reparse point:
     # it succeeds, and leaves a link that cannot be resolved.
     #
-    # `http_binary_clean.Tests.ps1` covers the default independent installation.
+    # Exercise both the default independent files and opt-in sharing with a
+    # nested bin_path, including command resolution and execution in each mode.
     #
     # `bin` is set so the installed filename is decided outright rather than by
     # the name-cleaning heuristics, which keeps a failure here pointing at the
@@ -21,11 +22,6 @@ Describe 'backend_http_raw_bin_path' {
         # process, so removing an inherited value would leave the next without it.
         $script:OriginalExperimental = [Environment]::GetEnvironmentVariable('MISE_EXPERIMENTAL', 'Process')
         $env:MISE_EXPERIMENTAL = "1"
-
-        @"
-[tools]
-"http:docker-compose-binpath" = { version = "2.29.1", url = "https://github.com/docker/compose/releases/download/v{version}/docker-compose-windows-x86_64.exe", bin = "docker-compose.exe", bin_path = "bin", shared_extraction = true }
-"@ | Set-Content -Path (Join-Path $script:TestRoot "mise.toml")
     }
 
     AfterAll {
@@ -38,25 +34,33 @@ Describe 'backend_http_raw_bin_path' {
         }
     }
 
-    It 'reports the install as successful' {
-        # Asserted on purpose: the defect said nothing at install time. Without
-        # this line a reader could assume the install used to fail loudly.
-        mise install -f http:docker-compose-binpath
+    It 'installs and runs a raw binary using <Mode> extraction' -TestCases @(
+        @{ Mode = 'independent'; SharingOption = '' },
+        @{ Mode = 'shared'; SharingOption = ', shared_extraction = true' }
+    ) {
+        param($Mode, $SharingOption)
+        $tool = "http:docker-compose-binpath-$Mode"
+        @"
+[tools]
+"$tool" = { version = "2.29.1", url = "https://github.com/docker/compose/releases/download/v{version}/docker-compose-windows-x86_64.exe", bin = "docker-compose.exe", bin_path = "nested/bin"$SharingOption }
+"@ | Set-Content -Path (Join-Path $script:TestRoot "mise.toml")
+
+        mise install -f $tool
         $LASTEXITCODE | Should -Be 0
-    }
 
-    It 'resolves the binary from the tool it installed' {
-        # Checking the version alone is not enough. Docker ships on the GitHub
-        # Windows images, so an unrelated `docker-compose.exe` further along PATH
-        # could satisfy a version check while the installed link stayed broken -
-        # the test would pass on unfixed code. Assert where the command actually
-        # resolves from first.
-        $resolved = (mise exec http:docker-compose-binpath -- where.exe docker-compose | Select-Object -First 1)
-        $resolved | Should -BeLike "*http-docker-compose-binpath*"
-        $resolved | Should -BeLike "*bin*docker-compose.exe"
-    }
+        $install = mise where "${tool}@2.29.1"
+        $LASTEXITCODE | Should -Be 0
+        $binary = Join-Path $install 'nested\bin\docker-compose.exe'
+        $item = Get-Item $binary
+        $item.PSIsContainer | Should -BeFalse
+        ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) | Should -Be 0
 
-    It 'installs a binary that actually runs' {
-        mise exec http:docker-compose-binpath -- docker-compose version | Should -BeLike "Docker Compose version *"
+        # Docker ships on the CI images. Confirm the executable resolves from
+        # this installation before checking that it actually runs.
+        $resolved = (mise exec $tool -- where.exe docker-compose | Select-Object -First 1)
+        $LASTEXITCODE | Should -Be 0
+        $resolved | Should -Be $binary
+        mise exec $tool -- docker-compose version | Should -BeLike "Docker Compose version *"
+        $LASTEXITCODE | Should -Be 0
     }
 }

--- a/e2e/backend/test_http_binary_clean
+++ b/e2e/backend/test_http_binary_clean
@@ -16,5 +16,5 @@ assert_succeed "mise install -f http:docker-compose"
 # Verify it's executable
 assert_succeed "mise exec http:docker-compose -- docker-compose version"
 
-# The binary should be cleaned to just "docker-compose" in the data dir
-assert_succeed "test -f $HOME/.local/share/mise/http-tarballs/*/docker-compose"
+# The binary should be cleaned to just "docker-compose" in the installation directory
+assert_succeed "test -f $MISE_DATA_DIR/installs/http-docker-compose/2.29.1/docker-compose"

--- a/e2e/backend/test_http_caching
+++ b/e2e/backend/test_http_caching
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Test HTTP backend caching functionality
-# This test verifies that the same tarball is reused when multiple tools use it
+# Tools opting into shared extraction reuse the same extracted tarball
 
 # First, let's check if the cache directory exists and is empty
 # Note: http-tarballs is stored in DATA dir (not CACHE) to survive `mise cache clear`
@@ -15,7 +15,7 @@ fi
 echo "Test 1: Installing first tool and checking cache creation"
 cat <<EOF >mise.toml
 [tools]
-"http:hello-cache1" = { version = "1.0.0", url = "https://mise.jdx.dev/test-fixtures/hello-world-1.0.0.tar.gz", bin_path = "hello-world-1.0.0/bin", postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-1.0.0/bin/hello-world" }
+"http:hello-cache1" = { shared_extraction = true, version = "1.0.0", url = "https://mise.jdx.dev/test-fixtures/hello-world-1.0.0.tar.gz", bin_path = "hello-world-1.0.0/bin", postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-1.0.0/bin/hello-world" }
 EOF
 
 mise install
@@ -40,7 +40,7 @@ fi
 echo "Test 2: Installing second tool with same tarball and checking cache reuse"
 cat <<EOF >mise.toml
 [tools]
-"http:hello-cache2" = { version = "1.0.0", url = "https://mise.jdx.dev/test-fixtures/hello-world-1.0.0.tar.gz", bin_path = "hello-world-1.0.0/bin", postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-1.0.0/bin/hello-world" }
+"http:hello-cache2" = { shared_extraction = true, version = "1.0.0", url = "https://mise.jdx.dev/test-fixtures/hello-world-1.0.0.tar.gz", bin_path = "hello-world-1.0.0/bin", postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-1.0.0/bin/hello-world" }
 EOF
 
 mise install
@@ -59,7 +59,7 @@ fi
 echo "Test 3: Installing tool with different tarball and checking new cache entry"
 cat <<EOF >mise.toml
 [tools]
-"http:hello-cache3" = { version = "2.0.0", url = "https://mise.jdx.dev/test-fixtures/hello-world-2.0.0.tar.gz", bin_path = "hello-world-2.0.0/bin", postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-2.0.0/bin/hello-world" }
+"http:hello-cache3" = { shared_extraction = true, version = "2.0.0", url = "https://mise.jdx.dev/test-fixtures/hello-world-2.0.0.tar.gz", bin_path = "hello-world-2.0.0/bin", postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-2.0.0/bin/hello-world" }
 EOF
 
 mise install
@@ -78,7 +78,7 @@ fi
 echo "Test 4: Installing tool with checksum and checking cache key"
 cat <<EOF >mise.toml
 [tools]
-"http:hello-cache4" = { version = "1.0.0", url = "https://mise.jdx.dev/test-fixtures/hello-world-1.0.0.tar.gz", bin_path = "hello-world-1.0.0/bin", checksum = "sha256:dbca4f08377d70dc0828f5822fc47ecec3895cd9a6dacbc54cc984d346a571af", postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-1.0.0/bin/hello-world" }
+"http:hello-cache4" = { shared_extraction = true, version = "1.0.0", url = "https://mise.jdx.dev/test-fixtures/hello-world-1.0.0.tar.gz", bin_path = "hello-world-1.0.0/bin", checksum = "sha256:dbca4f08377d70dc0828f5822fc47ecec3895cd9a6dacbc54cc984d346a571af", postinstall = "chmod +x \$MISE_TOOL_INSTALL_PATH/hello-world-1.0.0/bin/hello-world" }
 EOF
 
 mise install

--- a/e2e/backend/test_http_failed_extraction_cleanup
+++ b/e2e/backend/test_http_failed_extraction_cleanup
@@ -8,8 +8,8 @@ set -euo pipefail
 # so the "clean up any stale temp directory" check before it can never match what
 # an earlier run left, and before the fix nothing removed one on the way out of a
 # failure. Every failed extraction leaked a hash-named directory into
-# `http-tarballs` permanently. `mise prune` cannot reclaim them either — it skips
-# `.tmp-` names so it cannot destroy an extraction in flight.
+# `http-tarballs` permanently. Shared extraction is opt-in and these entries
+# are not automatically reclaimed.
 
 FIXTURES="$TMPDIR/http-failed-extraction-fixtures"
 PORT_FILE="$TMPDIR/http-failed-extraction-port"
@@ -58,6 +58,7 @@ leftover_temps() {
 cat >mise.toml <<EOF
 [tools."http:broken"]
 version = "1.0.0"
+shared_extraction = true
 url = "http://127.0.0.1:$PORT/broken.tar.gz"
 bin_path = "bin"
 EOF
@@ -83,6 +84,7 @@ assert "test '$(leftover_temps "$SHARED_INSTALLS" '.mise-tmp-*')' = 0"
 cat >mise.toml <<EOF
 [tools."http:good"]
 version = "1.0.0"
+shared_extraction = true
 url = "http://127.0.0.1:$PORT/good.tar.gz"
 bin_path = "good/bin"
 EOF

--- a/e2e/backend/test_http_install_storage
+++ b/e2e/backend/test_http_install_storage
@@ -188,3 +188,25 @@ EOF
   assert_contains "'$COPY'" raw-tool-ok
   assert "test '$(readlink "$COPY")' = '$(readlink "$FIRST")/first-name'"
 done
+# Nested bin names must stay file links on both cache misses and cache hits.
+for kind in raw compressed; do
+  artifact=raw-tool
+  if [[ $kind == compressed ]]; then
+    artifact=raw-tool.gz
+  fi
+  cat >mise.toml <<EOF
+[tools."http:nested-$kind"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/$artifact"
+bin = "nested/alpha"
+bin_path = "custom/bin"
+shared_extraction = true
+EOF
+  for attempt in first cached; do
+    echo "Checking $kind nested binary: $attempt install"
+    mise install --force
+    EXECUTABLE="$INSTALLS/http-nested-$kind/1.0.0/custom/bin/nested/alpha"
+    assert "test -L '$EXECUTABLE'"
+    assert_contains "'$EXECUTABLE'" raw-tool-ok
+  done
+done

--- a/e2e/backend/test_http_install_storage
+++ b/e2e/backend/test_http_install_storage
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURES="$TMPDIR/http-install-storage"
+PORT_FILE="$TMPDIR/http-install-storage-port"
+INSTALLS="$MISE_DATA_DIR/installs"
+TARBALLS="$MISE_DATA_DIR/http-tarballs"
+
+mkdir -p "$FIXTURES/archive/bin"
+cat >"$FIXTURES/archive/bin/storage-tool" <<'EOF'
+#!/usr/bin/env bash
+echo storage-tool-ok
+EOF
+chmod +x "$FIXTURES/archive/bin/storage-tool"
+tar czf "$FIXTURES/archive.tar.gz" -C "$FIXTURES" archive
+cat >"$FIXTURES/raw-tool" <<'EOF'
+#!/usr/bin/env bash
+echo raw-tool-ok
+EOF
+chmod +x "$FIXTURES/raw-tool"
+
+python3 -u - "$FIXTURES" "$PORT_FILE" <<'PY' >/dev/null 2>&1 &
+import functools
+import http.server
+import socketserver
+import sys
+from pathlib import Path
+
+handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=sys.argv[1])
+with socketserver.TCPServer(("127.0.0.1", 0), handler) as httpd:
+    Path(sys.argv[2]).write_text(str(httpd.server_address[1]))
+    httpd.serve_forever()
+PY
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+wait_for_file "$PORT_FILE" "HTTP install storage test server" 30 "$SERVER_PID"
+PORT=$(cat "$PORT_FILE")
+
+# Default installs own their files, including raw binaries with a nested bin_path.
+# A postinstall hook must not modify another installation of the same artifact.
+cat >mise.toml <<EOF
+[tools."http:direct-a"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/archive.tar.gz"
+bin_path = "archive/bin"
+postinstall = 'echo local > "\$MISE_TOOL_INSTALL_PATH/archive/marker"'
+
+[tools."http:direct-b"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/archive.tar.gz"
+bin_path = "archive/bin"
+
+[tools."http:raw"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/raw-tool"
+bin_path = "nested/bin"
+EOF
+
+mise install
+DIRECT_A="$INSTALLS/http-direct-a/1.0.0"
+DIRECT_B="$INSTALLS/http-direct-b/1.0.0"
+RAW="$INSTALLS/http-raw/1.0.0/nested/bin/raw-tool"
+assert "test -d '$DIRECT_A' && test ! -L '$DIRECT_A'"
+assert "test -d '$DIRECT_B' && test ! -L '$DIRECT_B'"
+assert "test -f '$RAW' && test ! -L '$RAW'"
+assert "test -f '$DIRECT_A/archive/marker'"
+assert "test ! -e '$DIRECT_B/archive/marker'"
+assert "test ! -e '$TARBALLS'"
+assert_contains "mise x -- storage-tool" storage-tool-ok
+assert_contains "mise x -- raw-tool" raw-tool-ok
+
+# Uninstall removes the payload and leaves the other copy executable.
+mise uninstall http:direct-a@1.0.0
+assert "test ! -e '$DIRECT_A'"
+assert_contains "'$DIRECT_B/archive/bin/storage-tool'" storage-tool-ok
+
+# Prune likewise reclaims the actual raw binary, honoring dry-run first.
+cat >mise.toml <<EOF
+[tools."http:direct-b"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/archive.tar.gz"
+bin_path = "archive/bin"
+EOF
+mise prune --dry-run http:raw
+assert_contains "'$RAW'" raw-tool-ok
+MISE_YES=1 mise prune http:raw
+assert "test ! -e '$INSTALLS/http-raw/1.0.0'"
+assert "test ! -e '$TARBALLS'"
+assert_contains "mise x -- storage-tool" storage-tool-ok
+
+# Opted-in installs retain the old shared layouts. Both archive installs point
+# into the same cache entry; raw installs link the binary under bin_path.
+cat >>mise.toml <<EOF
+
+[tools."http:shared-a"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/archive.tar.gz"
+bin_path = "archive/bin"
+shared_extraction = true
+
+[tools."http:shared-b"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/archive.tar.gz"
+bin_path = "archive/bin"
+shared_extraction = true
+
+[tools."http:raw"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/raw-tool"
+bin_path = "nested/bin"
+shared_extraction = true
+EOF
+mise install
+SHARED_A="$INSTALLS/http-shared-a/1.0.0"
+SHARED_B="$INSTALLS/http-shared-b/1.0.0"
+assert "test -L '$SHARED_A' && test -L '$SHARED_B'"
+assert "test '$(readlink "$SHARED_A")' = '$(readlink "$SHARED_B")'"
+assert "test -L '$RAW'"
+CACHED_ARCHIVE=$(readlink "$SHARED_B")
+CACHED_RAW=$(readlink "$RAW")
+
+# Changing configuration does not invalidate existing shared installations.
+# This also models legacy installations whose configs never opted into sharing.
+python3 - <<'PY'
+from pathlib import Path
+config = Path('mise.toml')
+config.write_text(config.read_text().replace('shared_extraction = true\n', ''))
+PY
+mise install
+assert "test -L '$SHARED_A' && test -L '$RAW'"
+assert_contains "'$SHARED_A/archive/bin/storage-tool'" storage-tool-ok
+assert_contains "mise x -- raw-tool" raw-tool-ok
+
+# Force-reinstall migrates only the requested installs. The shared content must
+# remain untouched: another installed tool still depends on it.
+mise install --force http:shared-a@1.0.0 http:raw@1.0.0
+assert "test -d '$SHARED_A' && test ! -L '$SHARED_A'"
+assert "test -f '$RAW' && test ! -L '$RAW'"
+assert "test -L '$SHARED_B'"
+assert_contains "'$SHARED_A/archive/bin/storage-tool'" storage-tool-ok
+assert_contains "'$SHARED_B/archive/bin/storage-tool'" storage-tool-ok
+assert_contains "'$CACHED_ARCHIVE/archive/bin/storage-tool'" storage-tool-ok
+assert_contains "'$CACHED_RAW'" raw-tool-ok
+assert_contains "mise x -- raw-tool" raw-tool-ok
+
+# An explicit false CLI option also selects an independent installation.
+mise install --force 'http:shared-b[shared_extraction=false]@1.0.0'
+assert "test -d '$SHARED_B' && test ! -L '$SHARED_B'"
+assert_contains "'$SHARED_B/archive/bin/storage-tool'" storage-tool-ok
+assert_contains "'$CACHED_ARCHIVE/archive/bin/storage-tool'" storage-tool-ok

--- a/e2e/backend/test_http_install_storage
+++ b/e2e/backend/test_http_install_storage
@@ -140,6 +140,7 @@ assert "test -L '$SHARED_B'"
 assert_contains "'$SHARED_A/archive/bin/storage-tool'" storage-tool-ok
 assert_contains "'$SHARED_B/archive/bin/storage-tool'" storage-tool-ok
 assert_contains "'$CACHED_ARCHIVE/archive/bin/storage-tool'" storage-tool-ok
+
 assert_contains "'$CACHED_RAW'" raw-tool-ok
 assert_contains "mise x -- raw-tool" raw-tool-ok
 
@@ -148,3 +149,42 @@ mise install --force 'http:shared-b[shared_extraction=false]@1.0.0'
 assert "test -d '$SHARED_B' && test ! -L '$SHARED_B'"
 assert_contains "'$SHARED_B/archive/bin/storage-tool'" storage-tool-ok
 assert_contains "'$CACHED_ARCHIVE/archive/bin/storage-tool'" storage-tool-ok
+
+# The effective executable name is part of shared content identity for both
+# raw and compressed binaries. Different bin_path values can still share it.
+gzip -c "$FIXTURES/raw-tool" >"$FIXTURES/raw-tool.gz"
+for kind in raw compressed; do
+  artifact=raw-tool
+  if [[ $kind == compressed ]]; then
+    artifact=raw-tool.gz
+  fi
+  cat >mise.toml <<EOF
+[tools."http:named-a-$kind"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/$artifact"
+bin = "first-name"
+shared_extraction = true
+
+[tools."http:named-b-$kind"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/$artifact"
+bin = "second-name"
+bin_path = "nested/bin"
+shared_extraction = true
+
+[tools."http:named-copy-$kind"]
+version = "1.0.0"
+url = "http://127.0.0.1:$PORT/$artifact"
+bin = "first-name"
+bin_path = "another/bin"
+shared_extraction = true
+EOF
+  mise install
+  FIRST="$INSTALLS/http-named-a-$kind/1.0.0"
+  SECOND="$INSTALLS/http-named-b-$kind/1.0.0/nested/bin/second-name"
+  COPY="$INSTALLS/http-named-copy-$kind/1.0.0/another/bin/first-name"
+  assert_contains "'$FIRST/first-name'" raw-tool-ok
+  assert_contains "'$SECOND'" raw-tool-ok
+  assert_contains "'$COPY'" raw-tool-ok
+  assert "test '$(readlink "$COPY")' = '$(readlink "$FIRST")/first-name'"
+done

--- a/e2e/backend/test_http_system_install
+++ b/e2e/backend/test_http_system_install
@@ -65,6 +65,7 @@ export MISE_SHARED_INSTALL_DIRS="$SHARED_INSTALLS"
 cat >mise.toml <<EOF
 [tools."http:system-archive"]
 version = "1.0.0"
+shared_extraction = true
 url = "http://127.0.0.1:$PORT/system-archive.tar.gz"
 bin_path = "archive/bin"
 EOF
@@ -78,7 +79,7 @@ assert "test ! -e '$USER_INSTALLS/http-system-archive/1.0.0' && test ! -L '$USER
 assert_contains "mise x -- system-archive" system-archive-ok
 assert "mise ls --json http:system-archive | jq -r '.[0].install_path'" "$SYSTEM_ARCHIVE"
 
-# Explicit destinations contain the real installation and leave no hidden cache.
+# Explicit destinations ignore shared_extraction and contain the real installation.
 assert "test ! -e '$SYSTEM_INSTALLS/http-system-archive/.http-tarballs' && echo missing" missing
 rm -rf "$MISE_DATA_DIR/http-tarballs"
 assert_contains "mise x -- system-archive" system-archive-ok
@@ -86,6 +87,7 @@ assert_contains "mise x -- system-archive" system-archive-ok
 cat >mise.toml <<EOF
 [tools."http:system-raw"]
 version = "1.0.0"
+shared_extraction = true
 url = "http://127.0.0.1:$PORT/system-raw"
 bin = "system-raw"
 bin_path = "bin"
@@ -100,6 +102,7 @@ assert_contains "mise x -- system-raw" system-raw-ok
 cat >mise.toml <<EOF
 [tools."http:shared-archive"]
 version = "1.0.0"
+shared_extraction = true
 url = "http://127.0.0.1:$PORT/shared-archive.tar.gz"
 bin_path = "shared-archive/bin"
 EOF
@@ -134,6 +137,7 @@ assert_contains "'$RELATIVE_SHARED/http-shared-archive/1.0.0/shared-archive/bin/
 cat >mise.toml <<EOF
 [tools."http:system-latest"]
 version = "latest"
+shared_extraction = true
 url = "http://127.0.0.1:$PORT/system-archive.tar.gz"
 version_list_url = "http://127.0.0.1:$PORT/versions.txt"
 bin_path = "archive/bin"
@@ -154,12 +158,12 @@ assert_contains "'$SYSTEM_LATEST/archive/bin/system-archive'" system-archive-ok
 # Install the same tool normally first and create a fuzzy runtime alias. Exact
 # install-into binary discovery must not remap through this existing install.
 mise install \
-  "http:install-into[url=http://127.0.0.1:$PORT/system-archive.tar.gz,bin_path=archive/bin,version_list_url=http://127.0.0.1:$PORT/exact-versions.txt]@1.0.0"
+  "http:install-into[shared_extraction=true,url=http://127.0.0.1:$PORT/system-archive.tar.gz,bin_path=archive/bin,version_list_url=http://127.0.0.1:$PORT/exact-versions.txt]@1.0.0"
 
 # install-into is also self-contained and does not link into the user's cache.
 INSTALL_INTO="$HOME/http-install-into"
 mise install-into \
-  "http:install-into[url=http://127.0.0.1:$PORT/install-into-exact.tar.gz,bin_path=install-into-exact/bin,version_list_url=http://127.0.0.1:$PORT/exact-versions.txt]@1" \
+  "http:install-into[shared_extraction=true,url=http://127.0.0.1:$PORT/install-into-exact.tar.gz,bin_path=install-into-exact/bin,version_list_url=http://127.0.0.1:$PORT/exact-versions.txt]@1" \
   "$INSTALL_INTO"
 assert_directory_exists "$INSTALL_INTO"
 assert "test ! -L '$INSTALL_INTO' && echo directory" directory

--- a/e2e/backend/test_http_upgrade
+++ b/e2e/backend/test_http_upgrade
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# Test that HTTP backend tools (which use symlinks to cache) can be upgraded
+# Test that HTTP backend tools opting into shared extraction can be upgraded
 # This validates the fix for https://github.com/jdx/mise/pull/7012
 #
-# The HTTP backend creates symlinks from installs/ to http-tarballs/ cache.
+# With shared_extraction enabled, the HTTP backend creates symlinks from installs/ to http-tarballs/ cache.
 # Before the fix, these symlinks caused tools to be incorrectly skipped
 # in the outdated check, preventing upgrades from working.
 
@@ -47,6 +47,7 @@ fi
 echo "Test 1: Install HTTP tool with version_list_url"
 cat <<EOF >mise.toml
 [tools."http:hello-upgrade"]
+shared_extraction = true
 version = "1.0.0"
 url = "https://mise.jdx.dev/test-fixtures/hello-world-{{version}}.tar.gz"
 version_list_url = "http://localhost:$HTTP_PORT/versions.txt"
@@ -66,6 +67,7 @@ echo "Verified: Install path is a symlink (HTTP backend caching)"
 
 cat <<EOF >mise.toml
 [tools."http:hello-upgrade"]
+shared_extraction = true
 version = "1.0.0"
 url = "https://mise.jdx.dev/test-fixtures/hello-world-{{version}}.tar.gz"
 version_list_url = "http://localhost:$HTTP_PORT/versions.txt"

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -427,8 +427,8 @@ impl HttpBackend {
     // -------------------------------------------------------------------------
 
     /// Determine the destination filename for a raw file or compressed binary.
-    /// `bin`/`rename_exe` values are joined onto the extraction directory, so a
-    /// path in either (`../evil`, `a/b`) would escape it and is rejected.
+    /// `bin` accepts safe relative paths; `rename_exe` must be a plain filename.
+    /// Both reject parent traversal and absolute paths outside the extraction directory.
     fn dest_filename(
         &self,
         file_path: &Path,
@@ -464,33 +464,22 @@ impl HttpBackend {
     // Extraction type detection
     // -------------------------------------------------------------------------
 
-    /// Detect extraction type and filename from an existing cache directory.
+    /// Reconstruct the extraction result from the options included in the cache key.
     fn extraction_type_from_cache(
         &self,
-        cache_dir: &Path,
-        cache_key: &str,
+        file_path: &Path,
         file_info: &FileInfo,
-    ) -> ExtractionType {
-        // For archives, we don't need to detect the filename
+        opts: &HttpOptions<'_>,
+    ) -> Result<ExtractionType> {
         if !file_info.is_compressed_binary && file_info.format != file::ExtractionFormat::Raw {
-            return ExtractionType::Archive;
+            return Ok(ExtractionType::Archive);
         }
 
-        // For raw files, find the actual filename in the cache directory
-        let cache_path = Self::cache_path(cache_dir, cache_key);
-        for entry in xx::file::ls(&cache_path).unwrap_or_default() {
-            if let Some(name) = entry.file_name().map(|n| n.to_string_lossy().to_string()) {
-                // Skip metadata file
-                if name != METADATA_FILE {
-                    return ExtractionType::RawFile { filename: name };
-                }
-            }
-        }
-
-        // Fallback: shouldn't happen if cache is valid, but use a sensible default
-        ExtractionType::RawFile {
-            filename: self.ba.tool_name.clone(),
-        }
+        // The cache key includes this exact filename, including nested paths.
+        // Listing immediate children would mistake a parent directory for the file.
+        Ok(ExtractionType::RawFile {
+            filename: self.dest_filename(file_path, file_info, opts)?,
+        })
     }
 
     // -------------------------------------------------------------------------
@@ -672,6 +661,9 @@ impl HttpBackend {
             pr.set_message(format!("extract {}", file_info.file_name()));
         }
 
+        if let Some(parent) = dest_file.parent() {
+            file::create_dir_all(parent)?;
+        }
         file::copy(file_path, &dest_file)?;
 
         file::make_executable(&dest_file)?;
@@ -847,6 +839,9 @@ impl HttpBackend {
 
             let cached_file = cache_path.join(filename);
             let install_file = dest_dir.join(filename);
+            if let Some(parent) = install_file.parent() {
+                file::create_dir_all(parent)?;
+            }
             // Not `make_symlink`: the target here is a *file*, and on Windows
             // that goes through `junction::create`, which builds a directory
             // reparse point. It succeeds and leaves a link that cannot be
@@ -1287,7 +1282,7 @@ impl Backend for HttpBackend {
                 ctx.pr.set_message("extracting from cache".into());
                 ctx.pr.set_length(1);
                 ctx.pr.set_position(1);
-                self.extraction_type_from_cache(&cache_dir, &cache_plan.key, &cache_plan.file_info)
+                self.extraction_type_from_cache(&file_path, &cache_plan.file_info, &opts)?
             } else {
                 ctx.pr.set_message("extracting to cache".into());
                 self.extract_to_cache(

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -192,6 +192,10 @@ impl<'a> HttpOptions<'a> {
         self.values.platform_string("bin_path")
     }
 
+    fn shared_extraction(&self) -> bool {
+        self.values.bool("shared_extraction")
+    }
+
     fn windows_script_interpreter(&self) -> Option<String> {
         self.values.platform_string("windows_script_interpreter")
     }
@@ -275,7 +279,7 @@ impl HttpBackend {
     // Cache path helpers
     // -------------------------------------------------------------------------
 
-    /// Get the shared extraction cache used by normal user installs.
+    /// Get the extraction cache used by installs opting into shared extraction.
     fn tarballs_dir() -> PathBuf {
         dirs::DATA.join(HTTP_TARBALLS_DIR)
     }
@@ -286,8 +290,7 @@ impl HttpBackend {
     }
 
     /// Remove an install entry without following an existing symlink. This is
-    /// needed when migrating a system/shared install created by an older mise
-    /// version from a cache symlink to a real directory.
+    /// needed when migrating an install from a cache symlink to a real directory.
     fn remove_install_path(path: &Path) -> Result<()> {
         if path
             .symlink_metadata()
@@ -555,9 +558,9 @@ impl HttpBackend {
         Ok(extraction_type)
     }
 
-    /// Extract directly into an explicit system/shared/install-into destination.
+    /// Extract directly into the installation's own directory.
     /// The temporary directory lives next to the destination so the final rename
-    /// is atomic and the resulting installation has no dependency on user data.
+    /// is atomic and the installation does not depend on shared extraction storage.
     fn extract_to_install_path(
         &self,
         tv: &ToolVersion,
@@ -1261,7 +1264,9 @@ impl Backend for HttpBackend {
         let cache_plan =
             self.cache_plan(&file_path, download.effective_filename.as_deref(), &opts)?;
         ctx.pr.next_operation();
-        if tv.install_path_is_explicit {
+        // Explicit destinations must remain independent of the user's data dir,
+        // even when the tool opts into sharing normal user installations.
+        if tv.install_path_is_explicit || !opts.shared_extraction() {
             ctx.pr.set_message("extracting to install path".into());
             self.extract_to_install_path(
                 &tv,
@@ -1592,12 +1597,7 @@ mod tests {
     }
 
     #[test]
-    fn primary_install_keeps_shared_data_cache() {
-        let temp = tempfile::tempdir().unwrap();
-        let primary_tool_dir = temp.path().join("user/installs/http-absolute-version");
-        let mut tv = http_test_tv_with_installs("1.0.0", Some(primary_tool_dir.clone()));
-        tv.install_path = Some(primary_tool_dir.join("1.0.0"));
-
+    fn shared_extractions_stay_in_data_dir() {
         assert_eq!(
             HttpBackend::tarballs_dir(),
             dirs::DATA.join(HTTP_TARBALLS_DIR)

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -334,10 +334,14 @@ impl HttpBackend {
 
         if file_info.format_affects_cache {
             parts.push(format!("format_{}", file_info.format));
-            if file_info.is_compressed_binary {
-                let destination = self.dest_filename(file_path, file_info, opts)?;
-                parts.push(format!("name_{}", hash::hash_blake3_to_str(&destination)));
-            }
+        }
+
+        // Raw files and compressed binaries are stored under their effective
+        // executable name. Reusing different names would expose the first
+        // install's filename on every subsequent cache hit.
+        if file_info.format == file::ExtractionFormat::Raw || file_info.is_compressed_binary {
+            let destination = self.dest_filename(file_path, file_info, opts)?;
+            parts.push(format!("name_{}", hash::hash_blake3_to_str(&destination)));
         }
 
         if let Some(strip) = opts.strip_components() {
@@ -460,9 +464,7 @@ impl HttpBackend {
     // Extraction type detection
     // -------------------------------------------------------------------------
 
-    /// Detect extraction type from an existing cache directory
-    /// This handles the case where a cache hit occurs but the original extraction
-    /// used different options (e.g., different `bin` name)
+    /// Detect extraction type and filename from an existing cache directory.
     fn extraction_type_from_cache(
         &self,
         cache_dir: &Path,
@@ -1737,6 +1739,33 @@ mod tests {
     }
 
     #[test]
+    fn raw_cache_identity_includes_effective_filename() {
+        let tv = http_test_tv("1.0.0");
+        let backend = HttpBackend {
+            ba: Arc::new(tv.ba().clone()),
+        };
+        let temp = tempfile::tempdir().unwrap();
+        for filename in ["tool", "tool.gz"] {
+            let artifact = temp.path().join(filename);
+            std::fs::write(&artifact, b"same-content").unwrap();
+            let key = |options: &str| {
+                let raw_opts = crate::toolset::parse_tool_options(options);
+                backend
+                    .cache_plan(&artifact, None, &HttpOptions::new(&raw_opts))
+                    .unwrap()
+                    .key
+            };
+            assert_ne!(key("bin=alpha"), key("bin=beta"), "{filename}");
+            assert_eq!(
+                key("bin=alpha,bin_path=first"),
+                key("bin=alpha,bin_path=second"),
+                "{filename}"
+            );
+            assert!(!key("bin=nested/alpha").contains('/'));
+        }
+    }
+
+    #[test]
     fn dest_filename_uses_decompressed_name_for_rename_exe_extension() {
         let backend = HttpBackend {
             ba: Arc::new(BackendArg::new_raw(
@@ -1809,7 +1838,10 @@ mod tests {
             )),
         };
 
-        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let tmp = tempfile::Builder::new()
+            .suffix(".tar.gz")
+            .tempfile()
+            .unwrap();
         std::fs::write(tmp.path(), b"archive-contents").unwrap();
 
         // Characters that are illegal or unsafe in Windows path components and


### PR DESCRIPTION
HTTP installations currently link into shared extraction storage that survives uninstall and prune, allowing unused payloads to accumulate. New installations now extract directly into their installation directories, so the existing uninstall/prune lifecycle removes their files.

Add `shared_extraction = true` as a per-tool opt-in to the previous deduplication behavior. Explicit system, shared, and install-into destinations remain independent even when the option is enabled.

Existing symlinked installations continue to work. Force-reinstalling without the option migrates the requested installation to independent files while preserving content that another install may still use. Legacy shared storage is not automatically reclaimed; the docs describe that limitation and the disk-space/postinstall tradeoffs of opting in.

Shared raw and compressed binary caches also include the effective executable filename in their identity, preventing differently named tools from reusing the wrong filename. Regression coverage checks distinct names and same-name sharing.

Related: https://github.com/jdx/mise/discussions/9477

## Validation

- 23 HTTP unit tests passed.
- Nine focused Linux HTTP end-to-end tests passed, including new coverage for independent payloads, uninstall/prune, opt-in sharing, and migration without damaging another sharer. The format test passed on retry after a transient DNS failure.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` passed.
- Scoped hk checks/fixes passed.
- Windows raw-file coverage exercises both independent and shared extraction with a nested bin_path, exact executable resolution, and execution; native Windows validation runs in CI.

*AI-assisted — Tool: Codex; model: openai/GPT-6; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in shared extraction for HTTP-based tools.
  * HTTP installations now store files directly in their installation directory by default.
  * Shared extraction uses a common cache when enabled, while explicit destinations retain real installation files.
  * Raw binaries support platform-appropriate linking or copying, including nested executable paths.

* **Bug Fixes**
  * Prevented cache collisions when tools use different executable names.
  * Improved cleanup, reinstall, and pruning behavior for independent and shared installations.

* **Documentation**
  * Documented shared extraction options, cache locations, installation behavior, and cleanup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default HTTP install layout and lifecycle cleanup for all `http:` tools, with migration and shared-cache edge cases; behavior is well tested but affects a core install path.
> 
> **Overview**
> **Default HTTP installs now keep extracted files in each tool’s install directory**, so `mise uninstall` and `mise prune` can remove payloads instead of leaving shared data under `$MISE_DATA_DIR/http-tarballs/`.
> 
> **Opt-in deduplication** is restored with **`shared_extraction = true`**, which symlinks (or file-links under `bin_path`) into the existing `http-tarballs` cache. System, `--shared`, and `install-into` destinations stay self-contained even when that flag is set. Legacy symlink installs keep working; **`mise install --force`** (or `shared_extraction=false` on the CLI) migrates selected versions to independent trees without breaking other sharers.
> 
> **Shared-cache identity** for raw and compressed binaries now includes the **effective executable name** (`bin` / rename / clean name), fixing collisions where different names reused the same cached file. Cache hits derive the raw filename from options instead of scanning the cache directory, and nested paths get parent dirs created on extract/link.
> 
> Docs describe the new default, opt-in tradeoffs (disk vs shared `postinstall` side effects), and that **`http-tarballs` is not auto-reclaimed**. E2E and Windows tests cover independent vs shared modes, migration, prune, and nested `bin_path` execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f27a4b34d7729576547c3f5cc1c1b44bbc25390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->