### PR TITLE
fix(doctor): align project check roots, dir expansion, schema, and signals

### DIFF
--- a/docs/configuration/project-diagnostics.md
+++ b/docs/configuration/project-diagnostics.md
@@ -46,15 +46,15 @@ task. There are no implicit project checks: declare the requirements you need.
 
 Each `[doctor.checks.<name>]` table supports:
 
-| Field         | Meaning                                                                                                                                             |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `run`         | Required shell command; exit zero to pass.                                                                                                          |
-| `description` | Human-readable requirement. Defaults to the check name in text output.                                                                              |
-| `hint`        | Guidance shown after a failure or execution error. Never executed.                                                                                  |
-| `timeout`     | Positive duration such as `500ms` or `5s`; defaults to `10s`.                                                                                       |
-| `dir`         | Working directory. Relative paths resolve from the declaring configuration's project root; absolute paths are used as given. Defaults to that root. |
-| `shell`       | Executable and arguments, including the command flag, such as `"bash -c"` or `"pwsh -Command"`. Defaults to mise's inline task shell.               |
-| `os`          | OS or OS/arch selector, or a nonempty list, such as `"linux/arm64"` or `["linux", "darwin"]`. Omit to run everywhere.                               |
+| Field         | Meaning                                                                                                                                              |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run`         | Required shell command; exit zero to pass.                                                                                                           |
+| `description` | Human-readable requirement. Defaults to the check name in text output.                                                                               |
+| `hint`        | Guidance shown after a failure or execution error. Never executed.                                                                                   |
+| `timeout`     | Positive duration such as `500ms` or `5s`; defaults to `10s`.                                                                                        |
+| `dir`         | Working directory. Relative paths resolve from the declaring configuration's root; `~/` and absolute paths are used as given. Defaults to that root. |
+| `shell`       | Executable and arguments, including the command flag, such as `"bash -c"` or `"pwsh -Command"`. Defaults to mise's inline task shell.                |
+| `os`          | OS or OS/arch selector, or a nonempty list, such as `"linux/arm64"` or `["linux", "darwin"]`. Omit to run everywhere.                                |
 
 Checks use the active configuration hierarchy, including environment-specific
 configuration. A higher-precedence definition replaces the entire check of the
@@ -76,18 +76,21 @@ accidentally print a credential into the report. Use `description` and `hint` to
 explain the requirement and remedy; run the command directly for its detailed
 output.
 
-Absolute paths and `..` components in `dir` are allowed, as with task working
-directories. The configuration root anchors relative paths; it is not a
-filesystem boundary. Checks can intentionally inspect a sibling checkout or
+Absolute paths, a leading `~/`, and `..` components in `dir` are allowed, as
+with task working directories; templates are not rendered. The configuration
+root anchors relative paths; it is not a filesystem boundary. Checks can intentionally inspect a sibling checkout or
 shared local service directory. Checks declared in global or system configuration
-use the invocation directory as their root, like tasks. Shell overrides use task
+use the invocation directory as their root, like tasks; a `mise.toml` directly in
+the home directory is project configuration and anchors at the home directory. Shell overrides use task
 quoting conventions and honor `windows_powershell_no_profile`. The OS selector
 accepts the same aliases (`darwin`, `win`, `amd64`, and others) as tool filters;
 `os = []` is rejected. Unknown `[doctor]` container options are ignored for
-forward compatibility, while unknown check fields are rejected to catch typos.
+forward compatibility (the JSON schema allows them too), while unknown check
+fields are rejected to catch typos.
 
 On Unix, Ctrl-C, SIGTERM, and SIGHUP cancel running checks and close their owned
-process groups, including when doctor runs inside a mise task. As with any cleanup
+process groups, including when doctor runs inside a mise task. A signal the
+parent ignored, such as SIGHUP under `nohup`, stays ignored. As with any cleanup
 that requires the supervisor to run, SIGKILL prevents cleanup; stop doctor with
 SIGTERM before escalating to SIGKILL.
 

--- a/e2e/cli/test_doctor_project_conventions
+++ b/e2e/cli/test_doctor_project_conventions
@@ -50,13 +50,25 @@ cat >project/mise.toml <<'TOML'
 [doctor.checks.project]
 run = "test -f project-marker"
 shell = "sh -c"
+[doctor.checks.tilde_dir]
+run = "test -f home-marker"
+dir = "~/home-dir"
 TOML
 # Clear the parent invalid config before testing nested projects.
 cat >mise.toml <<'TOML'
 TOML
 touch project/project-marker project/nested/invocation-marker
+mkdir -p "$HOME/home-dir" && touch "$HOME/home-dir/home-marker"
 assert_succeed "MISE_GLOBAL_CONFIG_FILE=$PWD/global/config.toml mise --cd project/nested doctor project --json > directories.json"
-assert_succeed "jq -e '[.checks[].status] == [\"pass\", \"pass\", \"pass\"]' directories.json"
+assert_succeed "jq -e '[.checks[].status] == [\"pass\", \"pass\", \"pass\", \"pass\"]' directories.json"
+
+# A mise.toml directly in $HOME is project configuration rooted at $HOME.
+cat >"$HOME/mise.toml" <<'TOML'
+[doctor.checks.home]
+run = "test -f home-dir/home-marker"
+TOML
+assert_succeed "mise --cd project/nested doctor project --json | jq -e '[.checks[] | select(.name == \"home\") | .status] == [\"pass\"]'"
+rm "$HOME/mise.toml"
 
 # OS aliases and architecture selectors use the same matcher as tools.
 cat >mise.toml <<TOML

--- a/e2e/cli/test_doctor_project_signals
+++ b/e2e/cli/test_doctor_project_signals
@@ -68,3 +68,34 @@ for nested in (False, True):
                     pass
             child.wait(timeout=5)
 PY
+
+# A SIGHUP the parent ignored (nohup style) must stay ignored: the run completes.
+cat >mise.toml <<'TOML'
+[doctor.checks.quick]
+run = "sleep 1"
+TOML
+python3 - <<'PY'
+import os
+import signal
+import subprocess
+import time
+
+child = subprocess.Popen(
+    ["mise", "doctor", "project"],
+    start_new_session=True,
+    preexec_fn=lambda: signal.signal(signal.SIGHUP, signal.SIG_IGN),
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+try:
+    time.sleep(.3)
+    os.killpg(child.pid, signal.SIGHUP)
+    stdout, stderr = child.communicate(timeout=15)
+    assert child.returncode == 0, (child.returncode, stdout, stderr)
+    assert b"PASS quick" in stdout, stdout
+finally:
+    try:
+        os.killpg(child.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+PY

--- a/e2e/cli/test_doctor_project_signals
+++ b/e2e/cli/test_doctor_project_signals
@@ -72,8 +72,9 @@ PY
 # A SIGHUP the parent ignored (nohup style) must stay ignored: the run completes.
 cat >mise.toml <<'TOML'
 [doctor.checks.quick]
-run = "sleep 1"
+run = "touch quick-started; sleep 1"
 TOML
+rm -f quick-started
 python3 - <<'PY'
 import os
 import signal
@@ -88,7 +89,13 @@ child = subprocess.Popen(
     stderr=subprocess.PIPE,
 )
 try:
-    time.sleep(.3)
+    # Signal handlers are installed before any check starts, so the marker
+    # proves the ignored disposition was already inspected.
+    deadline = time.monotonic() + 15
+    while not os.path.exists("quick-started"):
+        assert child.poll() is None, child.communicate()
+        assert time.monotonic() < deadline, "quick failed to start"
+        time.sleep(.05)
     os.killpg(child.pid, signal.SIGHUP)
     stdout, stderr = child.communicate(timeout=15)
     assert child.returncode == 0, (child.returncode, stdout, stderr)

--- a/e2e/config/test_schema_doctor
+++ b/e2e/config/test_schema_doctor
@@ -6,6 +6,11 @@ cat >doctor-valid.json <<'JSON'
 {"doctor":{"checks":{"database":{"run":"pg_isready --quiet","description":"Database accepts connections","hint":"Start the services","timeout":"5s","dir":"../database","shell":"bash -c","os":["linux","macos"]}}}}
 JSON
 assert_succeed "$validate -d doctor-valid.json"
+# Unknown container options stay valid, matching mise's forward compatibility.
+cat >doctor-forward.json <<'JSON'
+{"doctor":{"settings":{"future":true},"checks":{}}}
+JSON
+assert_succeed "$validate -d doctor-forward.json"
 # Each invalid root-level block used to pass because doctor was misplaced
 # inside task_dependency_item and was unvalidated at the root.
 cat >doctor-invalid.json <<'JSON'

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3796,7 +3796,7 @@
     "doctor": {
       "description": "Project diagnostic checks, run explicitly with mise doctor project.",
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "checks": {
           "type": "object",

--- a/schema/mise.json
+++ b/schema/mise.json
@@ -3824,7 +3824,7 @@
               },
               "dir": {
                 "type": "string",
-                "description": "Working directory. Relative paths resolve from the declaring config's project root; absolute paths are used as given."
+                "description": "Working directory. Relative paths resolve from the declaring config's root (the invocation directory for global and system config); a leading ~/ and absolute paths are used as given."
               },
               "shell": {
                 "description": "Shell command, including the command flag, as in tasks.",

--- a/src/cli/doctor/project.rs
+++ b/src/cli/doctor/project.rs
@@ -55,15 +55,16 @@ impl Project {
         // SIGINT already cancels the command future in Cli::run. Handle the
         // other normal supervisor shutdown signals here as well, so dropping
         // the bounded runner closes its owned group even under a nested task.
+        // Signals the parent chose to ignore (for example SIGHUP under nohup)
+        // stay ignored: registering a handler would otherwise replace SIG_IGN.
         #[cfg(unix)]
         let result = {
-            use tokio::signal::unix::{SignalKind, signal};
-            let mut terminate = signal(SignalKind::terminate())?;
-            let mut hangup = signal(SignalKind::hangup())?;
+            let mut terminate = shutdown_signal(nix::libc::SIGTERM)?;
+            let mut hangup = shutdown_signal(nix::libc::SIGHUP)?;
             tokio::select! {
                 result = self.check() => result,
-                _ = terminate.recv() => return Err(crate::request_exit(143)),
-                _ = hangup.recv() => return Err(crate::request_exit(129)),
+                _ = recv_or_pending(&mut terminate) => return Err(crate::request_exit(143)),
+                _ = recv_or_pending(&mut hangup) => return Err(crate::request_exit(129)),
             }
         };
         #[cfg(not(unix))]
@@ -122,12 +123,20 @@ impl Project {
         // Config files are ordered from highest to lowest precedence. Replace
         // whole named checks so a local command cannot inherit a stale remedy.
         for (path, cf) in config.config_files.iter().rev() {
-            for (name, check) in cf.doctor_config().checks {
-                let root = match cf.project_root() {
-                    Some(root) => root,
-                    None => std::env::current_dir()?,
-                };
-                checks.insert(name, (path.clone(), root, check));
+            let declared = cf.doctor_config().checks;
+            if declared.is_empty() {
+                continue;
+            }
+            // Match task conventions: project configuration (including a
+            // mise.toml directly in $HOME) anchors at its config root, while
+            // global and system configuration use the invocation directory.
+            let root = if cf.provenance().scope().is_project() {
+                cf.config_root()
+            } else {
+                std::env::current_dir()?
+            };
+            for (name, check) in declared {
+                checks.insert(name, (path.clone(), root.clone(), check));
             }
         }
         let mut report = Report::default();
@@ -198,9 +207,12 @@ impl Project {
                     result
                 }
             })
-            .buffered(crate::jobs::normalize(Settings::get().jobs))
+            // Unordered so a slow probe does not hold back admission of the
+            // remaining checks; the report is sorted by name afterwards.
+            .buffer_unordered(crate::jobs::normalize(Settings::get().jobs))
             .collect()
             .await;
+        report.checks.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(report)
     }
 }
@@ -239,7 +251,7 @@ async fn run_check(
             check
                 .dir
                 .as_ref()
-                .map(|dir| root.join(dir))
+                .map(|dir| root.join(crate::file::replace_path(dir)))
                 .unwrap_or_else(|| root.to_path_buf()),
         )
         .env_clear()
@@ -247,4 +259,31 @@ async fn run_check(
         .with_timeout(timeout)
         .output_isolated(64 * 1024)
         .await
+}
+
+/// Subscribe to a shutdown signal unless the process inherited it as ignored.
+#[cfg(unix)]
+fn shutdown_signal(signum: i32) -> Result<Option<tokio::signal::unix::Signal>> {
+    use tokio::signal::unix::{SignalKind, signal};
+    // SAFETY: a null new action only queries the current disposition; `old`
+    // is a valid, zeroed sigaction that the kernel fills in.
+    let ignored = unsafe {
+        let mut old: nix::libc::sigaction = std::mem::zeroed();
+        nix::libc::sigaction(signum, std::ptr::null(), &mut old) == 0
+            && old.sa_sigaction == nix::libc::SIG_IGN
+    };
+    if ignored {
+        return Ok(None);
+    }
+    Ok(Some(signal(SignalKind::from_raw(signum))?))
+}
+
+#[cfg(unix)]
+async fn recv_or_pending(signal: &mut Option<tokio::signal::unix::Signal>) {
+    match signal {
+        Some(signal) => {
+            signal.recv().await;
+        }
+        None => std::future::pending().await,
+    }
 }

--- a/src/config/doctor.rs
+++ b/src/config/doctor.rs
@@ -16,7 +16,9 @@ pub(crate) struct DoctorCheck {
     pub description: Option<String>,
     pub hint: Option<String>,
     pub timeout: Option<String>,
-    /// Relative paths use the configuration file's project root; absolute paths are used as given.
+    /// Relative paths use the configuration file's root (the invocation directory
+    /// for global and system configuration); a leading `~/` and absolute paths are
+    /// used as given.
     pub dir: Option<PathBuf>,
     /// Shell executable and arguments, including the command flag.
     pub shell: Option<String>,


### PR DESCRIPTION
Follow-up to #13062 from a post-merge review.

## Changes

- **Config root for `~/mise.toml`**: `project_root()` returns `None` for a project-scope file whose parent is `$HOME`, so checks declared there were rooted at the invocation directory while tasks from the same file root at `$HOME`. Checks now use `config_root()` for project configuration and the invocation directory only for global/system configuration, as the docs already said. The root is also computed once per config file instead of once per check.
- **`dir` tilde expansion**: `dir` was joined verbatim, so `dir = "~/x"` became `<root>/~/x`. It now goes through `file::replace_path` like task `dir`. Docs note that templates are still not rendered.
- **Schema vs runtime**: the schema set `additionalProperties: false` on `[doctor]` while `DoctorConfig`, the docs, and the e2e tests promise unknown container keys are tolerated. The schema now allows them; `test_schema_doctor` covers the case.
- **Head-of-line blocking**: `buffered(jobs)` counts completed-but-unyielded results toward the limit, so one probe hanging to its timeout stalled admission of every later check once the other slots finished. Switched to `buffer_unordered` and sort the report by name afterwards.
- **`nohup` / inherited `SIG_IGN`**: tokio's signal registration installs a handler even when SIGHUP was inherited as ignored, so `nohup mise doctor project &` died with exit 129 on terminal hangup. The handler is only registered when the signal is not already ignored.

Not included here, flagged for separate PRs: the inline-shell resolution and OS-selector deserializer/matcher duplicate existing helpers in `watch_files.rs`/`hooks.rs` and `system/mod.rs`/`history/select.rs`, and the SIGTERM/SIGHUP cleanup arguably belongs in the bounded runner's `ChildTree` so the packslip callers get it too.

## Validation

- `cargo clippy --bin mise --all-features -- -D warnings`
- `cargo test --bin mise doctor`
- `mise run test:e2e e2e/cli/test_doctor_project e2e/cli/test_doctor_project_conventions e2e/cli/test_doctor_project_signals e2e/config/test_schema_doctor` (new cases: `~/mise.toml` root, `~/` in `dir`, forward-compatible schema, SIGHUP ignored under nohup)
- `hk fix` on changed files

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5-1; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes diagnostic working-directory resolution, concurrent check scheduling, and Unix signal registration—behavioral fixes that could surprise users relying on the old (incorrect) paths or timing, but limited to explicit `doctor project` runs.
> 
> **Overview**
> **`mise doctor project`** now matches task conventions for where checks run and how `dir` is resolved, and fixes a few edge cases in concurrency and Unix signal handling.
> 
> Project-scoped configs (including **`~/mise.toml`**) anchor relative `dir` values at **`config_root()`**; global/system configs still use the invocation directory. Check **`dir`** expands a leading **`~/`** via **`file::replace_path`** (templates are still not rendered).
> 
> The **`[doctor]`** JSON schema allows unknown top-level keys again (**`additionalProperties: true`**), consistent with runtime forward compatibility. Checks run with **`buffer_unordered`** under the jobs limit and the report is sorted by name, avoiding head-of-line blocking when one probe sits on its timeout.
> 
> On Unix, **SIGTERM/SIGHUP** handlers are only installed when the process did not inherit **SIG_IGN** (e.g. **nohup**), so a hangup no longer exits with 129 mid-run. Docs and e2e cover tilde dirs, home-rooted config, schema forward compat, and ignored SIGHUP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8ba51b59025a0ee90fbfa01c8a355d1622b8d06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Doctor checks now resolve relative, absolute, and home-directory paths according to their configuration location.
  - Project diagnostics support configurations located directly in the home directory.
  - Doctor check results are consistently ordered, regardless of execution timing.
  - Diagnostics preserve inherited ignored signals, such as SIGHUP under `nohup`.

- **Compatibility**
  - Doctor configuration accepts additional top-level settings while continuing to validate check definitions strictly.

- **Documentation**
  - Clarified working-directory, path-resolution, signal-handling, and configuration-root behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->