### PR TITLE
registry: add agent-browser

### DIFF
--- a/registry/agent-browser.toml
+++ b/registry/agent-browser.toml
@@ -1,0 +1,6 @@
+backends = ["aqua:vercel-labs/agent-browser"]
+bins = ["agent-browser"]
+description = "Browser automation CLI for AI agents"
+os = ["linux", "macos", "windows"]
+test = { cmd = "agent-browser --version", expected = "agent-browser {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
Add [agent-browser](https://agent-browser.dev/) as a registry shorthand using its existing Aqua registry definition.

This entry uses `aqua:vercel-labs/agent-browser`, the preferred available Tier 2 backend, because upstream does not publish Packslip manifests. Aqua handles the platform-specific binaries, historical release exceptions, and Windows ARM64 emulation across Linux, macOS, and Windows, so npm or Cargo fallbacks are unnecessary.

## Popularity

- GitHub: [42.4k stars and 2.8k forks, checked on 2026-09-11](https://github.com/vercel-labs/agent-browser)
- npm: [1,035,933 downloads from 2026-09-04 through 2026-09-10](https://api.npmjs.org/downloads/point/2026-09-04:2026-09-10/agent-browser) and [4,845,726 downloads over the latest 30-day period](https://api.npmjs.org/downloads/point/2026-08-12:2026-09-10/agent-browser)
- Latest release: [v0.37.1](https://github.com/vercel-labs/agent-browser/releases/tag/v0.37.1), published on 2026-09-08
- Latest commit on `main`: [vercel-labs/agent-browser@8c15ff9](https://github.com/vercel-labs/agent-browser/commit/8c15ff9f71ae60c7e99e66afe1e2d4b9bf414fe2), committed on 2026-09-10
- Third-party use: GitHub's dependency graph lists approximately [1,006 dependent repositories and 144 dependent packages](https://github.com/vercel-labs/agent-browser/network/dependents).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `agent-browser` to the tool registry, including supported operating systems and automatic version detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->