### PR TITLE
docs: illustrate project environment switching

### DIFF
--- a/docs/.vitepress/theme/ProjectSwitchDiagram.vue
+++ b/docs/.vitepress/theme/ProjectSwitchDiagram.vue
@@ -1,0 +1,171 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+const projects = [
+  { name: "api", node: "22" },
+  { name: "dashboard", node: "24" },
+];
+const selected = ref(projects[0]);
+</script>
+
+<template>
+  <figure
+    class="project-switch-diagram"
+    aria-label="Project configuration follows your directory"
+  >
+    <div class="projects">
+      <button
+        v-for="project in projects"
+        :key="project.name"
+        type="button"
+        :aria-pressed="selected.name === project.name"
+        :aria-label="`Show the shell environment in ${project.name}`"
+        @click="selected = project"
+      >
+        <span class="project-path">{{ project.name }}/mise.toml</span>
+        <code
+          >[tools]<br />node = "{{
+            project.node
+          }}"<br /><br />[env]<br />APP_ENV = "{{ project.name }}"</code
+        >
+        <span class="project-command">$ cd ~/work/{{ project.name }}</span>
+      </button>
+    </div>
+    <div class="project-arrows" aria-hidden="true">
+      <span v-for="project in projects" :key="project.name">{{
+        selected.name === project.name ? "↓" : ""
+      }}</span>
+    </div>
+    <div class="project-shell" aria-live="polite" aria-atomic="true">
+      <div class="project-shell-bar">
+        <span>Active shell</span><span>~/work/{{ selected.name }}</span>
+      </div>
+      <dl>
+        <div>
+          <dt>Node</dt>
+          <dd>{{ selected.node }}</dd>
+        </div>
+        <div>
+          <dt>APP_ENV</dt>
+          <dd>{{ selected.name }}</dd>
+        </div>
+      </dl>
+    </div>
+    <figcaption>
+      Choose a project to see its environment. Shell activation and installed
+      tool versions are required.
+    </figcaption>
+  </figure>
+</template>
+
+<style scoped>
+.project-switch-diagram {
+  margin: 0;
+  min-width: 0;
+}
+.projects {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+.projects button {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 18px;
+  min-width: 0;
+  padding: 18px;
+  text-align: left;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  cursor: pointer;
+}
+.projects button[aria-pressed="true"] {
+  border-color: var(--vp-c-brand-1);
+  box-shadow: inset 0 0 0 1px var(--vp-c-brand-1);
+}
+.projects button:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 4px;
+}
+.project-path {
+  font-size: 0.8rem;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.projects code {
+  padding: 0;
+  color: var(--vp-c-text-1);
+  background: transparent;
+  font-size: 0.8rem;
+  line-height: 1.7;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+.project-command {
+  margin-top: auto;
+  color: var(--vp-c-brand-1);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+}
+.project-arrows {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 40px;
+  align-items: center;
+  text-align: center;
+  color: var(--vp-c-brand-1);
+  font-size: 1.5rem;
+}
+.project-shell {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--vp-c-bg-soft);
+}
+.project-shell-bar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-2);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.8rem;
+}
+dl {
+  margin: 0;
+  padding: 16px 18px;
+}
+dl > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  padding: 4px 0;
+}
+dt {
+  color: var(--vp-c-text-2);
+  font-size: 0.85rem;
+}
+dd {
+  margin: 0;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.85rem;
+  overflow-wrap: anywhere;
+}
+figcaption {
+  margin-top: 14px;
+  color: var(--vp-c-text-2);
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+@media (max-width: 480px) {
+  .projects button {
+    padding: 12px;
+  }
+}
+</style>

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,10 @@ hero:
   tagline: Dev tools, env vars, and tasks in one CLI
 ---
 
+<script setup>
+import ProjectSwitchDiagram from "./.vitepress/theme/ProjectSwitchDiagram.vue";
+</script>
+
 <section class="landing-page" aria-label="mise overview">
   <div class="landing-section landing-stations">
     <p class="landing-kicker"><span>01</span> The essentials</p>
@@ -72,24 +76,7 @@ hero:
           <li><code>mise exec</code> and <code>mise-action</code> for Docker and CI</li>
         </ul>
       </div>
-      <div class="landing-terminal" aria-label="Switching between two projects">
-        <div class="terminal-bar"><span>~/work</span><span>zsh</span></div>
-        <div class="terminal-lines">
-          <div><span class="prompt">$</span> cd api</div>
-          <div><span class="prompt">$</span> node --version</div>
-          <div>v22.12.0</div>
-          <div><span class="prompt">$</span> echo $DATABASE_URL</div>
-          <div>postgres://localhost/api</div>
-          <div>&nbsp;</div>
-          <div><span class="prompt">$</span> cd ../dashboard</div>
-          <div><span class="prompt">$</span> node --version</div>
-          <div>v24.18.0</div>
-          <div><span class="prompt">$</span> mise ls --current</div>
-          <div><span class="dim">Tool&nbsp;&nbsp;&nbsp;Version&nbsp;&nbsp;&nbsp;Source</span></div>
-          <div>bun&nbsp;&nbsp;&nbsp;&nbsp;1.2.20&nbsp;&nbsp;&nbsp;&nbsp;~/work/dashboard/mise.toml</div>
-          <div>node&nbsp;&nbsp;&nbsp;24.18.0&nbsp;&nbsp;&nbsp;~/work/dashboard/mise.toml</div>
-        </div>
-      </div>
+      <ProjectSwitchDiagram />
     </div>
   </div>
 


### PR DESCRIPTION
Replace the landing page’s directory-switching transcript with two selectable project configurations and the resulting shell environment. Selecting a project updates its Node major version and `APP_ENV`, with keyboard controls and an announced result. The caption calls out shell activation and installed tools.

Built with `mise run docs:build`; passed scoped hk checks. Checked light/dark rendering at 1440px and 390px, keyboard selection, updated shell values, and absence of browser errors. The new diagram fits the phone viewport; the pre-existing bootstrap-section overflow is addressed separately in the bootstrap diagram PR.

### Preview

![Desktop preview](https://github.com/user-attachments/assets/3032b5e1-3cc2-4d13-aa94-8999233cd32b)

<details>
<summary>Dark mode and phone layout</summary>

![Dark desktop preview](https://github.com/user-attachments/assets/28e6fb0c-7468-4189-b356-ec4e5970ff41)

![Phone preview](https://github.com/user-attachments/assets/908af4be-f234-4aa0-b1a7-304f555cb668)

</details>

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and landing-page UI only; no runtime CLI or product behavior changes.
> 
> **Overview**
> The landing page **“Day to day”** section no longer uses a fixed terminal transcript for switching between `api` and `dashboard`. It now embeds a new **`ProjectSwitchDiagram`** Vue component that lets readers pick a project and see how its `mise.toml` maps to an “active shell” (Node major and `APP_ENV`).
> 
> The diagram uses selectable project cards, VitePress theme tokens, a short caption about shell activation, and basic a11y (`aria-pressed`, `aria-live`, focus styles). `docs/index.md` imports the component via `<script setup>` and drops the previous `landing-terminal` markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e74a021bf7f99cc58de236053adb1822ddf2423d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the static project-switching example on the documentation home page with an interactive diagram.
  * Added selectable API and dashboard project views showing their Node.js versions and `APP_ENV` values.
  * Improved the example’s accessibility with live status updates and responsive presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->