### PR TITLE
fix: extract structured flight steps from tap casks

### DIFF
--- a/src/system/packages/brew/cask/artifacts.rs
+++ b/src/system/packages/brew/cask/artifacts.rs
@@ -718,6 +718,7 @@ pub(super) fn parse_flight_step(cask: &Cask, kind: &str, value: &Value) -> Resul
                     "sudo",
                     "guards",
                     "network_access",
+                    "must_succeed",
                 ],
             )?;
             let args = object
@@ -771,6 +772,7 @@ pub(super) fn parse_flight_step(cask: &Cask, kind: &str, value: &Value) -> Resul
                 .unwrap_or_default();
             let guards = parse_flight_guards(cask, kind, object.get("guards"))?;
             Ok(FlightStep::Run {
+                must_succeed: parse_optional_flight_bool(cask, kind, object, "must_succeed", true)?,
                 command: parse_run_command(cask, kind, object.get("command"))?,
                 args,
                 env,

--- a/src/system/packages/brew/cask/flight.rs
+++ b/src/system/packages/brew/cask/flight.rs
@@ -827,6 +827,7 @@ pub(super) fn execute_flight_step(
             }
         }
         FlightStep::Run {
+            must_succeed,
             command,
             args,
             env,
@@ -852,8 +853,8 @@ pub(super) fn execute_flight_step(
                     )
                 })
                 .collect::<Vec<_>>();
