### PR TITLE
feat(dotfiles): infer variant sources from dotfiles root

### DIFF
--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -240,9 +240,28 @@ skips the entry.
 A variant's `target` overrides the table key. When every variant supplies a
 `target`, the key can be a logical name, as above. Otherwise the key must
 be an absolute or home-relative target path. Every destination must be
-absolute or start with `~/`. Target overrides require an explicit `source`,
-which stays the same across machines and resolves relative to the config
-file. Omitting `target` uses the table key:
+absolute or start with `~/`.
+
+When every variant supplies a `target`, you can omit `source` and use a safe
+relative entry key as its path under `dotfiles.root`:
+
+```toml
+[settings]
+dotfiles.root = "~/.dotfiles"
+
+[dotfiles."vscode/settings.json"]
+mode = "copy"
+variants = [
+  { os = "macos", target = "~/Library/Application Support/Code/User/settings.json" },
+  { os = "linux", target = "~/.config/Code/User/settings.json" },
+]
+```
+
+This reads `~/.dotfiles/vscode/settings.json` on both machines. The relative
+key cannot contain `..`. An explicit `source` stays the same across machines
+and, when relative, resolves from the directory containing the config file.
+If any variant omits `target`, an explicit source is required and that variant
+uses the table key as its destination:
 
 ```toml
 [dotfiles."~/.config/example/settings.json"]

--- a/e2e/cli/test_dotfiles_destination_variants
+++ b/e2e/cli/test_dotfiles_destination_variants
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
-mkdir -p dotfiles/bin
+mkdir -p dotfiles/bin variant-root/vscode
 printf '{"shared":true}\n' >dotfiles/settings.json
+printf '{"rooted":true}\n' >variant-root/vscode/settings.json
 echo 'answer = {{ 6 * 7 }}' >dotfiles/settings.tera
 echo script >dotfiles/bin/example
 
-cat >mise.toml <<'TOML'
+cat >mise.toml <<TOML
+[settings]
+dotfiles.root = "$PWD/variant-root"
+
 [dotfiles.settings]
 source = "dotfiles/settings.json"
 mode = "copy"
@@ -13,6 +17,13 @@ variants = [
   { os = "linux", target = "~/.config/code/settings.json" },
   { os = "macos", target = "~/Library/Application Support/Code/User/settings.json" },
   { os = "windows", target = 'C:\Users\example\settings.json' },
+]
+
+[dotfiles."vscode/settings.json"]
+mode = "copy"
+variants = [
+  { os = "linux", target = "~/.config/rooted-code/settings.json" },
+  { os = "macos", target = "~/Library/Application Support/Rooted Code/User/settings.json" },
 ]
 
 [dotfiles."~/.default-settings.json"]
@@ -41,6 +52,7 @@ TOML
 
 assert_succeed "mise bootstrap dotfiles apply --yes"
 assert "cat ~/.config/code/settings.json" '{"shared":true}'
+assert "cat ~/.config/rooted-code/settings.json" '{"rooted":true}'
 assert "readlink ~/.default-settings.json" "$PWD/dotfiles/settings.json"
 assert "cat ~/.rendered-settings" "answer = 42"
 assert "readlink ~/.variant-bin/example" "$PWD/dotfiles/bin/example"
@@ -125,7 +137,13 @@ mode = "copy"
 variants = [{ default = true, target = "relative.json" }]
 [dotfiles.no-source]
 mode = "copy"
-variants = [{ default = true, target = "~/.no-source" }]
+variants = [
+  { profile = "work", target = "~/.no-source" },
+  { default = true },
+]
+[dotfiles."../escaping-source"]
+mode = "copy"
+variants = [{ default = true, target = "~/.escaping-source" }]
 TOML
 cat >"$MISE_CONFIG_DIR/config.toml" <<'TOML'
 [dotfiles."~/.tracked"]
@@ -136,6 +154,7 @@ assert_contains "mise bootstrap dotfiles status 2>&1" "ambiguous dotfile variant
 assert_contains "mise bootstrap dotfiles status 2>&1" "variants allow only one default"
 assert_contains "mise bootstrap dotfiles status 2>&1" "variant target must be absolute"
 assert_contains "mise bootstrap dotfiles status 2>&1" "target overrides are not supported"
-assert_contains "mise bootstrap dotfiles status 2>&1" "destination variants require an explicit source"
+assert_contains "mise bootstrap dotfiles status 2>&1" "destination variants require an explicit source when any variant uses the entry key as its target"
+assert_contains "mise bootstrap dotfiles status 2>&1" "an implied source entry key must not contain '..'"
 assert_fail "test -e ~/.ambiguous-one"
 assert_fail "test -e ~/.ambiguous-two"

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4289,7 +4289,7 @@
                     },
                     "target": {
                       "type": "string",
-                      "description": "deployment destination override; requires source and is not supported in track mode"
+                      "description": "deployment destination override; requires either an explicit source or a safe relative entry key when every variant has a target, and is not supported in track mode"
                     }
                   }
                 }

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -4180,7 +4180,7 @@
     },
     "dotfiles": {
       "type": "object",
-      "description": "dotfiles applied with `mise dotfiles apply` or `mise bootstrap`, keyed by target path or a logical name when every variant overrides the target",
+      "description": "dotfiles applied with `mise dotfiles apply` or `mise bootstrap`, keyed by target path or a logical name when every variant overrides the target; an omitted source for the latter resolves the relative key under dotfiles.root",
       "additionalProperties": {
         "oneOf": [
           {

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -693,7 +693,7 @@ pub(crate) fn validate_incoming_files(config_files: &ConfigMap) -> Result<()> {
                 ..
             } = entry
             {
-                validate_file_variants(
+                let implied_variant_source = validate_file_variants(
                     &target,
                     source.as_deref(),
                     content.as_deref(),
@@ -725,7 +725,11 @@ pub(crate) fn validate_incoming_files(config_files: &ConfigMap) -> Result<()> {
                 if source.is_some() && content.is_some() {
                     bail!("dotfile {target} cannot declare both source and content");
                 }
-                if mode != FileMode::Track && source.is_none() && content.is_none() {
+                if mode != FileMode::Track
+                    && source.is_none()
+                    && content.is_none()
+                    && implied_variant_source.is_none()
+                {
                     implied_source(&resolve_target_arg(&target))?;
                 }
                 if let Some(manifest) = manifest
@@ -3491,8 +3495,7 @@ mod tests {
 
         let path = dirs::HOME.join(".config/mise/config.toml");
         let body = r#"
-[dotfiles.settings]
-source = "dotfiles/settings.json"
+[dotfiles."vscode/settings.json"]
 mode = "copy"
 variants = [
     { os = "macos", target = "~/Library/Application Support/Code/User/settings.json" },

--- a/src/system/files.rs
+++ b/src/system/files.rs
@@ -201,22 +201,33 @@ impl<'de> Deserialize<'de> for FileVariant {
 }
 
 /// Validate selector combinations and destination syntax before selecting a variant.
+/// Returns a `dotfiles.root`-relative implied source for a logical entry key.
 fn validate_file_variants(
     target: &str,
     source: Option<&str>,
+    content: Option<&str>,
     mode: Option<&str>,
     variants: &[FileVariant],
-) -> Result<()> {
+) -> Result<Option<PathBuf>> {
     let selectors: Vec<_> = variants.iter().map(|v| v.selector.clone()).collect();
     crate::system::history::select::validate(&selectors)?;
-    if variants.iter().any(|v| v.target.is_some()) {
-        if mode == Some("track") {
-            bail!("target overrides are not supported with mode = \"track\"");
-        }
-        if source.is_none() {
-            bail!("destination variants require an explicit source");
-        }
+    let has_target_override = variants.iter().any(|v| v.target.is_some());
+    if has_target_override && mode == Some("track") {
+        bail!("target overrides are not supported with mode = \"track\"");
     }
+    if has_target_override && content.is_some() {
+        bail!("destination variants with inline content are not supported");
+    }
+    let implied_source = if has_target_override && source.is_none() {
+        if !variants.iter().all(|v| v.target.is_some()) {
+            bail!(
+                "destination variants require an explicit source when any variant uses the entry key as its target"
+            );
+        }
+        Some(logical_source_path(target)?)
+    } else {
+        None
+    };
     if variants.is_empty() && resolve_target_arg(target).is_relative() {
         bail!("target must be absolute or start with ~/");
     }
@@ -226,7 +237,33 @@ fn validate_file_variants(
             bail!("variant target must be absolute or start with ~/");
         }
     }
-    Ok(())
+    Ok(implied_source)
+}
+
+fn logical_source_path(key: &str) -> Result<PathBuf> {
+    let path = file::replace_path(key);
+    if !path.is_relative() {
+        bail!(
+            "destination variants require an explicit source unless the entry key is a relative source path"
+        );
+    }
+    let mut relative = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(component) => relative.push(component),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                bail!("an implied source entry key must not contain '..'");
+            }
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                bail!("an implied source entry key must be relative");
+            }
+        }
+    }
+    if relative.as_os_str().is_empty() {
+        bail!("an implied source entry key must not be empty");
+    }
+    Ok(relative)
 }
 
 /// Inactive variants can contain another platform's absolute path syntax.
@@ -644,7 +681,7 @@ pub(crate) fn validate_incoming_files(config_files: &ConfigMap) -> Result<()> {
                 }
             }
             if let FileTomlEntry::Source(_) = &entry {
-                validate_file_variants(&target, None, None, &[])?;
+                validate_file_variants(&target, None, None, None, &[])?;
             }
             if let FileTomlEntry::Table {
                 source,
@@ -659,6 +696,7 @@ pub(crate) fn validate_incoming_files(config_files: &ConfigMap) -> Result<()> {
                 validate_file_variants(
                     &target,
                     source.as_deref(),
+                    content.as_deref(),
                     mode.as_deref(),
                     variants.as_deref().unwrap_or_default(),
                 )?;
@@ -900,12 +938,20 @@ fn merge_file_entry(
     };
     let enabled = enabled.unwrap_or(true);
     let variants = variants.unwrap_or_default();
-    if let Err(err) =
-        validate_file_variants(&target_raw, source.as_deref(), mode.as_deref(), &variants)
-    {
-        record_invalid(&target_raw, &origin.config, err.to_string());
-        return;
-    }
+    let implied_variant_source = match validate_file_variants(
+        &target_raw,
+        source.as_deref(),
+        content.as_deref(),
+        mode.as_deref(),
+        &variants,
+    ) {
+        Ok(Some(relative)) => Some(dotfiles_root().join(relative)),
+        Ok(None) => None,
+        Err(err) => {
+            record_invalid(&target_raw, &origin.config, err.to_string());
+            return;
+        }
+    };
     let selectors: Vec<_> = variants.iter().map(|v| v.selector.clone()).collect();
     let policy_for = |mode: FileMode| {
         let defaults = FilePolicy::for_mode(mode);
@@ -1059,7 +1105,10 @@ fn merge_file_entry(
                 source
             }
         }
-        None => match implied_source(&target) {
+        None => match implied_variant_source
+            .map(Ok)
+            .unwrap_or_else(|| implied_source(&target))
+        {
             Ok(source) => source,
             Err(err) => {
                 warn!("[dotfiles].\"{target_raw}\": {err}, ignoring entry");
@@ -3468,6 +3517,49 @@ variants = [
             Arc::new(MiseToml::for_history_preflight(&invalid, &path)?),
         );
         assert!(validate_incoming_files(&configs).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn destination_variants_infer_safe_root_relative_sources() -> Result<()> {
+        let entry: FileTomlEntry = toml::from_str(
+            r#"
+mode = "copy"
+variants = [
+    { os = "macos", target = "~/Library/Application Support/Code/User/settings.json" },
+    { os = "linux", target = "~/.config/Code/User/settings.json" },
+]
+"#,
+        )?;
+        let FileTomlEntry::Table {
+            source,
+            content,
+            mode,
+            variants: Some(variants),
+            ..
+        } = entry
+        else {
+            bail!("expected a table entry with variants");
+        };
+        assert_eq!(
+            validate_file_variants(
+                "vscode/settings.json",
+                source.as_deref(),
+                content.as_deref(),
+                mode.as_deref(),
+                &variants,
+            )?,
+            Some(PathBuf::from("vscode/settings.json"))
+        );
+        for key in [
+            "",
+            ".",
+            "../settings.json",
+            "vscode/../settings.json",
+            "~/.settings.json",
+        ] {
+            assert!(logical_source_path(key).is_err(), "{key}");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- infer an omitted destination-variant source from a safe relative entry key under `dotfiles.root`
- preserve config-relative resolution for explicit relative sources and require one when any variant uses the entry key as its destination
- reject parent traversal and document the root-relative shorthand in the schema and dotfiles guide

```toml
[settings]
dotfiles.root = "~/.dotfiles"

