### PR TITLE
fix(task): explain MISE_CONFIG_DIR boundary in monorepo root error

### DIFF
--- a/e2e/tasks/test_task_monorepo_config_dir_error
+++ b/e2e/tasks/test_task_monorepo_config_dir_error
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Monorepo under $MISE_CONFIG_DIR is treated as global config and never
+# receives a project root, so // task paths cannot resolve there.
+# The error should name that boundary instead of only saying no root was found.
+# See https://github.com/jdx/mise/discussions/13076
+
+export MISE_TRUSTED_CONFIG_PATHS="$MISE_TRUSTED_CONFIG_PATHS:$MISE_CONFIG_DIR"
+
+MONOREPO="$MISE_CONFIG_DIR/my_monorepo"
+mkdir -p "$MONOREPO/workspace2"
+cat <<'TOML' >"$MONOREPO/mise.toml"
+monorepo_root = true
+
+[monorepo]
+config_roots = ["workspace2"]
+TOML
+cat <<'TOML' >"$MONOREPO/workspace2/mise.toml"
+[tasks."build:path"]
+run = 'echo the-path'
+TOML
+
+cd "$MONOREPO"
+output=$(mise run '//workspace2:build:path' 2>&1 || true)
+echo "$output"
+echo "$output" | grep -q "require a monorepo root configuration" || (echo "FAIL: expected monorepo root error" && exit 1)
+echo "$output" | grep -q "MISE_CONFIG_DIR" || (echo "FAIL: expected MISE_CONFIG_DIR boundary in error" && exit 1)
+echo "$output" | grep -q "never receive a project root" || (echo "FAIL: expected project-root boundary in error" && exit 1)
+echo "$output" | grep -q "Don't put your project there" || (echo "FAIL: expected location guidance in error" && exit 1)
+echo "$output" | grep -q "monorepo_root = true" || (echo "FAIL: expected rejected root path in error" && exit 1)

--- a/src/task/task_list.rs
+++ b/src/task/task_list.rs
@@ -62,6 +62,24 @@ pub(crate) fn split_task_spec(spec: &str) -> (&str, Vec<String>) {
 fn validate_monorepo_setup(config: &Arc<Config>) -> Result<()> {
     // Check if a monorepo root is configured
     if !config.is_monorepo() {
+        if let Some(hint) = rejected_monorepo_root_hint(config) {
+            bail!(
+                "Monorepo task paths (like `//path:task` or `:task`) require a monorepo root configuration.\n\
+                \n\
+                {}\n\
+                \n\
+                To set up monorepo support, add this to your root mise.toml:\n\
+                {}\n\
+                \n\
+                Then create task files in subdirectories that will be automatically discovered.\n\
+                See {} for more information.",
+                hint,
+                style::eyellow("  monorepo_root = true"),
+                style::eunderline(
+                    "https://mise.jdx.dev/tasks/task-configuration.html#monorepo-support"
+                )
+            );
+        }
         bail!(
             "Monorepo task paths (like `//path:task` or `:task`) require a monorepo root configuration.\n\
             \n\
@@ -78,6 +96,46 @@ fn validate_monorepo_setup(config: &Arc<Config>) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Explain why a `monorepo_root = true` declaration was ignored.
+///
+/// Configs under `$MISE_CONFIG_DIR` (and other global/system locations) never
+/// receive a project root, so they can never act as monorepo roots even when
+/// they declare `monorepo_root = true`. Naming that boundary saves a trace-dive
+/// when the same files work outside the config dir.
+fn rejected_monorepo_root_hint(config: &Arc<Config>) -> Option<String> {
+    let rejected: Vec<PathBuf> = config
+        .config_files
+        .values()
+        .filter(|cf| cf.monorepo_root() == Some(true))
+        .filter(|cf| cf.project_root().is_none())
+        .map(|cf| cf.get_path().to_path_buf())
+        .unique()
+        .collect();
+    if rejected.is_empty() {
+        return None;
+    }
+    let mut hint = String::from("Found `monorepo_root = true` in:");
+    for path in &rejected {
+        hint.push_str(&format!("\n  {}", display_path(path)));
+    }
+    if rejected.iter().any(|p| p.starts_with(*dirs::CONFIG)) {
+        hint.push_str(&format!(
+            "\nbut it lives under $MISE_CONFIG_DIR ({}), where configs are treated as global configuration and never receive a project root. Monorepo task paths require a project root, so this root is ignored.\n\nMove the monorepo outside $MISE_CONFIG_DIR (or point MISE_CONFIG_DIR elsewhere). Don't put your project there.",
+            display_path(*dirs::CONFIG)
+        ));
+    } else if rejected.iter().any(|p| p.starts_with(*dirs::SYSTEM_CONFIG)) {
+        hint.push_str(&format!(
+            "\nbut it lives under the system config directory ({}), where configs never receive a project root. Monorepo task paths require a project root, so this root is ignored.\n\nMove the monorepo outside the system config directory.",
+            display_path(*dirs::SYSTEM_CONFIG)
+        ));
+    } else {
+        hint.push_str(
+            "\nbut that config has no project root (global config), so it is ignored as a monorepo root. Monorepo task paths require a project root.",
+        );
+    }
+    Some(hint)
 }
 
 /// Check if a name is similar to any known CLI subcommands using fuzzy matching


### PR DESCRIPTION
Monorepos rooted under `$MISE_CONFIG_DIR` can never establish a project root, so `//` task paths fail even though a root `mise.toml` sets `monorepo_root = true`. The old error only said a root configuration was required, which sent reporters trace-diving (see #13076).

This keeps that message but appends the boundary when a declaring config was found and rejected for lack of a project root:

- lists each `monorepo_root = true` path with no project root
- when under `$MISE_CONFIG_DIR`, names it and explains configs there are treated as global configuration
- advises moving the monorepo outside `$MISE_CONFIG_DIR` or pointing `MISE_CONFIG_DIR` elsewhere

Generic no-root output is unchanged (no boundary hint).

Verification:

- `cargo fmt --check` clean
- `cargo check --bin mise --locked` exit 0
- `mise run test:e2e e2e/tasks/test_task_monorepo_config_dir_error e2e/tasks/test_task_monorepo_validation` passes (new test 6s, validation 1s)
- `mise run lint`: `cargo-fmt`, `shellcheck`, `shfmt`, `cargo-check` pass; only pre-existing missing-tool failures for `markdownlint`/`prettier`/`ajv` in this environment

*AI-assisted — Tool: opencode; model: opencode/muse-spark-1.3-contributor-free; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `meli` terminal mail client to the package registry, including Linux support and version verification.
  - Improved monorepo configuration errors with clearer guidance when configuration files declare a monorepo root without a project root, including relevant configuration locations and boundary details.

- **Tests**
  - Added end-to-end coverage for monorepo configuration errors involving `MISE_CONFIG_DIR`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->