### PR TITLE
fix(task): auto-install tools for run task references

### DIFF
--- a/e2e/tasks/test_task_skip_tools
+++ b/e2e/tasks/test_task_skip_tools
@@ -12,6 +12,13 @@ run = 'echo hello'
 # if tools were being installed, mise would try to install tiny
 tools = { tiny = "1.0.0" }
 run = 'echo ran'
+
+[tasks.deferred-check]
+tools = { tiny = "2.0.0" }
+run = 'echo deferred ran'
+
+[tasks.deferred-parent]
+run = [{ task = "deferred-check" }]
 EOF
 
 # --skip-tools before task name is a mise flag (skips tool install, task runs)
@@ -23,6 +30,12 @@ assert "mise run echo-args --skip-tools" "args: --skip-tools"
 # verify --skip-tools skips task-level tool installation
 # task declares tools = { tiny = "1.0.0" } but --skip-tools prevents install attempt
 assert "mise run --skip-tools check-tiny" "ran"
+
+rm -rf "$MISE_DATA_DIR/installs/tiny/2.0.0"
+
+# --skip-tools also applies to tasks resolved later from run entries.
+assert "mise run --skip-tools deferred-parent" "deferred ran"
+assert_fail "test -d '$MISE_DATA_DIR/installs/tiny/2.0.0'"
 
 credential_marker="$HOME/github-credential-command-called"
 credential_command="$HOME/fake-github-credential-command"

--- a/e2e/tasks/test_task_skip_tools
+++ b/e2e/tasks/test_task_skip_tools
@@ -31,8 +31,6 @@ assert "mise run echo-args --skip-tools" "args: --skip-tools"
 # task declares tools = { tiny = "1.0.0" } but --skip-tools prevents install attempt
 assert "mise run --skip-tools check-tiny" "ran"
 
-rm -rf "$MISE_DATA_DIR/installs/tiny/2.0.0"
-
 # --skip-tools also applies to tasks resolved later from run entries.
 assert "mise run --skip-tools deferred-parent" "deferred ran"
 assert_fail "test -d '$MISE_DATA_DIR/installs/tiny/2.0.0'"

--- a/e2e/tasks/test_task_tools
+++ b/e2e/tasks/test_task_tools
@@ -27,6 +27,24 @@ assert "mise run parent" "rtx-tiny: v1.1.0 args:"
 assert "mise run templated-parent" "rtx-tiny: v2.1.0 args:"
 
 cat <<EOF >mise.toml
+[tasks.install-failure]
+tools = { dummy = "other-dummy" }
+run = "echo should-not-run"
+
+[tasks.install-failure-parent]
+run = [{ task = "install-failure" }]
+
+[tasks.install-sibling]
+run = "sleep 0.2; echo sibling-completed"
+EOF
+
+# A failed late install is reported as a task failure and does not bypass
+# completion of already-running siblings in continue-on-error mode.
+assert_fail_contains \
+  "mise run --continue-on-error install-failure-parent ::: install-sibling 2>&1" \
+  "sibling-completed"
+
+cat <<EOF >mise.toml
 [tasks.a]
 tools = { tiny = "1" }
 run = "rtx-tiny"

--- a/e2e/tasks/test_task_tools
+++ b/e2e/tasks/test_task_tools
@@ -51,14 +51,18 @@ run = "dummy"
 tools = { dummy = "2.0.0" }
 run = "dummy"
 
-[tasks.install-pair]
-run = [{ task = "install-one" }, { task = "install-two" }]
+[tasks.install-one-parent]
+run = [{ task = "install-one" }]
+
+[tasks.install-two-parent]
+run = [{ task = "install-two" }]
 EOF
 
-# Deferred installs share the task scheduler's jobs limit.
+# Concurrent parents inject both children at once, so the overlap marker proves
+# deferred installs share the task scheduler's jobs limit.
 install_gate="$HOME/deferred-install-gate"
 assert_contains \