[dotfiles."vscode/settings.json"]
mode = "copy"
variants = [
  { os = "macos", target = "~/Library/Application Support/Code/User/settings.json" },
  { os = "linux", target = "~/.config/Code/User/settings.json" },
]
```

This reads `~/.dotfiles/vscode/settings.json` on both machines without tying the source to the location of `mise.toml`.

Related: https://github.com/jdx/mise/discussions/13045#discussioncomment-18396648

## Validation
- `mise run lint`
- `mise x -- cargo test --bin mise system::files::tests::destination_variant`
- `mise run docs:build`
- focused destination-variant e2e updated for Linux CI; the new root-relative macOS deployment was also exercised locally

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how dotfile sources are resolved during apply/bootstrap; mistaken keys could deploy wrong files, though `..` traversal is blocked.
> 
> **Overview**
> **Destination variants** can now omit `source` when **every** variant sets a `target`. The table key must be a safe relative path (no `..`); mise resolves it under `settings.dotfiles.root` instead of next to `mise.toml`.
> 
> Explicit `source` is still required if any variant falls back to the entry key as its destination, and relative explicit sources still resolve from the config file directory. New validation rejects destination variants combined with inline `content`, and tightens error messages for ambiguous or unsafe keys.
> 
> Docs, JSON schema descriptions, unit tests, and the destination-variant e2e cover the rooted shorthand and failure cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 124fdfbfa7125d470f8f061f5055abdd1d417cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dotfile variants can omit `source` when all variants specify destinations.
  * Relative logical names resolve safely under the configured dotfiles root.
  * Added support for platform-specific destination paths from rooted logical entries.

* **Bug Fixes**
  * Added validation for unsafe relative paths and incomplete destination variant configurations.
  * Prevented destination overrides from being combined with inline content.

* **Documentation**
  * Updated dotfiles configuration guidance and schema descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->