-            if *sudo {
-                sudo::run(&command, &args, &env)?;
+            let result = if *sudo {
+                sudo::run(&command, &args, &env)
             } else {
                 let mut runner = CmdLineRunner::new(&command);
                 for arg in &args {
@@ -862,7 +863,16 @@ pub(super) fn execute_flight_step(
                 for (key, value) in &env {
                     runner = runner.env(key, value);
                 }
-                runner.raw(true).execute()?;
+                runner.raw(true).execute()
+            };
+            if let Err(err) = result {
+                let exited = matches!(
+                    err.downcast_ref::<crate::errors::Error>(),
+                    Some(crate::errors::Error::ScriptFailed(_, Some(_)))
+                );
+                if *must_succeed || !exited {
+                    return Err(err);
+                }
             }
         }
         FlightStep::TerminateProcess { .. } => {

--- a/src/system/packages/brew/cask/flight.rs
+++ b/src/system/packages/brew/cask/flight.rs
@@ -868,7 +868,8 @@ pub(super) fn execute_flight_step(
             if let Err(err) = result {
                 let exited = matches!(
                     err.downcast_ref::<crate::errors::Error>(),
-                    Some(crate::errors::Error::ScriptFailed(_, Some(_)))
+                    Some(crate::errors::Error::ScriptFailed(_, Some(status)))
+                        if status.code().is_some()
                 );
                 if *must_succeed || !exited {
                     return Err(err);

--- a/src/system/packages/brew/cask/mod.rs
+++ b/src/system/packages/brew/cask/mod.rs
@@ -227,6 +227,7 @@ enum FlightStep {
         guards: Vec<FlightGuard>,
     },
     Run {
+        must_succeed: bool,
         command: FlightPath,
         args: Vec<String>,
         env: BTreeMap<String, String>,

--- a/src/system/packages/brew/cask/tests.rs
+++ b/src/system/packages/brew/cask/tests.rs
@@ -1112,6 +1112,7 @@ fn parses_orbstack_structured_run_step() -> Result<()> {
     assert_eq!(
         artifacts.postflight_steps,
         vec![FlightStep::Run {
+            must_succeed: true,
             command: FlightPath {
                 base: FlightPathBase::AppDir,
                 path: "OrbStack.app/Contents/MacOS/bin/orbctl".to_string(),
@@ -2972,6 +2973,7 @@ fn structured_run_expands_paths_args_and_env() -> Result<()> {
     execute_flight_steps(
         &test_cask("example", "1.2.3"),
         &[FlightStep::Run {
+            must_succeed: true,
             command: FlightPath {
                 base: FlightPathBase::Literal,
                 path: "/bin/sh".to_string(),
@@ -3500,6 +3502,12 @@ fn cask_shim_supports_completion_stanzas_and_system_command() -> Result<()> {
   zsh_completion "#{appdir}/Example.app/Contents/Resources/etc/example.zsh-completion"
   fish_completion "#{appdir}/Example.app/Contents/Resources/etc/example.fish-completion"
   manpage "#{appdir}/Example.app/Contents/Resources/man/example.1"
+  preflight_steps do
+    raise "structured steps must run only in Rust"
+  end
+  postflight_steps do
+    raise "structured steps must run only in Rust"
+  end
   postflight do
     kubectl_target = staged_path/"kubectl-link"
     next if kubectl_target.exist?
@@ -7961,5 +7969,44 @@ fn auto_updates_refuses_symlinked_and_nonregular_plist_paths() -> Result<()> {
             .success()
     );
     assert!(read_app_version(&fifo_app).is_err());
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn structured_run_respects_failure_policy() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let mut cask = test_cask("example", "1.0");
+    for (policy, succeeds) in [(None, false), (Some(true), false), (Some(false), true)] {
+        let mut step = serde_json::json!({
+            "type": "run", "command": {"path": "/usr/bin/false"}
+        });
+        if let Some(policy) = policy {
+            step["must_succeed"] = policy.into();
+        }
+        cask.artifacts = vec![
+            serde_json::json!({"app": ["Example.app"]}),
+            serde_json::json!({"postflight_steps": [{"steps": [step]}]}),
+        ];
+        let artifacts = cask_artifacts(&cask)?;
+        assert_eq!(
+            execute_flight_steps(
+                &cask,
+                &artifacts.postflight_steps,
+                tmp.path(),
+                tmp.path(),
+                "postflight_steps"
+            )
+            .is_ok(),
+            succeeds
+        );
+    }
+    let invalid = serde_json::json!({"type": "run", "command": {"path": "/usr/bin/false"}, "must_succeed": "false"});
+    assert!(parse_flight_step(&cask, "postflight_steps", &invalid).is_err());
+    let missing = serde_json::json!({"type": "run", "command": {"path": "/mise-nonexistent-command"}, "must_succeed": false});
+    let step = parse_flight_step(&cask, "postflight_steps", &missing)?;
+    assert!(
+        execute_flight_steps(&cask, &[step], tmp.path(), tmp.path(), "postflight_steps").is_err()
+    );
     Ok(())
 }

--- a/src/system/packages/brew/cask/tests.rs
+++ b/src/system/packages/brew/cask/tests.rs
@@ -8001,6 +8001,17 @@ fn structured_run_respects_failure_policy() -> Result<()> {
             succeeds
         );
     }
+    let signaled = serde_json::json!({
+        "type": "run", "command": {"path": "/bin/sh"},
+        "args": ["-c", "kill -TERM $$"], "must_succeed": false
+    });
+    let step = parse_flight_step(&cask, "postflight_steps", &signaled)?;
+    let err = execute_flight_steps(&cask, &[step], tmp.path(), tmp.path(), "postflight_steps")
+        .expect_err("signal termination must remain an error");
+    assert!(matches!(
+        err.downcast_ref::<crate::errors::Error>(),
+        Some(crate::errors::Error::ScriptFailed(_, Some(status))) if status.code().is_none()
+    ));
     let invalid = serde_json::json!({"type": "run", "command": {"path": "/usr/bin/false"}, "must_succeed": "false"});
     assert!(parse_flight_step(&cask, "postflight_steps", &invalid).is_err());
     let missing = serde_json::json!({"type": "run", "command": {"path": "/mise-nonexistent-command"}, "must_succeed": false});

--- a/src/system/packages/brew/cask_shim.rb
+++ b/src/system/packages/brew/cask_shim.rb
@@ -294,6 +294,9 @@ class CaskContext
   def uninstall(*) nil end
   def zap(*) nil end
 
+  def preflight_steps(*) nil end
+  def postflight_steps(*) nil end
+
   def preflight(&block) @hooks[:preflight] = block end
   def postflight(&block) @hooks[:postflight] = block end
   def uninstall_preflight(&block) @hooks[:uninstall_preflight] = block end

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -694,7 +694,8 @@ cask "widget" do
   app "Widget.app"
   binary "Widget.app/Contents/MacOS/widget", target: "widget"
   preflight_steps do
-    run "/this-command-must-never-execute", args: ["#{version}"]
+    run "Widget.app/Contents/MacOS/widget", base: :appdir, args: ["#{version}"]
+    run "bin/widget", base: :staged_path
   end
   postflight_steps do
     run "/usr/bin/xattr", args: ["-d", "com.apple.quarantine", "{{staged_path}}/Widget-#{version}/bin/widget"], must_succeed: false
@@ -729,7 +730,11 @@ end
         assert_eq!(metadata["artifacts"].as_array().unwrap().len(), 4);
         assert_eq!(
             metadata["artifacts"][2]["preflight_steps"][0]["steps"][0],
-            serde_json::json!({"type": "run", "command": {"path": "/this-command-must-never-execute"}, "args": ["1.2.3"]})
+            serde_json::json!({"type": "run", "command": {"path": "Widget.app/Contents/MacOS/widget", "base": "appdir"}, "args": ["1.2.3"]})
+        );
+        assert_eq!(
+            metadata["artifacts"][2]["preflight_steps"][0]["steps"][1],
+            serde_json::json!({"type": "run", "command": {"path": "bin/widget", "base": "staged_path"}})
         );
         assert_eq!(
             metadata["artifacts"][3]["postflight_steps"][0]["steps"],

--- a/src/system/packages/brew/tap.rs
+++ b/src/system/packages/brew/tap.rs
@@ -679,7 +679,7 @@ end
         let cask_file = dir.path().join("widget.rb");
         crate::file::write(
             &cask_file,
-            r#"
+            r##"
 cask "widget" do
   version "1.2.3"
   sha256 :no_check
@@ -693,8 +693,15 @@ cask "widget" do
   end
   app "Widget.app"
   binary "Widget.app/Contents/MacOS/widget", target: "widget"
+  preflight_steps do
+    run "/this-command-must-never-execute", args: ["#{version}"]
+  end
+  postflight_steps do
+    run "/usr/bin/xattr", args: ["-d", "com.apple.quarantine", "{{staged_path}}/Widget-#{version}/bin/widget"], must_succeed: false
+    run "/usr/bin/xattr", args: ["-d", "com.apple.quarantine", "{{appdir}}/Widget.app"], must_succeed: false
+  end
 end
-"#,
+"##,
         )?;
         let mut runner = CmdLineRunner::new(ruby)
             .with_on_stderr(|line| eprintln!("{line}"))
@@ -719,7 +726,18 @@ end
         assert_eq!(metadata["sha256"], "no_check");
         assert_eq!(metadata["url"], "https://example.com/café/widget-1.2.3.zip");
         assert_eq!(metadata["depends_on"]["formula"][0], "libfoo");
-        assert_eq!(metadata["artifacts"].as_array().unwrap().len(), 2);
+        assert_eq!(metadata["artifacts"].as_array().unwrap().len(), 4);
+        assert_eq!(
+            metadata["artifacts"][2]["preflight_steps"][0]["steps"][0],
+            serde_json::json!({"type": "run", "command": {"path": "/this-command-must-never-execute"}, "args": ["1.2.3"]})
+        );
+        assert_eq!(
+            metadata["artifacts"][3]["postflight_steps"][0]["steps"],
+            serde_json::json!([
+                {"type": "run", "command": {"path": "/usr/bin/xattr"}, "args": ["-d", "com.apple.quarantine", "{{staged_path}}/Widget-1.2.3/bin/widget"], "must_succeed": false},
+                {"type": "run", "command": {"path": "/usr/bin/xattr"}, "args": ["-d", "com.apple.quarantine", "{{appdir}}/Widget.app"], "must_succeed": false}
+            ])
+        );
         Ok(())
     }
 

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -112,8 +112,10 @@ class CaskFlightSteps
   def version = @cask.version
   def arch = @cask.arch
 
-  def run(command, **options)
-    @steps << options.merge(type: "run", command: { path: command.to_s })
+  def run(command, base: nil, **options)
+    path = { path: command.to_s }
+    path[:base] = base.to_s unless base.nil?
+    @steps << options.merge(type: "run", command: path)
   end
 
   def method_missing(name, *, &block)

--- a/src/system/packages/brew/tap_cask_metadata.rb
+++ b/src/system/packages/brew/tap_cask_metadata.rb
@@ -100,6 +100,29 @@ class Version
   def token(index) = self.class.new(@value.split(".")[index].to_s)
 end
 
+# Collect declarative steps only; commands run later in the Rust installer.
+class CaskFlightSteps
+  attr_reader :steps
+
+  def initialize(cask)
+    @cask = cask
+    @steps = []
+  end
+
+  def version = @cask.version
+  def arch = @cask.arch
+
+  def run(command, **options)
+    @steps << options.merge(type: "run", command: { path: command.to_s })
+  end
+
+  def method_missing(name, *, &block)
+    raise "unsupported cask flight step DSL `#{name}`"
+  end
+
+  def respond_to_missing?(*) = true
+end
+
 class CaskMetadata
   attr_reader :token, :artifacts, :formula_dependencies, :cask_dependencies,
               :conflicting_casks
@@ -163,6 +186,8 @@ class CaskMetadata
   def artifact(source, target: nil) = add_artifact("artifact", source, target)
   def uninstall(**values) = @artifacts << { "uninstall" => values }
   def zap(**values) = @artifacts << { "zap" => values }
+  def preflight_steps(&block) = add_flight_steps("preflight_steps", &block)
+  def postflight_steps(&block) = add_flight_steps("postflight_steps", &block)
   def preflight(*) = @artifacts << { "preflight" => nil }
   def postflight(*) = @artifacts << { "postflight" => nil }
   def uninstall_preflight(*) = @artifacts << { "uninstall_preflight" => nil }
@@ -274,6 +299,12 @@ class CaskMetadata
   def respond_to_missing?(*) = true
 
   private
+
+  def add_flight_steps(kind, &block)
+    collector = CaskFlightSteps.new(self)
+    collector.instance_eval(&block)
+    @artifacts << { kind => [{ "steps" => collector.steps }] }
+  end
 
   def add_artifact(kind, source, target)
     value = [source.to_s]


### PR DESCRIPTION
Tap casks containing `preflight_steps` or `postflight_steps` currently fail during Ruby metadata extraction, before a dry-run can produce a plan. Collect declarative `run` steps into the existing structured artifact format without executing their commands, preserving version interpolation, argument templates, command bases, and options. Ordinary lifecycle evaluation skips these blocks because Rust executes the structured steps.

Support `must_succeed` on structured run commands: retain the existing required-success default, allow nonzero exits when explicitly false, and continue reporting signal termination, spawn failures, and other execution errors. Unsupported step DSL and unsupported serialized fields still fail explicitly.

Addresses the flight-step metadata failure in https://github.com/jdx/mise/discussions/13053. This does **not** establish full AeroSpace tap compatibility: evaluating the pinned full cask now advances to a separate existing `HOMEBREW_PREFIX` constant error in the metadata shim.

Validation:
- `cargo test --locked --all-features --bin mise structured_run`: 3 passed.
- Sandboxed metadata extraction and mixed lifecycle-hook regression tests: 2 passed with Homebrew portable Ruby 4.0.6 on PATH.
- Regression coverage includes signal termination and symbol-valued appdir/staged_path command bases.
- Direct Ruby metadata checks confirm unknown steps fail and commands are not executed.
- `mise run lint-fix` (including `cargo check --all-features`).

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cask install metadata parsing and when postflight commands fail, which can alter install success for taps using structured steps or optional `must_succeed: false` runs.
> 
> **Overview**
> Tap cask metadata extraction now **records** `preflight_steps` / `postflight_steps` as structured JSON instead of failing when those DSL blocks appear. A Ruby `CaskFlightSteps` collector captures declarative `run` steps (paths, bases, args, `must_succeed`) during shim evaluation; the install shim stubs the same stanzas so ordinary lifecycle hooks do not execute them in Ruby.
> 
> Structured **`run`** steps in Rust gain a **`must_succeed`** flag (default **true**). When it is **false**, a normal nonzero exit is ignored, but signal termination, missing commands, and other non-exit failures still abort the install.
> 
> Tests cover metadata serialization (including quarantine `xattr` examples), mixed legacy `postflight` hooks, and the new failure policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1732050defbead143ad13847960c611c01b9f43c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for declarative preflight and postflight steps in brew casks.
  * Run steps can specify a command base path, such as the app directory or staged path.
  * Added optional failure handling for run steps, allowing expected command failures with `must_succeed: false`.
  * Cask metadata now preserves configured flight-step commands and execution settings.

* **Bug Fixes**
  * Improved handling of failed commands while continuing cask lifecycle processing when explicitly permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->