### PR TITLE
fix(dotfiles): warn when tracking a symlink without its source

### DIFF
--- a/e2e/cli/test_dotfiles_track
+++ b/e2e/cli/test_dotfiles_track
@@ -96,6 +96,20 @@ assert_contains 'mise bootstrap dotfiles track ~/tracked-link 2>&1' 'is a symlin
 ln -s missing-source ~/dangling-link
 assert_contains 'mise bootstrap dotfiles track ~/dangling-link 2>&1' 'missing-source'
 
+# An enrolled intermediate link does not protect a dangling final source.
+ln -s chain-missing ~/chain-middle
+ln -s chain-middle ~/chain-start
+assert_succeed 'mise bootstrap dotfiles track ~/chain-middle'
+assert_contains 'mise bootstrap dotfiles track ~/chain-start 2>&1' 'chain-missing'
+assert_contains 'mise bootstrap dotfiles track ~/chain-start 2>&1' 'not tracked for capture'
+# Enrolling the final source suppresses the warning even before it exists.
+mise bootstrap dotfiles track ~/chain-missing ~/chain-start >track-output 2>&1
+assert_fail "grep -q 'is a symlink' track-output"
+# Cycles warn without preventing the link objects themselves from being tracked.
+ln -s cycle-b ~/cycle-a
+ln -s cycle-a ~/cycle-b
+assert_contains 'mise bootstrap dotfiles track ~/cycle-a ~/cycle-b 2>&1' 'Could not resolve its source'
+
 if [[ $(uname -s) == Linux ]]; then
   mkdir -p ~/.raw-names
   echo ordinary >~/.raw-names/ordinary

--- a/e2e/cli/test_dotfiles_track
+++ b/e2e/cli/test_dotfiles_track
@@ -69,6 +69,33 @@ assert_succeed 'mise bootstrap dotfiles untrack ~/native'
 assert 'cat ~/native/config' native
 assert_fail "git --git-dir=$repository cat-file -e HEAD:home/native/config"
 
+# A source-managed file added in the default symlink mode needs its source enrolled too.
+echo added >~/added-dotfile
+assert_succeed 'mise bootstrap dotfiles add --source ~/added-source ~/added-dotfile --yes'
+assert_contains 'mise bootstrap dotfiles track ~/added-dotfile 2>&1' 'history saves and syncs the link, not its contents'
+assert_fail "git --git-dir=$repository cat-file -e HEAD:home/added-source"
+
+# Explicit enrollment warns when only a symlink, not its source, is saved.
+echo source >~/link-source
+ln -s link-source ~/tracked-link
+assert_contains 'mise bootstrap dotfiles track ~/tracked-link 2>&1' 'history saves and syncs the link, not its contents'
+assert_contains 'mise bootstrap dotfiles track ~/tracked-link 2>&1' 'mise bootstrap dotfiles track '
+assert_contains "git --git-dir=$repository ls-tree HEAD home/tracked-link" 120000
+assert_fail "git --git-dir=$repository cat-file -e HEAD:home/link-source"
+# Enrolling both in one command suppresses the warning regardless of order.
+mise bootstrap dotfiles track ~/tracked-link ~/link-source >track-output 2>&1
+assert_fail "grep -q 'is a symlink' track-output"
+assert "git --git-dir=$repository show HEAD:home/link-source" source
+# A tracked parent directory also covers the source.
+ln -s target-dir/config ~/directory-source-link
+mise bootstrap dotfiles track ~/directory-source-link ~/target-dir >track-output 2>&1
+assert_fail "grep -q 'is a symlink' track-output"
+# Excluded and missing sources must not look protected.
+assert_succeed 'mise bootstrap dotfiles exclude ~/link-source'
+assert_contains 'mise bootstrap dotfiles track ~/tracked-link 2>&1' 'is a symlink'
+ln -s missing-source ~/dangling-link
+assert_contains 'mise bootstrap dotfiles track ~/dangling-link 2>&1' 'missing-source'
+
 if [[ $(uname -s) == Linux ]]; then
   mkdir -p ~/.raw-names
   echo ordinary >~/.raw-names/ordinary

