### PR TITLE
registry: added xytz

### DIFF
--- a/registry/xytz.toml
+++ b/registry/xytz.toml
@@ -1,0 +1,5 @@
+backends = ["github:xdagiz/xytz"]
+bins = ["xytz"]
+description = "A Beautiful YouTube Downloader/Player TUI"
+test = { cmd = "xytz --version", expected = "xytz version v{{version}}" }
+version_order = "semver"


### PR DESCRIPTION
Added [xytz](https://github.com/xdagiz/xytz), a TUI for yt-dlp into registry

## Popularity
- GitHub: 637 stars, 35 forks, Part of [awesome-tuis](https://github.com/rothgar/awesome-tuis)
- Latest release: v0.9.3 (Sep 7, 2026; previous release was Jul 26, 2026)
- Distribution: installer script, Homebrew (tap + formula), AUR, Scoop, go install, Nix flake

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata for the `xytz` GitHub backend, including version detection and semantic-version ordering support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->