### PR TITLE
fix(dotfiles): honor global yes setting when tracking files

### DIFF
--- a/e2e/cli/test_dotfiles_track_yes
+++ b/e2e/cli/test_dotfiles_track_yes
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# stderr must be a terminal to exercise track's confirmation guard. Leave stdin
+# at EOF so a broken guard declines instead of waiting for an interactive answer.
+python3 - <<'PY'
+import errno
+import os
+from pathlib import Path
+import pty
+import subprocess
+
+for name, yes, flags, accepted in [
+    ("env-yes", "1", [], True),
+    ("flag-yes", "0", ["--yes"], True),
+    ("declined", "0", [], False),
+]:
+    target = Path.home() / f".track-{name}"
+    target.write_text("test fixture\n")
+    master, slave = pty.openpty()
+    try:
+        try:
+            result = subprocess.run(
+                ["mise", "bootstrap", "dotfiles", "track", *flags, str(target)],
+                env={**os.environ, "MISE_YES": yes},
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=slave,
+                timeout=30,
+                text=True,
+            )
+        finally:
+            os.close(slave)
+        chunks = []
+        while True:
+            try:
+                chunk = os.read(master, 4096)
+            except OSError as error:
+                if error.errno != errno.EIO:
+                    raise
+                break
+            if not chunk:
+                break
+            chunks.append(chunk)
+        output = result.stdout + b"".join(chunks).decode(errors="replace")
+    finally:
+        os.close(master)
+    assert result.returncode == 0, f"{name}: exit {result.returncode}: {output!r}"
+    if accepted:
+        assert "dotfiles: track " not in output, f"{name}: unexpected prompt: {output!r}"
+PY
+
+# Verify the declarations, independently of informational logging verbosity.
+# The unanswered request must not have enrolled its file.
+assert "mise bootstrap dotfiles paths --json | jq -r '.entries[].path' | sort" "$(printf '~/.track-env-yes\n~/.track-flag-yes')"

--- a/src/cli/dotfiles/track.rs
+++ b/src/cli/dotfiles/track.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use eyre::{Result, bail};
 use toml_edit::{Array, DocumentMut, InlineTable, Item, Value};
 
-use crate::config::Config;
+use crate::config::{Config, Settings};
 use crate::file::{self, display_path};
 use crate::path::PathExt;
 use crate::system::files::{FileMode, FileRequest};
@@ -117,7 +117,7 @@ impl DotfilesTrack {
             }
             declared.push((target_key, target));
         }
-        if !self.yes && console::user_attended_stderr() {
+        if !self.yes && !Settings::get().yes && console::user_attended_stderr() {
             let list = declared
                 .iter()
                 .map(|(key, _)| key.as_str())


### PR DESCRIPTION
Found this issue while running local tests for my current draft PR: https://github.com/jdx/mise/pull/13042.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `dotfiles track` now supports automatic confirmation when the global “yes” setting is enabled, in addition to the existing `--yes` option.

- **Tests**
  - Added end-to-end coverage for confirmation behavior, including accepted and declined tracking requests.
  - Verified that declined requests do not add dotfiles to tracking declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->