### PR TITLE
docs: illustrate bootstrap machine resources

### DIFF
--- a/docs/.vitepress/theme/landing.css
+++ b/docs/.vitepress/theme/landing.css
@@ -345,25 +345,79 @@ a:hover > div + .card-link::after {
   padding: 18px 20px;
 }
 
+/* Bootstrap: one declaration fans out to machine resources. */
+.bootstrap-diagram {
+  margin: 0;
+  min-width: 0;
+}
+
+.bootstrap-source,
+.bootstrap-resources > div {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 20px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  background: var(--vp-c-bg-soft);
+}
+
+.bootstrap-source {
+  align-items: center;
+}
+.bootstrap-source > strong {
+  font-family: var(--vp-font-family-mono);
+  font-size: 1.2rem;
+}
+.bootstrap-source > code {
+  margin-top: 10px;
+  padding: 0;
+  background: transparent;
+  font-size: 0.85rem;
+  line-height: 1.8;
+}
+.bootstrap-label,
+.bootstrap-resources span {
+  color: var(--vp-c-text-2);
+  font-size: 0.85rem;
+}
+.bootstrap-connector {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 16px 0;
+  color: var(--vp-c-brand-1);
+}
+.bootstrap-connector > span {
+  font-size: 1.5rem;
+}
+.bootstrap-resources {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+.bootstrap-resources > div {
+  padding: 16px;
+  overflow-wrap: anywhere;
+}
+.bootstrap-resources strong {
+  font-size: 1rem;
+  font-weight: 600;
+}
+.bootstrap-diagram figcaption {
+  margin-top: 16px;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+}
+
 /* 04 · New machine: bootstrap config beside the pitch */
 .landing-machine-grid {
   display: grid;
   grid-template-columns: minmax(360px, 1.1fr) minmax(0, 0.9fr);
   gap: 56px;
   align-items: center;
-}
-
-.landing-config-card {
-  min-width: 0;
-  overflow: hidden;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 10px;
-  background: var(--vp-c-bg-soft);
-  box-shadow: 0 32px 64px -48px rgba(0, 0, 0, 0.45);
-}
-
-.landing-config-card .card-toml {
-  padding: 18px 0;
 }
 
 .landing-inline-cmd {
@@ -674,11 +728,11 @@ a:hover > div + .card-link::after {
   }
 
   .landing-machine-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  /* pitch first, config second on narrow screens */
-  .landing-machine-grid > .landing-config-card {
+  /* pitch first, diagram second on narrow screens */
+  .landing-machine-grid > .bootstrap-diagram {
     order: 2;
   }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,28 +96,21 @@ hero:
   <div class="landing-section landing-machine">
     <p class="landing-kicker"><span>03</span> New machine</p>
     <div class="landing-machine-grid">
-      <div class="landing-config-card" aria-label="Example bootstrap config">
-        <div class="card-bar"><strong>mise.toml</strong><span>~/.config/mise</span></div>
-        <div class="card-toml">
-          <div class="row row-boot"><span class="tk-section">[bootstrap.packages]</span></div>
-          <div class="row row-boot"><span class="tk-key">"brew:postgresql@17"</span><span class="tk-op"> = </span><span class="tk-str">"latest"</span></div>
-          <div class="row row-boot"><span class="tk-key">"apt:build-essential"</span><span class="tk-op"> = </span><span class="tk-str">"latest"</span></div>
-          <div class="row row-blank"></div>
-          <div class="row row-boot"><span class="tk-section">[bootstrap.repos]</span></div>
-          <div class="row row-boot"><span class="tk-key">"~/src/notes"</span><span class="tk-op"> = { </span><span class="tk-key">url</span><span class="tk-op"> = </span><span class="tk-str">"git@github.com:me/notes.git"</span><span class="tk-op"> }</span></div>
-          <div class="row row-blank"></div>
-          <div class="row row-boot"><span class="tk-section">[dotfiles]</span></div>
-          <div class="row row-boot"><span class="tk-key">"~/.config/mise/config.toml"</span><span class="tk-op"> = { </span><span class="tk-key">source</span><span class="tk-op"> = </span><span class="tk-str">"config.toml"</span><span class="tk-op">, </span><span class="tk-key">mode</span><span class="tk-op"> = </span><span class="tk-str">"symlink"</span><span class="tk-op"> }</span></div>
-          <div class="row row-boot"><span class="tk-key">"~/.gitconfig"</span><span class="tk-op"> = { </span><span class="tk-key">source</span><span class="tk-op"> = </span><span class="tk-str">"dotfiles/gitconfig"</span><span class="tk-op">, </span><span class="tk-key">mode</span><span class="tk-op"> = </span><span class="tk-str">"template"</span><span class="tk-op"> }</span></div>
-          <div class="row row-boot"><span class="tk-key">"~/.config/nvim"</span><span class="tk-op"> = { </span><span class="tk-key">source</span><span class="tk-op"> = </span><span class="tk-str">"dotfiles/nvim"</span><span class="tk-op">, </span><span class="tk-key">mode</span><span class="tk-op"> = </span><span class="tk-str">"symlink"</span><span class="tk-op"> }</span></div>
-          <div class="row row-blank"></div>
-          <div class="row row-boot"><span class="tk-section">[bootstrap.macos.dock]</span></div>
-          <div class="row row-boot"><span class="tk-key">autohide</span><span class="tk-op"> = </span><span class="tk-str">true</span></div>
-          <div class="row row-blank"></div>
-          <div class="row row-boot"><span class="tk-section">[bootstrap.mise_shell_activate]</span></div>
-          <div class="row row-boot"><span class="tk-key">zshrc</span><span class="tk-op"> = </span><span class="tk-str">"activate"</span></div>
+      <figure class="bootstrap-diagram" aria-label="mise bootstrap applies one configuration to packages, repositories, dotfiles, and services">
+        <div class="bootstrap-source">
+          <span class="bootstrap-label">Declare your setup</span>
+          <strong>mise.toml</strong>
+          <code>[bootstrap.packages]<br>[bootstrap.repos]<br>[dotfiles]<br>[bootstrap.services]</code>
         </div>
-      </div>
+        <div class="bootstrap-connector"><span aria-hidden="true">↓</span> <code>mise bootstrap</code></div>
+        <div class="bootstrap-resources">
+          <div><strong>Packages</strong><span>brew · apt · winget</span></div>
+          <div><strong>Repositories</strong><span>Project checkouts</span></div>
+          <div><strong>Dotfiles</strong><span>Link · copy · template</span></div>
+          <div><strong>Services</strong><span>Background processes</span></div>
+        </div>
+        <figcaption><code>mise bootstrap plan</code> previews declarative resource changes before you apply them.</figcaption>
+      </figure>
       <div>
         <h2>One config for the <em>whole machine.</em></h2>
         <p class="landing-lede">


### PR DESCRIPTION
Replace the landing page’s long bootstrap TOML sample with a diagram connecting `mise.toml` to packages, repositories, dotfiles, and services. Keep the plan command alongside it, put the pitch before the diagram on phones, and prevent the mobile grid from expanding beyond the viewport.

Built with `mise run docs:build`; passed scoped hk checks. Checked light/dark rendering at 1440px and 390px, absence of horizontal page overflow, and absence of browser errors.

### Preview

![Desktop preview](https://github.com/user-attachments/assets/dc91de78-a4cf-4628-bd08-d6873678653e)

<details>
<summary>Dark mode and phone layout</summary>

![Dark desktop preview](https://github.com/user-attachments/assets/76a0662d-ae77-4d5d-b469-77982a82496d)

![Phone preview](https://github.com/user-attachments/assets/f8991647-8676-439e-8c8d-b1d588194bfa)

</details>

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and landing-page CSS/markup only; no runtime or API behavior changes.
> 
> **Overview**
> Replaces the **New machine** landing section’s long annotated `mise.toml` card with a **bootstrap diagram** that shows one config flowing through `mise bootstrap` into four resource types (packages, repositories, dotfiles, services), plus a figcaption for `mise bootstrap plan`.
> 
> Adds dedicated **`.bootstrap-*` CSS** for the diagram layout (source block, connector, 2×2 resource grid, caption) and drops the old `.landing-config-card` styling tied to the TOML mockup. On narrow viewports, responsive rules still put the pitch first and the visual second, now targeting `.bootstrap-diagram`, and use `minmax(0, 1fr)` on the machine grid to avoid horizontal overflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c49a5718410e3eebb4a416b023b88a8babc64e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the home page’s bootstrap configuration card with a visual diagram showing how declarations flow through `mise bootstrap`.
  * Added illustrated resource categories for packages, repositories, dotfiles, and services.
  * Highlighted `mise bootstrap plan` as a command for previewing changes.
  * Improved the diagram’s responsive layout for narrow screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->