-  "DUMMY_INSTALL_GATE_DIR='$install_gate' mise run --jobs 1 install-pair" \
+  "DUMMY_INSTALL_GATE_DIR='$install_gate' mise run --jobs 1 install-one-parent ::: install-two-parent" \
   "This is Dummy"
 assert_fail "test -e '$install_gate.overlap'"
 

--- a/e2e/tasks/test_task_tools
+++ b/e2e/tasks/test_task_tools
@@ -1,6 +1,32 @@
 #!/usr/bin/env bash
 
 cat <<EOF >mise.toml
+[tasks.child]
+tools = { tiny = "1" }
+run = "rtx-tiny"
+
+[tasks.parent]
+run = [{ task = "child" }]
+
+[tasks.templated-child]
+tools = { tiny = "2" }
+run = "rtx-tiny"
+
+[tasks.templated-parent]
+env = { CHILD = "templated-child" }
+run = [{ task = "{{ env.CHILD }}" }]
+EOF
+
+rm -rf "$MISE_DATA_DIR/installs/tiny"
+
+# A task referenced from a run entry is resolved at execution time, but its
+# task-only tools must still be installed before the injected task starts.
+assert "mise run parent" "rtx-tiny: v1.1.0 args:"
+
+# Runtime-rendered task references take the same late installation path.
+assert "mise run templated-parent" "rtx-tiny: v2.1.0 args:"
+
+cat <<EOF >mise.toml
 [tasks.a]
 tools = { tiny = "1" }
 run = "rtx-tiny"

--- a/e2e/tasks/test_task_tools
+++ b/e2e/tasks/test_task_tools
@@ -17,8 +17,6 @@ env = { CHILD = "templated-child" }
 run = [{ task = "{{ env.CHILD }}" }]
 EOF
 
-rm -rf "$MISE_DATA_DIR/installs/tiny"
-
 # A task referenced from a run entry is resolved at execution time, but its
 # task-only tools must still be installed before the injected task starts.
 assert "mise run parent" "rtx-tiny: v1.1.0 args:"
@@ -43,6 +41,26 @@ EOF
 assert_fail_contains \
   "mise run --continue-on-error install-failure-parent ::: install-sibling 2>&1" \
   "sibling-completed"
