### PR TITLE
registry: add meli (github:meli/meli)

### DIFF
--- a/registry/meli.toml
+++ b/registry/meli.toml
@@ -1,4 +1,10 @@
-backends = ["github:meli/meli", "cargo:meli"]
+backends = [
+  "cargo:meli",
+  # GitHub releases are Linux-only and lag latest (e.g. v0.8.13 has no assets),
+  # so Cargo stays first: a short name resolves to backends().first() with no
+  # install-time fallback, and latest must be 0.8.13 on all platforms.
+  { full = "github:meli/meli", platforms = ["linux"] },
+]
 bins = ["meli"]
 description = "Terminal mail client"
 test = { cmd = "meli --version", expected = "meli {{version}}" }

--- a/registry/meli.toml
+++ b/registry/meli.toml
@@ -1,11 +1,6 @@
-backends = [
-  "cargo:meli",
-  # GitHub releases are Linux-only and lag latest (e.g. v0.8.13 has no assets),
-  # so Cargo stays first: a short name resolves to backends().first() with no
-  # install-time fallback, and latest must be 0.8.13 on all platforms.
-  { full = "github:meli/meli", platforms = ["linux"] },
-]
+backends = ["github:meli/meli"]
 bins = ["meli"]
 description = "Terminal mail client"
+os = ["linux"]
 test = { cmd = "meli --version", expected = "meli {{version}}" }
 version_order = "semver"

--- a/registry/meli.toml
+++ b/registry/meli.toml
@@ -1,0 +1,5 @@
+backends = ["github:meli/meli", "cargo:meli"]
+bins = ["meli"]
+description = "Terminal mail client"
+test = { cmd = "meli --version", expected = "meli {{version}}" }
+version_order = "semver"


### PR DESCRIPTION
Add meli Rust terminal email client as a registry shorthand (Linux-only GitHub binaries).

## Popularity
- GitHub: 889 stars, 29 forks, last release v0.8.13 (2026-01-05), pushed 2026-09-11 (active maintenance, but below the usual thousands-stars bar — submitting per request, expect possible close without reason)
- crates.io: 34,197 total downloads, 253 recent downloads, description "terminal e-mail client"
- Used by: packaged in Debian/Ubuntu/OpenSUSE (meli manpages), referenced in awesome-lists/libhunt comparisons with himalaya, mirror of git.meli-email.org canonical repo

## Backends validated (`mise ls-remote`)
- `github:meli/meli` (only backend): lists the asset-bearing releases (0.8.1, 0.8.4, 0.8.8, 0.8.9, 0.8.11). Releases without binary assets (0.8.10, 0.8.12, 0.8.13) are not installable via this backend, so `latest` resolves to the newest release with assets (currently 0.8.11). All published assets are Linux-only (e.g. v0.8.11: meli-0.8.11-linux-amd64.deb, meli-0.8.11-linux-arm64.deb, meli-linux-amd64-0.8.11.zip, meli-linux-arm64-0.8.11.zip), hence `os = ["linux"]`.
- No `cargo` backend: intentionally omitted — Cargo is Tier 4 and would require explicit @jdx approval, and as a fallback it would be unreachable anyway (a short name resolves to `backends().first()` with no install-time fallback). Users who need newer versions or macOS builds can install explicitly via `mise use cargo:meli`.
- `aqua:meli/meli`: NONE — `registry not available: no aqua-registry found`, omitted.
- `packslip:meli/meli`: NONE, omitted.
- No `asdf`/`vfox`/`ubi` (not accepted for new entries).

Test: `meli --version` prints `meli <version>` (from `println!("meli {}", CARGO_PKG_VERSION)`), matched with `expected = "meli {{version}}"`. CI `test-tool` runs on Linux, where the 0.8.11 binary assets install.

*AI-assisted — Tool: OpenCode; model: opencode/muse-spark-1.3-contributor-free; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Updated Meli installation support to use GitHub as the available source.
  - Meli remains available for Linux systems.
  - Removed Cargo as an installation source.
  - Existing version detection and semantic version ordering remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->