### PR TITLE
docs(agents): write PR titles and descriptions for release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,47 @@ commit subjects are not checked because pull requests are squash-merged. CI
 mechanically checks the allowed type, syntax, and lowercase-leading description;
 imperative mood and breaking-change details remain review rules.
 
+### PR titles and descriptions are release-note inputs
+
+Communique uses PR titles and descriptions to generate release notes. Write them
+for a mise user who has not read the diff or this conversation.
+
+- **Describe the final result.** Before requesting review and again after feedback
+  changes the implementation, compare the title and body with the complete current
+  diff. Rewrite both when the scope changes. Remove abandoned approaches, stale
+  requirements, and claims that the final code or validation no longer supports.
+- **Lead with the user-visible change.** Keep the conventional commit format, but
+  name the affected behavior and outcome in the title. Open the body with the
+  problem or use case and what users can now do. Avoid titles such as "address
+  feedback" or "fix CI" when the PR's actual purpose is a feature or behavior fix.
+  For internal-only work, explain the concrete maintainer or contributor benefit
+  without inventing a user-facing impact.
+- **Make the change concrete.** For new configuration or commands, include a small,
+  valid example and explain its result. For a bug fix, describe the trigger and
+  before/after behavior. For visible UI or output changes, include actual before/after
+  screenshots or a short recording when they help reviewers assess the change;
+  CLI input/output snippets are often clearer than screenshots of a terminal.
+  Use measured results for performance claims and state how they were measured.
+- **Keep the essential facts in text.** Caption screenshots and explain examples.
+  A reader or release-note generator should understand the change without opening
+  an image, following an external link, or reading the diff. Do not fabricate
+  screenshots, output, measurements, or validation results.
+- **State adoption details when relevant.** Include new flags or settings, defaults,
+  supported platforms, experimental status, required dependency versions, and any
+  compatibility changes or migration steps that affect using the feature. Distinguish
+  current behavior from planned follow-ups; do not advertise unfinished work.
+- **Keep review details proportionate.** Summarize meaningful validation and its
+  limitations. Include implementation details only when they explain behavior or a
+  tradeoff reviewers need to assess. Omit agent work logs, intermediate commit
+  summaries, and exhaustive test-command lists. A small fix can be a short paragraph
+  and a test result; screenshots and sections are not mandatory for every PR.
+
+For example, prefer `fix(task): install missing tools before running referenced tasks`
+over `fix(task): address review feedback`. Its description should explain which
+command previously failed, show the same command succeeding with automatic tool
+installation, and mention any relevant prerequisites. Keep this guidance alongside
+the required AI disclosure below; it does not replace that disclosure.
+
 ### Pre-commit Process
 1. Run `mise run lint-fix` and `git add` any lint fixes before committing
 2. Use `mise run test:e2e [test_filename]...` for running specific e2e tests


### PR DESCRIPTION
Communique uses PR titles and descriptions to generate release notes. This adds guidance for giving it a clear account of the final change: what users can do, which behavior changed, and any requirements or migration steps.

PR authors must update the title and body when scope changes, include a concrete command/configuration example or before/after behavior where useful, and explain meaningful screenshots or recordings in text. Small fixes can stay short; screenshots are encouraged when they help, rather than required for every PR.

For example, prefer `fix(task): install missing tools before running referenced tasks` over `fix(task): address review feedback`, then explain the affected command and its resulting behavior.

Validation: `mise run lint-fix`. Documentation-only change.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor/agent guidance; no runtime or CI behavior changes.
> 
> **Overview**
> Adds a **PR titles and descriptions are release-note inputs** section to `AGENTS.md`, right after the conventional-commit rules. It tells contributors and agents that **Communique** derives release notes from PR titles and bodies, so they should be written for readers who never saw the diff.
> 
> The new bullets require keeping title/body aligned with the **final** diff after review, leading with user-visible outcomes (not meta titles like “address feedback”), using concrete examples or before/after behavior, putting essential facts in text (no fabricated screenshots or metrics), noting adoption/migration details when relevant, and keeping validation notes proportionate. An example contrasts a behavior-focused `fix(task): …` title with a vague one and notes this guidance sits alongside—not instead of—the AI disclosure rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d44519a8f5cd81e31889d3c10bdc37f856fd1bda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for writing clear, user-focused pull request titles and descriptions.
  - Encourages leading with the visible change, including concrete examples and measured results when available, and documenting adoption details.
  - Clarifies that essential facts should remain in text without fabricated screenshots or measurements.
  - Provides a preferred title example and explains how the guidance complements required AI disclosure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->