### PR TITLE
fix(config): merge monorepo settings across overlays

### DIFF
--- a/e2e/tasks/test_task_monorepo_config_roots
+++ b/e2e/tasks/test_task_monorepo_config_roots
@@ -86,3 +86,62 @@ mise run '//packages/frontend:build' | grep -q "frontend build" || (echo "FAIL: 
 mise run '//services/api:serve' | grep -q "api serve" || (echo "FAIL: couldn't run api task" && exit 1)
 
 echo "=== All config_roots tests passed! ==="
+
+# Same-directory environment overlays are layers of one monorepo root. Repeating
+# monorepo_root in an overlay must not hide [monorepo] from the base config.
+mkdir -p overlay-projects/base overlay-projects/override
+cat <<'TOML' >overlay-projects/base/mise.toml
+[tasks.layer]
+run = 'echo "base layer"'
+TOML
+cat <<'TOML' >overlay-projects/override/mise.toml
+[tasks.layer]
+run = 'echo "override layer"'
+TOML
+
+cat <<'TOML' >mise.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["overlay-projects/base"]
+TOML
+cat <<'TOML' >mise.overlay.toml
+monorepo_root = true
+
+[env]
+OVERLAY_ACTIVE = true
+TOML
+
+echo "=== Test 5: overlays inherit config_roots from the base config ==="
+output=$(MISE_ENV=overlay mise tasks --all 2>&1)
+echo "$output"
+echo "$output" | grep -q "//overlay-projects/base:layer" || (echo "FAIL: base config_roots not inherited" && exit 1)
+if echo "$output" | grep -q "monorepo_auto_discovery"; then
+  echo "FAIL: automatic discovery warning emitted"
+  exit 1
+fi
+
+cat <<'TOML' >mise.overlay.toml
+monorepo_root = true
+
+[monorepo]
+config_roots = ["overlay-projects/override"]
+TOML
+
+echo "=== Test 6: overlay config_roots replace the base list ==="
+output=$(MISE_ENV=overlay mise tasks --all 2>&1)
+echo "$output"
+echo "$output" | grep -q "//overlay-projects/override:layer" || (echo "FAIL: overlay config_roots not used" && exit 1)
+if echo "$output" | grep -q "//overlay-projects/base:layer"; then
+  echo "FAIL: base config_roots should be replaced by the overlay"
+  exit 1
+fi
+
+cat <<'TOML' >mise.disabled.toml
+monorepo_root = false
+TOML
+
+echo "=== Test 7: overlays can disable a root ==="
+assert_fail_contains "MISE_ENV=disabled mise run //overlay-projects/base:layer 2>&1" "require a monorepo root configuration"
+
+echo "=== All layered config_roots tests passed! ==="

--- a/e2e/tasks/test_task_monorepo_trust
+++ b/e2e/tasks/test_task_monorepo_trust
@@ -43,6 +43,20 @@ assert_not_contains "mise tasks ls --all 2>&1" "Trust them"
 assert_contains "mise run '//projects/frontend:build'" "frontend build"
 assert_contains "mise run '//projects/frontend/components:test'" "component test"
 
+# A higher-precedence false overlay disables both monorepo behavior and the
+# derived trust marker. A marker created by the earlier commands must not keep
+# authorizing descendant configs.
+cat <<EOF >mise.disabled.toml
+monorepo_root = false
+EOF
+mkdir -p disabled-child
+cat <<EOF >disabled-child/mise.toml
+[env]
+UNTRUSTED_CHILD = "must prompt"
+EOF
+export MISE_TRUSTED_CONFIG_PATHS=""
+assert_contains "MISE_ENV=disabled MISE_YES=0 mise -C disabled-child env 2>&1 || true" "are not trusted"
+
 # Test that trust warnings DO appear for unsafe configs outside monorepo
 # (tasks-only configs are safe and load without trust, so use [env] to make
 # this one require trust)
@@ -56,8 +70,5 @@ run = 'echo "parent task"'
 EOF
 
 # Clear trust to simulate untrusted state
-# We need to explicitly unset MISE_TRUSTED_CONFIG_PATHS to test trust warnings
-export MISE_TRUSTED_CONFIG_PATHS=""
-
 # Verify trust error appears for the parent config (command should fail)
 assert_contains "MISE_YES=0 mise -C ../parent-dir tasks ls 2>&1 || true" "are not trusted"

--- a/src/config/config_file/mise_toml.rs
+++ b/src/config/config_file/mise_toml.rs
@@ -499,8 +499,7 @@ pub(crate) struct EnvList(pub(crate) Vec<EnvDirective>);
 pub(crate) struct MonorepoConfig {
     /// Explicit list of config roots for monorepo task discovery.
     /// Supports single-level glob patterns (*).
-    #[serde(default)]
-    pub config_roots: Vec<String>,
+    pub config_roots: Option<Vec<String>>,
     /// Use a single lockfile at the monorepo root for descendant config roots.
     /// None follows the rollout default; true opts in, false keeps colocated locks.
     pub lockfile: Option<bool>,

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -820,14 +820,22 @@ pub(crate) fn trust(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Marks a trusted config as a monorepo root, allowing all descendant configs to be trusted
-pub(crate) fn mark_as_monorepo_root(path: &Path) -> Result<()> {
+/// Synchronizes the derived monorepo marker used to trust descendant configs.
+pub(crate) fn set_monorepo_root_marker(path: &Path, enabled: bool) -> Result<()> {
     let config_root = config_trust_root(path);
     let hashed_path = trust_path(&config_root);
     let monorepo_marker = with_appended_extension(&hashed_path, "monorepo");
-    if !monorepo_marker.exists() {
+    if enabled && !monorepo_marker.exists() {
         file::create_dir_all(monorepo_marker.parent().unwrap())?;
         file::write(&monorepo_marker, "")?;
+    } else if !enabled && monorepo_marker.exists() {
+        file::remove_file(&monorepo_marker)?;
+        if let Ok(config_root) = config_root.canonicalize() {
+            IS_TRUSTED
+                .lock()
+                .unwrap()
+                .retain(|path| path == &config_root || !path.starts_with(&config_root));
+        }
     }
     Ok(())
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,7 +20,7 @@ use crate::cli::args::{BackendArg, split_bracketed_opts};
 use crate::cli::version;
 use crate::config::config_file::idiomatic_version::IdiomaticVersionFile;
 use crate::config::config_file::min_version::MinVersionSpec;
-use crate::config::config_file::mise_toml::{MiseToml, Tasks};
+use crate::config::config_file::mise_toml::{MiseToml, MonorepoConfig, Tasks};
 use crate::config::config_file::{
     ConfigFile, TaskConfig, config_trust_root, is_path_trusted, trust_check,
 };
@@ -719,14 +719,11 @@ impl Config {
     pub(crate) fn monorepo_lockfile_discovery_key(
         &self,
     ) -> Option<(PathBuf, Option<bool>, Vec<String>)> {
-        let cf = find_monorepo_config(&self.config_files)?;
-        let monorepo = cf.monorepo();
+        let config = find_monorepo_config(&self.config_files)?;
         Some((
-            cf.get_path().to_path_buf(),
-            monorepo.and_then(|config| config.lockfile),
-            monorepo
-                .map(|config| config.config_roots.clone())
-                .unwrap_or_default(),
+            config.monorepo_source.get_path().to_path_buf(),
+            config.monorepo.lockfile,
+            config.monorepo.config_roots.unwrap_or_default(),
         ))
     }
 
@@ -746,10 +743,7 @@ impl Config {
     pub(crate) async fn monorepo_global_task_inputs(self: &Arc<Self>) -> Result<Vec<String>> {
         let monorepo_config = find_monorepo_config(&self.config_files)
             .ok_or_else(|| eyre!("no config file in scope sets monorepo_root = true"))?;
-        let monorepo_root = monorepo_config
-            .project_root()
-            .ok_or_else(|| eyre!("monorepo root config has no project root"))?
-            .to_path_buf();
+        let monorepo_root = monorepo_config.root;
         let configs = self
             .config_files
             .values()
@@ -758,7 +752,7 @@ impl Config {
         let task_inputs = ResolvedTaskInputs::from_configs(&configs);
         let mut task = Task {
             name: "affected".to_string(),
-            cf: Some(monorepo_config.clone()),
+            cf: Some(monorepo_config.root_config),
             config_root: Some(monorepo_root),
             ..Default::default()
         };
@@ -782,14 +776,8 @@ impl Config {
     ) -> Result<crate::task::workspace::WorkspaceProjectGraph> {
         let monorepo_config = find_monorepo_config(&self.config_files)
             .ok_or_else(|| eyre!("no config file in scope sets monorepo_root = true"))?;
-        let monorepo_root = monorepo_config
-            .project_root()
-            .ok_or_else(|| eyre!("monorepo root config has no project root"))?;
-        let overrides = monorepo_config
-            .monorepo()
-            .map(|config| &config.projects)
-            .cloned()
-            .unwrap_or_default();
+        let monorepo_root = monorepo_config.root;
+        let overrides = monorepo_config.monorepo.projects;
         let cargo = crate::task::workspace::cargo::CargoWorkspaceProvider;
         let go = crate::task::workspace::go::GoWorkspaceProvider;
         let node = crate::task::workspace::node::NodeWorkspaceProvider;
@@ -808,12 +796,12 @@ impl Config {
     /// `[monorepo].config_roots` to match directories, because legacy lockfiles
     /// can exist in roots whose live config is idiomatic-only or was removed.
     pub(crate) fn monorepo_lockfile_root(&self) -> Option<PathBuf> {
-        let cf = find_monorepo_config(&self.config_files)?;
-        let setting = cf.monorepo().and_then(|m| m.lockfile);
+        let config = find_monorepo_config(&self.config_files)?;
+        let setting = config.monorepo.lockfile;
         if !monorepo_lockfile_enabled_for_version(&version::V, setting) {
             return None;
         }
-        let monorepo_root = cf.project_root().map(|p| p.to_path_buf())?;
+        let monorepo_root = config.root;
 
         // An explicit opt-in always routes descendant configs to the root
         // lockfile, even when config_roots cannot be resolved. Avoid expanding
@@ -864,21 +852,19 @@ impl Config {
     ) -> Result<Vec<PathBuf>> {
         let monorepo_config = find_monorepo_config(&self.config_files)
             .ok_or_else(|| eyre!("no config file in scope sets monorepo_root = true"))?;
-        let monorepo_root = monorepo_config
-            .project_root()
-            .ok_or_else(|| eyre!("monorepo root config has no project root"))?;
-        let patterns = &monorepo_config
-            .monorepo()
-            .ok_or_else(|| eyre!("[monorepo].config_roots is required for monorepo operations"))?
-            .config_roots;
+        let monorepo_root = monorepo_config.root;
+        let patterns = monorepo_config
+            .monorepo
+            .config_roots
+            .ok_or_else(|| eyre!("[monorepo].config_roots is required for monorepo operations"))?;
         if patterns.is_empty() {
             bail!("[monorepo].config_roots is required for monorepo operations");
         }
         let roots = match filenames {
             Some(filenames) => {
-                expand_config_roots_with_filenames(&monorepo_root, patterns, None, filenames)?
+                expand_config_roots_with_filenames(&monorepo_root, &patterns, None, filenames)?
             }
-            None => expand_config_root_dirs(&monorepo_root, patterns, None)?,
+            None => expand_config_root_dirs(&monorepo_root, &patterns, None)?,
         };
         if roots.is_empty() {
             bail!("[monorepo].config_roots did not match any config roots");
@@ -1720,25 +1706,68 @@ fn get_project_root(config_files: &ConfigMap) -> Option<PathBuf> {
 }
 
 fn find_monorepo_root(config_files: &ConfigMap) -> Option<PathBuf> {
-    find_monorepo_config(config_files).and_then(|cf| cf.project_root().map(|p| p.to_path_buf()))
+    find_monorepo_config(config_files).map(|config| config.root)
 }
 
-/// Find the config file that has monorepo_root = true
+#[derive(Clone)]
+struct ResolvedMonorepoConfig {
+    root: PathBuf,
+    root_config: Arc<dyn ConfigFile>,
+    monorepo_source: Arc<dyn ConfigFile>,
+    monorepo: MonorepoConfig,
+}
+
+/// Find the nearest directory whose effective layered config has `monorepo_root = true`.
 ///
 /// `ConfigMap` is ordered nearest-first — [`load_config_paths`] builds it from
-/// [`file::all_dirs`], which walks from the cwd upward — so the first match is the
-/// *deepest* applicable monorepo root. That matters when monorepo roots nest, e.g. a
-/// git worktree checked out inside the main checkout (`<repo>/.worktrees/<name>`),
-/// where both configs set `monorepo_root = true`: the nested one wins, and its
-/// `[monorepo].config_roots` are the ones expanded. Configs above the selected root
-/// still inherit as ordinary parent configs for env/tools/vars, but tasks from an
-/// enclosing monorepo are dropped — see [`dir_is_in_enclosing_monorepo`],
-/// `e2e/tasks/test_task_monorepo_nested_root`, and
-/// https://github.com/jdx/mise/discussions/11276.
-fn find_monorepo_config(config_files: &ConfigMap) -> Option<&Arc<dyn ConfigFile>> {
+/// [`file::all_dirs`], which walks from the cwd upward. Within one directory,
+/// `configs_at_root` returns config layers from highest to lowest precedence, so an
+/// environment overlay can override `monorepo_root` without becoming a separate root.
+/// This preserves nearest-root behavior for nested monorepos while resolving sibling
+/// overlays as one logical root configuration.
+fn find_monorepo_config(config_files: &ConfigMap) -> Option<ResolvedMonorepoConfig> {
     config_files
         .values()
-        .find(|cf| cf.monorepo_root() == Some(true))
+        .filter_map(|cf| cf.project_root())
+        .unique()
+        .find_map(|root| resolve_monorepo_config_at_root(&root, config_files))
+}
+
+fn resolve_monorepo_config_at_root(
+    root: &Path,
+    config_files: &ConfigMap,
+) -> Option<ResolvedMonorepoConfig> {
+    let configs = configs_at_root(root, config_files);
+    let (root_config, enabled) = configs
+        .iter()
+        .find_map(|cf| cf.monorepo_root().map(|enabled| ((*cf).clone(), enabled)))?;
+    if !enabled {
+        return None;
+    }
+
+    let mut monorepo = MonorepoConfig::default();
+    let mut monorepo_source = root_config.clone();
+    for cf in configs.into_iter().rev() {
+        let Some(layer) = cf.monorepo() else {
+            continue;
+        };
+        monorepo_source = cf.clone();
+        if layer.config_roots.is_some() {
+            monorepo.config_roots.clone_from(&layer.config_roots);
+        }
+        if layer.lockfile.is_some() {
+            monorepo.lockfile = layer.lockfile;
+        }
+        monorepo.projects.extend(layer.projects.clone());
+        monorepo.task_defaults.extend(layer.task_defaults.clone());
+    }
+
+    Some(ResolvedMonorepoConfig {
+        root: root.to_path_buf(),
+        root_config,
+        monorepo_source,
+        monorepo,
+    })
 }
 
 /// Loads each selected bootstrap root as an independent hierarchy with scoped variables.
@@ -2461,15 +2490,15 @@ fn warn_if_monorepo_lockfile_default_changes(config: &Config) {
         !monorepo_lockfile_default_for_version(&version::V),
         "monorepo lockfiles are now default-on; remove warn_if_monorepo_lockfile_default_changes() and should_warn_monorepo_lockfile_default()"
     );
-    let Some(cf) = find_monorepo_config(&config.config_files) else {
+    let Some(monorepo_config) = find_monorepo_config(&config.config_files) else {
         return;
     };
-    let setting = cf.monorepo().and_then(|m| m.lockfile);
+    let setting = monorepo_config.monorepo.lockfile;
     if !should_warn_monorepo_lockfile_default(
         &version::V,
         setting,
         Settings::get().lockfile_enabled(),
-        monorepo_lockfiles_exist(config, cf),
+        monorepo_lockfiles_exist(config, &monorepo_config),
     ) {
         return;
     }
@@ -2477,14 +2506,12 @@ fn warn_if_monorepo_lockfile_default_changes(config: &Config) {
     warn_once!(
         "Monorepo lockfiles will default to a single root lockfile starting in mise {MONOREPO_LOCKFILE_DEFAULT_AT}. \
         Set `[monorepo] lockfile = true` in {} to opt in now, or `lockfile = false` to keep per-subproject lockfiles and silence this warning.",
-        display_path(cf.get_path())
+        display_path(monorepo_config.monorepo_source.get_path())
     );
 }
 
-fn monorepo_lockfiles_exist(config: &Config, monorepo_config: &Arc<dyn ConfigFile>) -> bool {
-    let Some(monorepo_root) = monorepo_config.project_root() else {
-        return false;
-    };
+fn monorepo_lockfiles_exist(config: &Config, monorepo_config: &ResolvedMonorepoConfig) -> bool {
+    let monorepo_root = &monorepo_config.root;
     let mut lockfile_paths = IndexSet::new();
 
     for (config_path, cf) in &config.config_files {
@@ -2497,9 +2524,8 @@ fn monorepo_lockfiles_exist(config: &Config, monorepo_config: &Arc<dyn ConfigFil
         );
     }
 
-    if let Some(monorepo) = monorepo_config.monorepo()
-        && let Ok(config_roots) =
-            expand_config_root_dirs(&monorepo_root, &monorepo.config_roots, None)
+    if let Some(patterns) = &monorepo_config.monorepo.config_roots
+        && let Ok(config_roots) = expand_config_root_dirs(monorepo_root, patterns, None)
     {
         for config_root in config_roots {
             for lockfile_path in lockfile::lockfile_variant_paths_in_dir(&config_root) {
@@ -3471,15 +3497,19 @@ fn collect_task_definitions(
     let workspace_defaults = Settings::get()
         .experimental
         .then(|| {
-            let cf = find_monorepo_config(config_files)?;
-            let root = cf.project_root()?.to_path_buf();
-            let monorepo = cf.monorepo()?;
-            let tasks = monorepo.task_defaults.clone();
-            let mut project_roots = expand_config_root_dirs(&root, &monorepo.config_roots, None)
-                .unwrap_or_default()
-                .into_iter()
-                .map(|project_root| file::desymlink_path(&project_root))
-                .collect::<BTreeSet<_>>();
+            let config = find_monorepo_config(config_files)?;
+            let root = config.root;
+            let monorepo = config.monorepo;
+            let tasks = monorepo.task_defaults;
+            let mut project_roots = expand_config_root_dirs(
+                &root,
+                monorepo.config_roots.as_deref().unwrap_or_default(),
+                None,
+            )
+            .unwrap_or_default()
+            .into_iter()
+            .map(|project_root| file::desymlink_path(&project_root))
+            .collect::<BTreeSet<_>>();
             project_roots.extend(
                 monorepo
                     .projects
@@ -3498,7 +3528,7 @@ fn collect_task_definitions(
             (!tasks.is_empty()).then_some(WorkspaceTaskDefaults {
                 project_roots,
                 tasks,
-                source: cf.get_path().to_path_buf(),
+                source: config.monorepo_source.get_path().to_path_buf(),
             })
         })
         .flatten();
@@ -4070,8 +4100,9 @@ async fn inferred_workspace_tasks(
 fn enclosing_monorepo_roots(config_files: &ConfigMap, selected_root: &Path) -> Vec<PathBuf> {
     config_files
         .values()
-        .filter(|cf| cf.monorepo_root() == Some(true))
         .filter_map(|cf| cf.project_root())
+        .unique()
+        .filter_map(|root| resolve_monorepo_config_at_root(&root, config_files).map(|c| c.root))
         .filter(|root| {
             !file::same_file(root, selected_root)
                 && file::path_starts_with_resolved(selected_root, root)
@@ -4115,7 +4146,7 @@ async fn load_local_tasks_with_context(
 ) -> Result<Vec<Task>> {
     let mut tasks = vec![];
     let monorepo_config = find_monorepo_config(&config.config_files);
-    let monorepo_root = monorepo_config.and_then(|cf| cf.project_root().map(|p| p.to_path_buf()));
+    let monorepo_root = monorepo_config.as_ref().map(|config| config.root.clone());
 
     // Load tasks from parent directories (current working directory up to root)
 
@@ -4170,8 +4201,8 @@ async fn load_local_tasks_with_context(
 
         // Get config_roots from [monorepo] section if defined
         let config_roots = monorepo_config
-            .and_then(|cf| cf.monorepo())
-            .map(|m| &m.config_roots);
+            .as_ref()
+            .and_then(|config| config.monorepo.config_roots.as_ref());
         let subdirs = discover_monorepo_subdirs(monorepo_root, config_roots, ctx)?;
 
         // Load tasks from subdirectories in parallel

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1715,6 +1715,7 @@ struct ResolvedMonorepoConfig {
     root_config: Arc<dyn ConfigFile>,
     monorepo_source: Arc<dyn ConfigFile>,
     monorepo: MonorepoConfig,
+    task_defaults: IndexMap<String, SourcedTaskTemplate>,
 }
 
 /// Find the nearest directory whose effective layered config has `monorepo_root = true`.
@@ -1747,6 +1748,7 @@ fn resolve_monorepo_config_at_root(
 
     let mut monorepo = MonorepoConfig::default();
     let mut monorepo_source = root_config.clone();
+    let mut task_defaults = IndexMap::new();
     for cf in configs.into_iter().rev() {
         let Some(layer) = cf.monorepo() else {
             continue;
@@ -1760,6 +1762,15 @@ fn resolve_monorepo_config_at_root(
         }
         monorepo.projects.extend(layer.projects.clone());
         monorepo.task_defaults.extend(layer.task_defaults.clone());
+        task_defaults.extend(layer.task_defaults.iter().map(|(name, template)| {
+            (
+                name.clone(),
+                SourcedTaskTemplate {
+                    template: template.clone(),
+                    source: cf.get_path().to_path_buf(),
+                },
+            )
+        }));
     }
 
     Some(ResolvedMonorepoConfig {
@@ -1767,6 +1778,7 @@ fn resolve_monorepo_config_at_root(
         root_config,
         monorepo_source,
         monorepo,
+        task_defaults,
     })
 }
 
@@ -2515,7 +2527,7 @@ fn monorepo_lockfiles_exist(config: &Config, monorepo_config: &ResolvedMonorepoC
     let mut lockfile_paths = IndexSet::new();
 
     for (config_path, cf) in &config.config_files {
-        if !config_path.starts_with(&monorepo_root) || !cf.source().is_mise_toml() {
+        if !config_path.starts_with(monorepo_root) || !cf.source().is_mise_toml() {
             continue;
         }
         lockfile_paths.insert(lockfile::lockfile_path_for_config(config_path, None).0);
@@ -3100,34 +3112,60 @@ async fn load_all_config_files(
     idiomatic_filenames: &BTreeMap<String, Vec<String>>,
 ) -> Result<ConfigMap> {
     backend::load_tools().await?;
-    let mut config_map = ConfigMap::default();
-    for f in config_filenames.iter().unique() {
-        if f.is_dir() {
-            continue;
-        }
-        let cf = match parse_config_file(f, idiomatic_filenames).await {
-            Ok(cfg) => cfg,
-            Err(err) => {
-                return Err(err.wrap_err(format!(
-                    "error parsing config file: {}",
-                    style::ebold(display_path(f))
-                )));
+    let mut groups = config_filenames
+        .iter()
+        .unique()
+        .filter(|path| !path.is_dir())
+        .fold(
+            IndexMap::<PathBuf, Vec<&PathBuf>>::new(),
+            |mut groups, path| {
+                groups
+                    .entry(config_trust_root(path))
+                    .or_default()
+                    .push(path);
+                groups
+            },
+        )
+        .into_iter()
+        .collect_vec();
+    // Resolve trusted ancestor roots before parsing descendants so a stale
+    // monorepo marker cannot authorize a child after an overlay disables it.
+    groups.sort_by_key(|(root, _)| root.components().count());
+
+    let mut parsed = HashMap::new();
+    for (_, paths) in groups {
+        let mut root_configs = ConfigMap::new();
+        for f in paths {
+            let cf = match parse_config_file(f, idiomatic_filenames).await {
+                Ok(cfg) => cfg,
+                Err(err) => {
+                    return Err(err.wrap_err(format!(
+                        "error parsing config file: {}",
+                        style::ebold(display_path(f))
+                    )));
+                }
+            };
+            if let Err(err) = Tracker::track(f) {
+                warn!("tracking config: {err:#}");
             }
-        };
-        if let Err(err) = Tracker::track(f) {
-            warn!("tracking config: {err:#}");
+            parsed.insert(f.clone(), cf.clone());
+            root_configs.insert(f.clone(), cf);
         }
 
-        // Mark monorepo roots so descendant configs are implicitly trusted
-        if cf.monorepo_root() == Some(true)
-            && let Err(err) = config_file::mark_as_monorepo_root(f)
-        {
-            warn!("failed to mark monorepo root: {err:#}");
+        if let Some(project_root) = root_configs.values().find_map(|cf| cf.project_root()) {
+            let enabled = resolve_monorepo_config_at_root(&project_root, &root_configs).is_some();
+            if let Some(source) = root_configs.values().next()
+                && let Err(err) = config_file::set_monorepo_root_marker(source.get_path(), enabled)
+            {
+                warn!("failed to synchronize monorepo root marker: {err:#}");
+            }
         }
-
-        config_map.insert(f.clone(), cf);
     }
-    Ok(config_map)
+
+    Ok(config_filenames
+        .iter()
+        .filter_map(|path| parsed.remove(path).map(|cf| (path.clone(), cf)))
+        .collect())
 }
 
 /// Load config files from a list of paths (for monorepo task config contexts)
@@ -3468,8 +3506,7 @@ struct SourcedTaskTemplate {
 #[derive(Clone, Debug)]
 struct WorkspaceTaskDefaults {
     project_roots: BTreeSet<PathBuf>,
-    tasks: IndexMap<String, TaskTemplate>,
-    source: PathBuf,
+    tasks: IndexMap<String, SourcedTaskTemplate>,
 }
 
 /// Collect all task templates from the config file hierarchy and task-name defaults from the
@@ -3500,7 +3537,7 @@ fn collect_task_definitions(
             let config = find_monorepo_config(config_files)?;
             let root = config.root;
             let monorepo = config.monorepo;
-            let tasks = monorepo.task_defaults;
+            let tasks = config.task_defaults;
             let mut project_roots = expand_config_root_dirs(
                 &root,
                 monorepo.config_roots.as_deref().unwrap_or_default(),
@@ -3528,7 +3565,6 @@ fn collect_task_definitions(
             (!tasks.is_empty()).then_some(WorkspaceTaskDefaults {
                 project_roots,
                 tasks,
-                source: config.monorepo_source.get_path().to_path_buf(),
             })
         })
         .flatten();
@@ -3577,8 +3613,8 @@ fn resolve_task_template(task: &mut Task, definitions: &TaskDefinitions) -> Resu
             .filter(|_| crate::task::is_workspace_project_task(&task.name))
             .map_or(task.name.as_str(), |(_, name)| name);
         if let Some(default) = defaults.tasks.get(task_name) {
-            task.merge_template(default);
-            task.add_config_source(&defaults.source);
+            task.merge_template(&default.template);
+            task.add_config_source(&default.source);
         }
     }
     Ok(())
@@ -5847,12 +5883,14 @@ mod tests {
             project_roots: BTreeSet::from([project_root.clone()]),
             tasks: IndexMap::from([(
                 "build".to_string(),
-                TaskTemplate {
-                    description: "default description".to_string(),
-                    ..Default::default()
+                SourcedTaskTemplate {
+                    template: TaskTemplate {
+                        description: "default description".to_string(),
+                        ..Default::default()
+                    },
+                    source: defaults_source.clone(),
                 },
             )]),
-            source: defaults_source.clone(),
         });
         let primary_source = project_root.join("mise.toml");
         let mut task = Task {


### PR DESCRIPTION
## Summary
- resolve monorepo roots from the effective same-directory config layers instead of whichever individual file appears first
- inherit omitted monorepo fields while allowing higher-precedence overlays to replace config_roots and override scalar values
- preserve nearest-root behavior for nested monorepos and allow an overlay to disable a root

Related to https://github.com/jdx/mise/discussions/13035

## Testing
- mise run lint
- mise run test:e2e e2e/tasks/test_task_monorepo_config_roots
- mise run test:e2e e2e/tasks/test_task_monorepo_nested_root e2e/cli/test_install_monorepo

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes config layering, monorepo task discovery, and derived trust markers—incorrect merge or marker sync could widen implicit trust or break monorepo commands.
> 
> **Overview**
> Monorepo roots are now resolved from **all config layers in the same directory** (base + env overlays), not from whichever single file wins in the flat config map. Effective `[monorepo]` settings are merged low-to-high precedence: omitted fields (including `config_roots`) are inherited, while an overlay that sets `config_roots` **replaces** the base list; `monorepo_root = false` in a higher layer disables the root entirely.
> 
> Downstream monorepo behavior (task discovery, lockfiles, workspace graph, task defaults) reads this **resolved** config via a new `ResolvedMonorepoConfig`. `[monorepo].config_roots` is now `Option<Vec<String>>` so “missing” and “explicit empty” differ during merge.
> 
> Trust sync changes: **`set_monorepo_root_marker`** creates or removes the derived monorepo marker from the effective layered state, clears stale descendant trust from cache when disabled, and config parsing groups files by trust root and processes **shallower roots first** so a disabled overlay cannot leave an old marker authorizing children. E2E tests cover overlay `config_roots` inheritance/replacement and trust after disabling a root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f5c83e8059f67abb7802f6653b7c50f0fc6121d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Monorepo settings can be layered across project configuration files.
  - Overlays inherit `config_roots` when none are specified or replace inherited entries when provided.

- **Bug Fixes**
  - Monorepo task discovery and workspace behavior now consistently use the effective configuration.
  - Setting `monorepo_root = false` in an overlay disables the monorepo root and descendant trust.
  - Disabled roots no longer retain stale trust markers.
  - Task execution reports a clear error when monorepo root configuration is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->