### PR TITLE
docs: diagram tool configuration precedence

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,33 @@ discovery, not a final override applied after the hierarchy.
                 └── mise.toml         # Service-specific config (highest precedence)
 ```
 
+### Example: merging tool versions
+
+For a project with these three config files, each later file overrides the same
+tool from an earlier file. A tool omitted from the later files is inherited.
+All entries shown below belong to each file's `[tools]` section.
+
+```mermaid
+---
+config:
+  htmlLabels: false
+---
+flowchart TB
+    accTitle: Tool configuration precedence
+    accDescr: Project and local config override the Node request. The Python request is inherited from global config.
+    global["Global config<br/>node = &quot;22&quot;<br/>python = &quot;3.13&quot;"]
+    project["Project mise.toml<br/>node = &quot;24&quot;"]
+    local["Project mise.local.toml<br/>node = &quot;20&quot;"]
+    effective["Effective tool requests<br/>node = &quot;20&quot;<br/>python = &quot;3.13&quot;"]
+    global -->|Override Node| project
+    project -->|Override Node again| local
+    local -->|Keep other tool requests| effective
+```
+
+The local file wins for Node; Python keeps its global request. These are version
+requests, which mise still resolves to concrete tool versions. This example
+illustrates `[tools]`; other sections have the merge rules below.
+
 ### Merge Behavior by Section
 
 Different configuration sections merge in different ways:


### PR DESCRIPTION
Add a worked diagram showing how global, project, and local `[tools]` entries combine. Node takes the local override while Python keeps its global request; the accompanying text distinguishes version requests from resolved versions and limits the example to tool merging.

Built with `mise run docs:build`; passed scoped hk checks. Checked Mermaid rendering and readable labels in light/dark mode at 1440px and 390px, with no horizontal page overflow or browser errors.

### Preview

![Desktop preview](https://github.com/user-attachments/assets/3f56d129-a4dc-4bf0-b457-cf4d1603f204)

<details>
<summary>Dark mode and phone layout</summary>

![Dark desktop preview](https://github.com/user-attachments/assets/3216db8d-8339-48f1-8e7f-57be41321b97)

![Phone preview](https://github.com/user-attachments/assets/bc02aec8-b659-4d19-bd5d-9e3561fd0abb)

</details>

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to configuration.md; no runtime or config-loading behavior is modified.
> 
> **Overview**
> Adds an **Example: merging tool versions** subsection to `docs/configuration.md`, immediately before **Merge Behavior by Section**.
> 
> The new content is a **Mermaid flowchart** that walks through global → project `mise.toml` → `mise.local.toml` for `[tools]`: Node is overridden at each step until the local file wins (`20`), while Python is inherited from global when absent from project/local files. Short prose clarifies that values shown are **version requests** (not final resolved installs), that omitted tools are inherited, and that the example applies only to `[tools]`—other sections still use the merge rules that follow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 741a8505282ecfab3d21bd18b4fde9d493b8fbda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an example explaining how tool versions are merged across global, project, and local configuration files.
  - Included a visual flowchart and resolved-version example showing that later values override earlier ones while unspecified tools are inherited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->