### PR TITLE
docs: diagram artifact cache execution

### DIFF
--- a/docs/tasks/caching.md
+++ b/docs/tasks/caching.md
@@ -17,6 +17,38 @@ For freshness configuration, see [`sources`](/tasks/task-configuration.html#sour
 and [`outputs`](/tasks/task-configuration.html#outputs). The remainder of this guide
 covers the experimental artifact cache.
 
+## Artifact cache flow
+
+For an eligible task with artifact caching enabled and cache reads and writes
+allowed, mise uses this flow:
+
+```mermaid
+---
+config:
+  htmlLabels: false
+---
+flowchart TB
+    accTitle: Artifact cache lookup and execution
+    accDescr: A usable artifact restores outputs and logs without running the task. Otherwise the task runs and successful results are saved.
+    inputs["Declared inputs<br/>and task context"]
+    key["Compute artifact key"]
+    lookup{"Cache hit?"}
+    restore["Restore outputs<br/>Replay logs<br/>Skip command"]
+    run["Run command"]
+    save["Save outputs<br/>and logs"]
+    inputs --> key --> lookup
+    lookup -->|Yes| restore
+    lookup -->|No| run
+    run -->|Success| save
+```
+
+This describes artifact caching, rather than the modification-time freshness
+check above. With `outputs = []`, a hit reuses the successful result and logs
+without restoring files. Failed runs are not cached. Forced runs, disabled cache
+access, and ineligible tasks can bypass parts of this flow; see
+[per-run cache access](#per-run-cache-access) and
+[storage and output replay](#storage-retention-and-output-replay).
+
 ## Enable artifact caching
 
 Stores successful task results in a content-addressed local cache and reuses them when the same task


### PR DESCRIPTION
Add an artifact-cache flow diagram showing cache-key computation, restoring a hit, and executing and saving a successful miss. Explain how this differs from timestamp freshness checks and note empty outputs, failed runs, and cache bypasses.

Built with `mise run docs:build`; passed scoped hk checks. Checked Mermaid rendering and readable labels in light/dark mode at 1440px and 390px, with no horizontal page overflow or browser errors.

### Preview

![Desktop preview](https://github.com/user-attachments/assets/21d4da51-6068-4a15-9536-51ee0fedeaec)

<details>
<summary>Dark mode and phone layout</summary>

![Dark desktop preview](https://github.com/user-attachments/assets/536a7332-2e6c-4f80-86c7-716dbda91d8b)

![Phone preview](https://github.com/user-attachments/assets/ecc82acf-bdcd-4f7c-86f2-0d708347482d)

</details>

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `docs/tasks/caching.md` with no runtime or configuration behavior changes.
> 
> **Overview**
> Adds an **Artifact cache flow** section to the task caching guide with a Mermaid flowchart for eligible tasks: declared inputs feed cache-key computation, a hit restores outputs and replays logs without running the command, and a miss runs the task and saves results on success.
> 
> The new prose clarifies that this path is separate from modification-time freshness checks, calls out **`outputs = []`** behavior, notes that failed runs are not cached, and points readers to per-run cache access and storage/replay for bypass and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7ecee223904d1ae7014f02bbc75e884c5cfd4bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “Artifact cache flow” section describing cache hits, misses, output restoration, log replay, and successful result storage.
  * Documented behavior for tasks with no outputs, failed runs, forced execution, disabled cache access, and ineligible tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->