--- a/src/cli/dotfiles/track.rs
+++ b/src/cli/dotfiles/track.rs
@@ -354,10 +354,18 @@ async fn activate_and_baseline(declared: &[(String, PathBuf)]) -> Result<()> {
     }
     baseline(&tracked, declared).await?;
     for (key, target) in declared {
-        if let Ok(source) = std::fs::read_link(target) {
-            let source = crate::system::history::tracked::normalize(
-                &target.parent().unwrap_or(Path::new("/")).join(source),
-            );
+        if target.is_symlink() {
+            // This resolver is read-only, follows dangling chains, and bounds
+            // traversal so cyclic links cannot hang an advisory check.
+            let source = match file::atomic_write_target(target) {
+                Ok(source) => source,
+                Err(error) => {
+                    warn!(
+                        "dotfiles: {key} is a symlink; history saves and syncs the link, not its contents. Could not resolve its source: {error}"
+                    );
+                    continue;
+                }
+            };
             if !tracked.would_capture(&source)? {
                 warn!(
                     "dotfiles: {key} is a symlink; history saves and syncs the link, not its contents. Its source {} is not tracked for capture; track the source with `mise bootstrap dotfiles track {}` (and check any exclusions) to include its contents",

--- a/src/cli/dotfiles/track.rs
+++ b/src/cli/dotfiles/track.rs
@@ -352,7 +352,22 @@ async fn activate_and_baseline(declared: &[(String, PathBuf)]) -> Result<()> {
             bail!("dotfiles: {key} could not be tracked: {reason}");
         }
     }
-    baseline(&tracked, declared).await
+    baseline(&tracked, declared).await?;
+    for (key, target) in declared {
+        if let Ok(source) = std::fs::read_link(target) {
+            let source = crate::system::history::tracked::normalize(
+                &target.parent().unwrap_or(Path::new("/")).join(source),
+            );
+            if !tracked.would_capture(&source)? {
+                warn!(
+                    "dotfiles: {key} is a symlink; history saves and syncs the link, not its contents. Its source {} is not tracked for capture; track the source with `mise bootstrap dotfiles track {}` (and check any exclusions) to include its contents",
+                    display_path(&source),
+                    shell_words::quote(&source.to_string_lossy()),
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Saves the baseline checkpoint of newly tracked paths; a failure fails

--- a/src/cli/dotfiles/track.rs
+++ b/src/cli/dotfiles/track.rs
@@ -357,7 +357,7 @@ async fn activate_and_baseline(declared: &[(String, PathBuf)]) -> Result<()> {
         if target.is_symlink() {
             // This resolver is read-only, follows dangling chains, and bounds
             // traversal so cyclic links cannot hang an advisory check.
-            let source = match file::atomic_write_target(target) {
+            let source = match resolve_symlink_source(target) {
                 Ok(source) => source,
                 Err(error) => {
                     warn!(
@@ -376,6 +376,11 @@ async fn activate_and_baseline(declared: &[(String, PathBuf)]) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Resolve link chains using the same path representation as tracked entries.
+fn resolve_symlink_source(target: &Path) -> Result<PathBuf> {
+    file::atomic_write_target(target).map(|source| normalize_target(&source))
 }
 
 /// Saves the baseline checkpoint of newly tracked paths; a failure fails
@@ -527,6 +532,18 @@ pub(crate) fn edit_exclude(glob: &str, add: bool) -> Result<bool> {
 #[cfg(test)]
 mod declaration_tests {
     use super::*;
+
+    #[test]
+    fn resolved_sources_use_tracking_path_representation() {
+        let temporary = tempfile::tempdir().unwrap();
+        let source = temporary.path().join("source");
+        std::fs::write(&source, "contents").unwrap();
+        let tracked = normalize_target(&source);
+        // Windows canonicalization adds a verbatim prefix. No symlink
+        // privilege is needed to exercise the resolver's final path format.
+        let canonical = source.canonicalize().unwrap();
+        assert_eq!(resolve_symlink_source(&canonical).unwrap(), tracked);
+    }
 
     #[test]
     fn declaration_commands_fail_promptly_on_contention() {


### PR DESCRIPTION
Tracking a symlink saves the link itself, which can leave its contents out of history and sync without an explanation. Warn when the resolved source is not covered by effective tracking and show the command to enroll it. Sources enrolled in the same invocation or through a tracked directory suppress the warning; exclusions still count as uncaptured.

Validation: focused dotfiles tracking E2E test, scoped hk checks, and Rust formatting. Regression coverage checks relative links, source enrollment, directory coverage, exclusions, dangling links, and preservation of the link itself.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds read-only advisory checks and user-facing warnings after successful track enrollment; capture and git behavior for symlinks themselves are unchanged aside from clearer guidance.
> 
> **Overview**
> **`mise bootstrap dotfiles track`** now runs an advisory pass after enrollment: for each newly declared symlink it resolves the link target (including bounded chain traversal) and **warns** that history will store the link object, not the target’s contents, when the resolved source is not covered by effective tracking.
> 
> Warnings include a suggested `track` command for the source, are **suppressed** when the source is enrolled in the same invocation or already covered (e.g. tracked parent directory), and still apply for excluded or missing sources; unresolvable or cyclic links get a separate resolution warning without blocking enrollment. A small **`resolve_symlink_source`** helper aligns resolved paths with tracking path representation, with a unit test; E2E coverage exercises `add`, explicit track, directories, exclusions, dangling links, chains, and cycles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b9fdb6e8697fffe7dcacab6007d68e7cc0f617a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added warnings when tracking a symbolic link without also tracking its source file.
  - Warnings are suppressed when the source is tracked in the same command or covered by a tracked parent directory.
  - Symbolic links are preserved as links rather than committing their target contents.
  - Added support for resolving nested symbolic-link chains, including warnings for unresolved or cyclic links.

- **Bug Fixes**
  - Excluded or missing source files are no longer incorrectly treated as protected when tracking symbolic links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->