### PR TITLE
registry: add himalaya (github:pimalaya/himalaya)

### DIFF
--- a/registry/himalaya.toml
+++ b/registry/himalaya.toml
@@ -1,4 +1,4 @@
-backends = ["github:pimalaya/himalaya", "aqua:pimalaya/himalaya", "cargo:himalaya"]
+backends = ["aqua:pimalaya/himalaya", "github:pimalaya/himalaya", "cargo:himalaya"]
 bins = ["himalaya"]
 description = "CLI to manage emails"
 test = { cmd = "himalaya --version", expected = "himalaya v{{version}}" }

--- a/registry/himalaya.toml
+++ b/registry/himalaya.toml
@@ -1,0 +1,5 @@
+backends = ["github:pimalaya/himalaya", "aqua:pimalaya/himalaya", "cargo:himalaya"]
+bins = ["himalaya"]
+description = "CLI to manage emails"
+test = { cmd = "himalaya --version", expected = "himalaya v{{version}}" }
+version_order = "semver"

--- a/registry/himalaya.toml
+++ b/registry/himalaya.toml
@@ -1,4 +1,8 @@
-backends = ["aqua:pimalaya/himalaya", "github:pimalaya/himalaya", "cargo:himalaya"]
+backends = [
+  "github:pimalaya/himalaya",
+  "aqua:pimalaya/himalaya",
+  "cargo:himalaya",
+]
 bins = ["himalaya"]
 description = "CLI to manage emails"
 test = { cmd = "himalaya --version", expected = "himalaya v{{version}}" }


### PR DESCRIPTION
Add himalaya Rust email client as a registry shorthand.
- https://github.com/pimalaya/himalaya

## Popularity
- GitHub: 7224 stars, 235 forks, last release v2.1.0 (2026-08-16), pushed 2026-09-08
- crates.io: 66,790 total downloads, 7,059 recent downloads
- Used by: Arch Linux community package (`pacman -S himalaya`), Nix, himalaya-vim plugin, himalaya-emacs, Raycast extension, dfzf integration

## Backends validated (`mise ls-remote`)
- `github:pimalaya/himalaya` (preferred, in title): FULL — 0.1.0 through 2.1.0, binary tgz assets for linux/darwin/windows (e.g. himalaya.aarch64-darwin.tgz, himalaya.x86_64-linux.tgz). Verified install: `mise x github:pimalaya/himalaya@2.1.0 -- himalaya --version` → `himalaya v2.1.0 ...` on macos-arm64.
- `aqua:pimalaya/himalaya`: FULL — same versions, aqua-registry entry exists with per-version asset logic.
- `cargo:himalaya`: FULL — 0.5.2 through 2.1.0 on crates.io.
- `packslip:pimalaya/himalaya`: NONE — no signed manifests, omitted.
- No `asdf`/`vfox`/`ubi` (not accepted for new entries).

Test: `himalaya --version` prints `himalaya v2.1.0 ...`, matched with `expected = "himalaya v{{version}}"`.

*AI-assisted — Tool: OpenCode; model: opencode/muse-spark-1.3-contributor-free; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added registry support for the Himalaya email command-line tool.
  - Added installation options through Aqua, GitHub, and Cargo.
  - Added automatic binary identification and version detection.
  - Added semantic version ordering for available releases.
  - Listed the GitHub installation option before Aqua in the backend order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->