### PR TITLE
fix(nushell): wrap hide-env in try instead of in-env guard

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -77,8 +77,8 @@ impl Shell for Nushell {
                 }} else {{
                   load-env {{($var.name): $var.value}}
                 }}
-              }} else if $var.op == "hide" and $var.name in $env {{
-                hide-env $var.name
+              }} else if $var.op == "hide" {{
+                try {{ hide-env $var.name }}
               }}
             }}
           }}

--- a/src/shell/snapshots/mise__shell__nushell__tests__hook_init.snap
+++ b/src/shell/snapshots/mise__shell__nushell__tests__hook_init.snap
@@ -14,8 +14,8 @@ def --env "update-env" [] {
       } else {
         load-env {($var.name): $var.value}
       }
-    } else if $var.op == "hide" and $var.name in $env {
-      hide-env $var.name
+    } else if $var.op == "hide" {
+      try { hide-env $var.name }
     }
   }
 }


### PR DESCRIPTION
`mise activate nu` emits `hide-env` guarded by `$var.name in $env`,
but in real hook contexts (export-env at startup, mise_hook on
prompt/cd) this still throws `nu::shell::env_variable_not_found`
(e.g. ABEYANT) on every prompt, breaking the session.

The guard checks merged-scope visibility while hide-env is
current-scope-sensitive, so the guard can pass and the hide still
throw. Wrap the call in `try` and drop the now-redundant guard,
matching other shells where unsetting a missing var is a no-op
(bash/zsh `unset`, fish `set -e`). `try` is used instead of the
`--ignore-errors` flag so the hook works on every Nushell version.

Verified: `cargo test shell::` (76 passed), `cargo fmt --check`
clean, plus a live `nu` check that `try` suppresses the error
for missing vars.

# before

$ cd
Error: nu::shell::env_variable_not_found

  × Environment variable 'ABEYANT' not found
    ╭─[/Users/a/.config/mise/hooks/mise-hook.nu:14:16]
 13 │     } else if $var.op == "hide" and $var.name in $env {
 14 │       hide-env $var.name
    ·                ────┬────
    ·                    ╰── environment variable not found
 15 │     }
    ╰────

# after

$ cd
$ 'hide,ABEYANT,\nhide,DEFINITELY_MISSING_XYZ123,'
  | from csv --noheaders --no-infer
  | rename op name value
  | update-env  # now runs `try { hide-env $var.name }`
hook-env applied with no error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nushell environment activation now silently ignores attempts to hide variables that are not present, avoiding unnecessary errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->