+
+cat <<EOF >mise.toml
+[tasks.install-one]
+tools = { dummy = "1.0.0" }
+run = "dummy"
+
+[tasks.install-two]
+tools = { dummy = "2.0.0" }
+run = "dummy"
+
+[tasks.install-pair]
+run = [{ task = "install-one" }, { task = "install-two" }]
+EOF
+
+# Deferred installs share the task scheduler's jobs limit.
+install_gate="$HOME/deferred-install-gate"
+assert_contains \
+  "DUMMY_INSTALL_GATE_DIR='$install_gate' mise run --jobs 1 install-pair" \
+  "This is Dummy"
+assert_fail "test -e '$install_gate.overlap'"
 
 cat <<EOF >mise.toml
 [tasks.a]

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -934,17 +934,23 @@ impl Run {
                     async move {
                         if install_tools && !this.skip_tools {
                             let mut install_config = spawn_context.config.clone();
-                            crate::task::task_tool_installer::TaskToolInstaller::new(
-                                &this.context_builder,
-                                &this.tool,
-                            )
-                            .install_tasks(
-                                &mut install_config,
-                                vec![task.clone()],
-                                this.dry_run,
-                                &HashSet::new(),
-                            )
-                            .await?;
+                            let install_result =
+                                crate::task::task_tool_installer::TaskToolInstaller::new(
+                                    &this.context_builder,
+                                    &this.tool,
+                                )
+                                .install_tasks(
+                                    &mut install_config,
+                                    vec![task.clone()],
+                                    this.dry_run,
+                                    &HashSet::new(),
+                                )
+                                .await;
+                            if let Err(err) = install_result {
+                                this.fail_sched_job_before_start(task, deps_for_remove, err)
+                                    .await;
+                                return Ok(());
+                            }
                         }
                         Self::spawn_sched_job(
                             this,
@@ -1164,6 +1170,33 @@ impl Run {
         });
 
         Ok(())
+    }
+
+    /// Record a preparation failure through the same task-level result path as
+    /// an execution failure, then release its dependency graph entry.
+    async fn fail_sched_job_before_start(
+        &self,
+        task: Task,
+        deps_for_remove: Arc<Mutex<Deps>>,
+        err: eyre::Report,
+    ) {
+        let prefix = task.estyled_prefix();
+        if Settings::get().verbose {
+            self.eprint(&task, &prefix, &format!("{} {err:?}", style::ered("ERROR")));
+        } else {
+            self.eprint(&task, &prefix, &format!("{} {err}", style::ered("ERROR")));
+        }
+        self.add_failed_task(task.clone(), Error::get_exit_status(&err));
+        if !self.continue_on_error {
+            #[cfg(unix)]
+            crate::cmd::CmdLineRunner::kill_all(nix::sys::signal::SIGTERM);
+            #[cfg(windows)]
+            crate::cmd::CmdLineRunner::kill_all();
+        }
+        self.retire_keep_order_slot(&task);
+        let mut deps = deps_for_remove.lock().await;
+        deps.mark_executed(&task);
+        deps.remove(&task);
     }
 
     /// Retire a task's keep-order slot because it will never run.

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -928,10 +928,24 @@ impl Run {
                     on_task_dropped: |task: &Task| this.retire_keep_order_slot(task),
                     continue_on_error: this.continue_on_error,
                 },
-                |task, deps_for_remove, allow_during_interruption| {
+                |task, deps_for_remove, allow_during_interruption, install_tools| {
                     let this = this.clone();
                     let spawn_context = spawn_context.clone();
                     async move {
+                        if install_tools && !this.skip_tools {
+                            let mut install_config = spawn_context.config.clone();
+                            crate::task::task_tool_installer::TaskToolInstaller::new(
+                                &this.context_builder,
+                                &this.tool,
+                            )
+                            .install_tasks(
+                                &mut install_config,
+                                vec![task.clone()],
+                                this.dry_run,
+                                &HashSet::new(),
+                            )
+                            .await?;
+                        }
                         Self::spawn_sched_job(
                             this,
                             task,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -932,31 +932,12 @@ impl Run {
                     let this = this.clone();
                     let spawn_context = spawn_context.clone();
                     async move {
-                        if install_tools && !this.skip_tools {
-                            let mut install_config = spawn_context.config.clone();
-                            let install_result =
-                                crate::task::task_tool_installer::TaskToolInstaller::new(
-                                    &this.context_builder,
-                                    &this.tool,
-                                )
-                                .install_tasks(
-                                    &mut install_config,
-                                    vec![task.clone()],
-                                    this.dry_run,
-                                    &HashSet::new(),
-                                )
-                                .await;
-                            if let Err(err) = install_result {
-                                this.fail_sched_job_before_start(task, deps_for_remove, err)
-                                    .await;
-                                return Ok(());
-                            }
-                        }
                         Self::spawn_sched_job(
                             this,
                             task,
                             deps_for_remove,
                             allow_during_interruption,
+                            install_tools,
                             spawn_context,
                         )
                         .await
@@ -991,6 +972,7 @@ impl Run {
         task: Task,
         deps_for_remove: Arc<Mutex<Deps>>,
         inherited_allow_during_interruption: bool,
+        install_tools: bool,
         ctx: crate::task::task_scheduler::SpawnContext,
     ) -> Result<()> {
         if Self::should_abort_while_stopping(
@@ -1008,8 +990,9 @@ impl Run {
             );
             return Ok(());
         }
-        let needs_permit = task_needs_permit(&task);
-        let permit_opt = if needs_permit {
+        let needs_task_permit = task_needs_permit(&task);
+        let needs_install = install_tools && !this.skip_tools;
+        let mut permit_opt = if needs_task_permit || needs_install {
             let wait_start = std::time::Instant::now();
             let p = Some(ctx.semaphore.clone().acquire_owned().await?);
             trace!(
@@ -1040,6 +1023,51 @@ impl Run {
             trace!("no semaphore needed for orchestrator task: {}", task.name);
             None
         };
+
+        if needs_install {
+            let mut install_config = ctx.config.clone();
+            let install_result = crate::task::task_tool_installer::TaskToolInstaller::new(
+                &this.context_builder,
+                &this.tool,
+            )
+            .install_tasks(
+                &mut install_config,
+                vec![task.clone()],
+                this.dry_run,
+                &HashSet::new(),
+            )
+            .await;
+            if let Err(err) = install_result {
+                if Self::should_abort_while_stopping(
+                    &this,
+                    &task,
+                    &deps_for_remove,
+                    inherited_allow_during_interruption,
+                )
+                .await
+                {
+                    return Ok(());
+                }
+                this.fail_sched_job_before_start(task, deps_for_remove, err)
+                    .await;
+                return Ok(());
+            }
+            if Self::should_abort_while_stopping(
+                &this,
+                &task,
+                &deps_for_remove,
+                inherited_allow_during_interruption,
+            )
+            .await
+            {
+                return Ok(());
+            }
+            if !needs_task_permit {
+                // Orchestrator tasks must release the preparation permit before
+                // waiting for children, especially when --jobs is 1.
+                permit_opt = None;
+            }
+        }
 
         ctx.in_flight
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);

--- a/src/task/task_executor.rs
+++ b/src/task/task_executor.rs
@@ -1098,7 +1098,7 @@ impl TaskExecutor {
                             any = true;
                             let task = task.derive_env(&task_env_directives);
                             trace!("inject initial leaf: {} {}", task.name, task.args.join(" "));
-                            let _ = sched_tx.send(SchedMsg::new(
+                            let _ = sched_tx.send(SchedMsg::injected(
                                 task,
                                 sub_deps_clone.clone(),
                                 allow_during_interruption,
@@ -1132,7 +1132,7 @@ impl TaskExecutor {
                                 task.args.join(" ")
                             );
                             let task = task.derive_env(&task_env_directives);
-                            let _ = sched_tx.send(SchedMsg::new(
+                            let _ = sched_tx.send(SchedMsg::injected(
                                 task,
                                 sub_deps_clone.clone(),
                                 allow_during_interruption,

--- a/src/task/task_scheduler.rs
+++ b/src/task/task_scheduler.rs
@@ -2,6 +2,7 @@ use crate::cmd::CmdLineRunner;
 use crate::config::Config;
 use crate::task::{Deps, Task};
 use eyre::Result;
+use futures_util::stream::{FuturesUnordered, StreamExt};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::{Mutex, Semaphore, mpsc};
@@ -245,6 +246,7 @@ impl Scheduler {
             continue_on_error,
         } = hooks;
         let mut sched_rx = self.take_receiver().expect("receiver already taken");
+        let mut pending_jobs = FuturesUnordered::new();
         let mut stop_cleanup_done = false;
 
         loop {
@@ -272,13 +274,12 @@ impl Scheduler {
                                 continue;
                             }
                         }
-                        spawn_job(
+                        pending_jobs.push(spawn_job(
                             task,
                             deps_for_remove,
                             allow_during_interruption,
                             install_tools,
-                        )
-                        .await?;
+                        ));
                     }
                     Err(mpsc::error::TryRecvError::Empty) => break,
                     Err(mpsc::error::TryRecvError::Disconnected) => break,
@@ -315,13 +316,22 @@ impl Scheduler {
             }
 
             // Exit if main deps finished and nothing is running/queued
-            if *main_done_rx.borrow() && self.in_flight_count() == 0 && !drained_any {
+            if *main_done_rx.borrow()
+                && self.in_flight_count() == 0
+                && pending_jobs.is_empty()
+                && !drained_any
+            {
                 trace!("scheduler drain complete; exiting loop");
                 break;
             }
 
             // Await either new work or main_done change
             tokio::select! {
+                result = pending_jobs.next(), if !pending_jobs.is_empty() => {
+                    if let Some(result) = result {
+                        result?;
+                    }
+                }
                 m = sched_rx.recv() => {
                     if let Some(SchedMsg {
                         task,
@@ -342,13 +352,12 @@ impl Scheduler {
                                 continue;
                             }
                         }
-                        spawn_job(
+                        pending_jobs.push(spawn_job(
                             task,
                             deps_for_remove,
                             allow_during_interruption,
                             install_tools,
-                        )
-                        .await?;
+                        ));
                     } else {
                         // channel closed; rely on main_done/in_flight to exit soon
                     }

--- a/src/task/task_scheduler.rs
+++ b/src/task/task_scheduler.rs
@@ -14,6 +14,7 @@ pub(crate) struct SchedMsg {
     pub task: Task,
     pub deps: Arc<Mutex<Deps>>,
     pub allow_during_interruption: bool,
+    pub install_tools: bool,
 }
 
 impl SchedMsg {
@@ -22,6 +23,18 @@ impl SchedMsg {
             task,
             deps,
             allow_during_interruption,
+            install_tools: false,
+        }
+    }
+
+    pub(crate) fn injected(
+        task: Task,
+        deps: Arc<Mutex<Deps>>,
+        allow_during_interruption: bool,
+    ) -> Self {
+        Self {
+            install_tools: true,
+            ..Self::new(task, deps, allow_during_interruption)
         }
     }
 }
@@ -219,7 +232,7 @@ impl Scheduler {
         mut spawn_job: F,
     ) -> Result<()>
     where
-        F: FnMut(Task, Arc<Mutex<Deps>>, bool) -> Fut,
+        F: FnMut(Task, Arc<Mutex<Deps>>, bool, bool) -> Fut,
         Fut: std::future::Future<Output = Result<()>>,
         S: Fn() -> bool,
         I: Fn() -> bool,
@@ -243,6 +256,7 @@ impl Scheduler {
                         task,
                         deps: deps_for_remove,
                         allow_during_interruption,
+                        install_tools,
                     }) => {
                         drained_any = true;
                         trace!("scheduler received: {} {}", task.name, task.args.join(" "));
@@ -258,7 +272,13 @@ impl Scheduler {
                                 continue;
                             }
                         }
-                        spawn_job(task, deps_for_remove, allow_during_interruption).await?;
+                        spawn_job(
+                            task,
+                            deps_for_remove,
+                            allow_during_interruption,
+                            install_tools,
+                        )
+                        .await?;
                     }
                     Err(mpsc::error::TryRecvError::Empty) => break,
                     Err(mpsc::error::TryRecvError::Disconnected) => break,
@@ -307,6 +327,7 @@ impl Scheduler {
                         task,
                         deps: deps_for_remove,
                         allow_during_interruption,
+                        install_tools,
                     }) = m {
                         trace!("scheduler received: {} {}", task.name, task.args.join(" "));
                         if should_stop() && (!continue_on_error || was_interrupted()) {
@@ -321,7 +342,13 @@ impl Scheduler {
                                 continue;
                             }
                         }
-                        spawn_job(task, deps_for_remove, allow_during_interruption).await?;
+                        spawn_job(
+                            task,
+                            deps_for_remove,
+                            allow_during_interruption,
+                            install_tools,
+                        )
+                        .await?;
                     } else {
                         // channel closed; rely on main_done/in_flight to exit soon
                     }

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -31,11 +31,12 @@ impl<'a> TaskToolInstaller<'a> {
         dry_run: bool,
         previewed_tools: &HashSet<ToolVersion>,
     ) -> Result<()> {
-        self.install_tasks(
+        self.install_task_list(
             config,
             tasks.all().cloned().collect(),
             dry_run,
             previewed_tools,
+            true,
         )
         .await
     }
@@ -48,11 +49,23 @@ impl<'a> TaskToolInstaller<'a> {
         dry_run: bool,
         previewed_tools: &HashSet<ToolVersion>,
     ) -> Result<()> {
+        self.install_task_list(config, tasks, dry_run, previewed_tools, false)
+            .await
+    }
+
+    async fn install_task_list(
+        &self,
+        config: &mut Arc<Config>,
+        tasks: Vec<Task>,
+        dry_run: bool,
+        previewed_tools: &HashSet<ToolVersion>,
+        reload_config: bool,
+    ) -> Result<()> {
         let all_tool_requests = self.collect_tool_requests(config, &tasks).await?;
         let toolset = self
             .build_toolset(config, self.cli_tools.to_vec(), all_tool_requests)
             .await?;
-        self.install_toolset(config, toolset, dry_run, previewed_tools)
+        self.install_toolset(config, toolset, dry_run, previewed_tools, reload_config)
             .await
     }
 
@@ -211,6 +224,7 @@ impl<'a> TaskToolInstaller<'a> {
         mut ts: Toolset,
         dry_run: bool,
         previewed_tools: &HashSet<ToolVersion>,
+        reload_config: bool,
     ) -> Result<()> {
         if dry_run {
             for tvl in ts.versions.values_mut() {
@@ -225,6 +239,7 @@ impl<'a> TaskToolInstaller<'a> {
                     missing_args_only: !Settings::get().task.run_auto_install,
                     skip_auto_install: !Settings::get().task.run_auto_install
                         || !Settings::get().auto_install,
+                    reload_config,
                     ..Default::default()
                 },
             )

--- a/src/task/task_tool_installer.rs
+++ b/src/task/task_tool_installer.rs
@@ -31,17 +31,29 @@ impl<'a> TaskToolInstaller<'a> {
         dry_run: bool,
         previewed_tools: &HashSet<ToolVersion>,
     ) -> Result<()> {
-        let all_tasks: Vec<_> = tasks.all().collect();
-        let all_tool_requests = self.collect_tool_requests(config, all_tasks).await?;
+        self.install_tasks(
+            config,
+            tasks.all().cloned().collect(),
+            dry_run,
+            previewed_tools,
+        )
+        .await
+    }
 
-        // Build and install toolset
+    /// Install tools for tasks that were resolved after the initial graph.
+    pub(crate) async fn install_tasks(
+        &self,
+        config: &mut Arc<Config>,
+        tasks: Vec<Task>,
+        dry_run: bool,
+        previewed_tools: &HashSet<ToolVersion>,
+    ) -> Result<()> {
+        let all_tool_requests = self.collect_tool_requests(config, &tasks).await?;
         let toolset = self
             .build_toolset(config, self.cli_tools.to_vec(), all_tool_requests)
             .await?;
         self.install_toolset(config, toolset, dry_run, previewed_tools)
-            .await?;
-
-        Ok(())
+            .await
     }
 
     /// Collect every tool request needed to prepare the supplied tasks without

--- a/src/toolset/install_options.rs
+++ b/src/toolset/install_options.rs
@@ -33,6 +33,11 @@ pub(crate) struct InstallOptions {
     /// skip confirmation prompts (e.g. installing missing plugin system deps).
     /// Defaults to the global `yes` setting; `mise bootstrap --yes` also sets it.
     pub yes: bool,
+    /// Reload global configuration after installation.
+    ///
+    /// Task-only tools resolved while a run is active must leave the live config
+    /// alone because sibling tasks may still be using it.
+    pub reload_config: bool,
 }
 
 impl Default for InstallOptions {
@@ -54,6 +59,7 @@ impl Default for InstallOptions {
             install_dir: None,
             scoped_install_dirs: false,
             yes: Settings::get().yes,
+            reload_config: true,
         }
     }
 }

--- a/src/toolset/toolset_install.rs
+++ b/src/toolset/toolset_install.rs
@@ -404,7 +404,7 @@ impl Toolset {
         }
 
         // Skip config reload and resolve in dry-run mode
-        if !opts.dry_run {
+        if !opts.dry_run && opts.reload_config {
             // Reload config and resolve (ignoring errors like the original does)
             trace!("install: reloading config");
             *config = Config::reset().await?;
@@ -418,6 +418,21 @@ impl Toolset {
             {
                 warn!("failed to restore runtime symlinks after install failure: {err:#}");
             }
+        } else if !opts.dry_run {
+            // The caller has a live config that other work is using. Refresh this
+            // toolset against that snapshot without replacing the global config.
+            trace!("install: resolving without reloading config");
+            if let Err(err) = self.resolve(config).await {
+                debug!("error resolving versions after install: {err:#}");
+            }
+            if !failed_backends.is_empty()
+                && let Err(err) =
+                    runtime_symlinks::rebuild_for_backends(config, self, failed_backends).await
+            {
+                warn!("failed to restore runtime symlinks after install failure: {err:#}");
+            }
+        }
+        if !opts.dry_run {
             crate::packslip::auto_sync_skills(config).await;
         }
 

--- a/test/data/plugins/dummy/bin/install
+++ b/test/data/plugins/dummy/bin/install
@@ -10,6 +10,17 @@ check_dummy_versions() {
 }
 
 check_dummy_versions
+
+# Optional E2E instrumentation for detecting overlapping top-level installs.
+if [ -n "${DUMMY_INSTALL_GATE_DIR:-}" ]; then
+    if mkdir "$DUMMY_INSTALL_GATE_DIR" 2>/dev/null; then
+        sleep 0.2
+        rmdir "$DUMMY_INSTALL_GATE_DIR"
+    else
+        touch "$DUMMY_INSTALL_GATE_DIR.overlap"
+    fi
+fi
+
 mkdir -p "$ASDF_INSTALL_PATH"
 env >"$ASDF_INSTALL_PATH/env"
 echo "$ASDF_INSTALL_VERSION" >"$ASDF_INSTALL_PATH/version"


### PR DESCRIPTION
## Summary

- auto-install task-only tools for tasks injected from `run` entries
- perform late installation before spawning the injected task, including runtime-rendered references
- preserve `--skip-tools` for dynamically resolved tasks

Fixes https://github.com/jdx/mise/discussions/13082

## Testing

- `mise run lint`
- `mise run test:e2e e2e/tasks/test_task_tools e2e/tasks/test_task_skip_tools`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task run scheduling, concurrent install behavior, and when global config reloads after installs—areas that can affect parallel runs and tool resolution mid-flight.
> 
> **Overview**
> **Tasks referenced from `run` entries (including templated names resolved at runtime) now get their task-level tools installed right before execution**, matching behavior that already applied to upfront graph tasks.
> 
> Injected work is marked via `SchedMsg::injected` and `spawn_sched_job` runs `TaskToolInstaller::install_tasks` under the scheduler semaphore (so `--jobs` limits overlapping installs), honors `--skip-tools`, and surfaces install failures through the normal task failure path (`fail_sched_job_before_start`) without blocking siblings when `--continue-on-error` is set. Orchestrator tasks release the prep permit after install when they do not need a task permit.
> 
> Late installs use a new `InstallOptions::reload_config` (default **true** for the initial batch, **false** for mid-run installs) so `Config::reset` is not run while other tasks still hold the live config; the toolset still resolves against the current snapshot. The scheduler run loop queues spawns in `FuturesUnordered` so job setup can proceed concurrently with draining the schedule channel.
> 
> E2E coverage adds deferred parent/skip-tools cases, templated references, install-failure + sibling completion, and a dummy install gate to assert no overlapping top-level installs under `--jobs 1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9666fdbc9ab29cf64387e5a8300fdadaff0e8ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tools required by tasks referenced through `run` entries are installed automatically before execution.
  - Tool installation supports task references resolved dynamically at runtime.
  - Deferred tool installations respect the configured task concurrency limit.

- **Bug Fixes**
  - `--skip-tools` consistently prevents installation for deferred and indirectly referenced tasks while allowing them to run.
  - Tool installation failures are reported as task failures without blocking eligible sibling tasks.
  - Concurrent task execution now handles output ordering and cleanup more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->