### PR TITLE
fix(bootstrap): explain macos defaults type differences

### DIFF
--- a/e2e/cli/test_system_defaults_types
+++ b/e2e/cli/test_system_defaults_types
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+if [[ $(uname) != Darwin ]]; then
+  exit 0
+fi
+require_cmd jq
+domain="com.mise.defaults-types-test.$$"
+# Core Foundation preferences are outside the harness HOME; isolate and remove this domain.
+trap 'defaults delete "$domain" >/dev/null 2>&1 || true' EXIT
+defaults write "$domain" KeyRepeat -float 2
+defaults write "$domain" InitialKeyRepeat -string 15
+cat >mise.toml <<EOF_CONFIG
+[bootstrap.macos.defaults."$domain"]
+KeyRepeat = 2
+InitialKeyRepeat = 15
+EOF_CONFIG
+assert_contains 'mise bootstrap macos defaults status' '2 (real; expected integer)'
+assert_contains 'mise bootstrap macos defaults status' '15 (string; expected integer)'
+assert_fail 'mise bootstrap macos defaults status --missing'
+assert 'mise bootstrap macos defaults status --json | jq -r '\''.macos_defaults.entries[] | select(.key == "KeyRepeat") | .current'\''' '2 (real; expected integer)'
+# Read-only status preserves the stored type; applying still enforces the configured type.
+assert_contains 'defaults read-type "$domain" KeyRepeat' float
+assert_succeed 'mise bootstrap macos defaults apply --yes'
+assert_succeed 'mise bootstrap macos defaults status --missing'
+assert_contains 'defaults read-type "$domain" KeyRepeat' integer

--- a/e2e/cli/test_system_defaults_types
+++ b/e2e/cli/test_system_defaults_types
@@ -18,8 +18,8 @@ assert_contains 'mise bootstrap macos defaults status' '2 (real; expected intege
 assert_contains 'mise bootstrap macos defaults status' '15 (string; expected integer)'
 assert_fail 'mise bootstrap macos defaults status --missing'
 assert 'mise bootstrap macos defaults status --json | jq -r '\''.macos_defaults.entries[] | select(.key == "KeyRepeat") | .current'\''' '2 (real; expected integer)'
-# Read-only status preserves the stored type; applying still enforces the configured type.
-assert_contains 'defaults read-type "$domain" KeyRepeat' float
+# Read-only status preserves the stored type; applying still corrects a string value.
+assert_contains "defaults read-type '$domain' KeyRepeat" float
 assert_succeed 'mise bootstrap macos defaults apply --yes'
-assert_succeed 'mise bootstrap macos defaults status --missing'
-assert_contains 'defaults read-type "$domain" KeyRepeat' integer
+assert 'mise bootstrap macos defaults status --json | jq -r '\''.macos_defaults.entries[] | select(.key == "InitialKeyRepeat") | .state'\''' 'set'
+assert_contains "defaults read-type '$domain' InitialKeyRepeat" integer

--- a/src/system/defaults.rs
+++ b/src/system/defaults.rs
@@ -395,7 +395,14 @@ fn prepare_writes(
 }
 
 fn display_difference(expected: &DefaultsValue, current: &plist::Value) -> String {
-    let expected_type = plist_type(&expected.to_plist());
+    let expected_type = match expected {
+        DefaultsValue::Bool(_) => "boolean",
+        DefaultsValue::Int(_) => "integer",
+        DefaultsValue::Float(_) => "real",
+        DefaultsValue::Str(_) => "string",
+        DefaultsValue::Array(_) => "array",
+        DefaultsValue::Dict(_) => "dictionary",
+    };
     let current_type = plist_type(current);
     let value = display_plist(current);
     if expected_type == current_type {

--- a/src/system/defaults.rs
+++ b/src/system/defaults.rs
@@ -245,7 +245,7 @@ fn status_sync(requests: &[DefaultsRequest]) -> Result<Vec<DefaultsStatus>> {
                     DefaultsState::Set
                 } else {
                     DefaultsState::Differs {
-                        current: display_plist(current),
+                        current: display_difference(&req.value, current),
                     }
                 }
             }
@@ -392,6 +392,32 @@ fn prepare_writes(
         }
     }
     Ok(writes)
+}
+
+fn display_difference(expected: &DefaultsValue, current: &plist::Value) -> String {
+    let expected_type = plist_type(&expected.to_plist());
+    let current_type = plist_type(current);
+    let value = display_plist(current);
+    if expected_type == current_type {
+        value
+    } else {
+        format!("{value} ({current_type}; expected {expected_type})")
+    }
+}
+
+fn plist_type(value: &plist::Value) -> &'static str {
+    match value {
+        plist::Value::Boolean(_) => "boolean",
+        plist::Value::Integer(_) => "integer",
+        plist::Value::Real(_) => "real",
+        plist::Value::String(_) => "string",
+        plist::Value::Array(_) => "array",
+        plist::Value::Dictionary(_) => "dictionary",
+        plist::Value::Data(_) => "data",
+        plist::Value::Date(_) => "date",
+        plist::Value::Uid(_) => "uid",
+        _ => "unknown",
+    }
 }
 
 fn display_plist(value: &plist::Value) -> String {
@@ -697,6 +723,36 @@ mod tests {
             ["-string", "left"]
         );
         assert_eq!(DefaultsValue::Array(vec![]).write_args(), None);
+    }
+
+    #[test]
+    fn differing_types_are_visible_even_when_values_render_identically() {
+        for (expected, current, display) in [
+            (
+                DefaultsValue::Int(2),
+                plist::Value::Real(2.0),
+                "2 (real; expected integer)",
+            ),
+            (
+                DefaultsValue::Float(15.0),
+                plist::Value::Integer(15.into()),
+                "15 (integer; expected real)",
+            ),
+            (
+                DefaultsValue::Int(2),
+                plist::Value::String("2".into()),
+                "2 (string; expected integer)",
+            ),
+            (
+                DefaultsValue::Bool(true),
+                plist::Value::String("true".into()),
+                "true (string; expected boolean)",
+            ),
+            (DefaultsValue::Int(2), plist::Value::Integer(3.into()), "3"),
+        ] {
+            assert!(!expected.matches(&current));
+            assert_eq!(display_difference(&expected, &current), display);
+        }
     }
 
     #[test]


### PR DESCRIPTION
macOS defaults status can display identical desired and current values while reporting `differs`, because comparison includes the property-list type. Show the actual and expected types when they differ: an integer `KeyRepeat = 2` against a stored real now reports `2 (real; expected integer)` in Current. Strict comparison and apply behavior remain unchanged; same-type value differences keep their existing display.

Validation: focused defaults unit tests, a macOS E2E test using an isolated preference domain, scoped hk checks, and Rust formatting. The E2E test verifies text and JSON output, read-only status, and string-to-integer correction through apply.

Native testing also exposed an existing write limitation: CFPreferences can retain a real `2.0` when applying integer `2`. This PR explains the resulting status mismatch; it does not change that write behavior.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only change to status messaging and tests; macOS defaults matching and write paths are untouched.
> 
> **Overview**
> **macOS defaults status** now explains *why* a preference shows as `differs` when the printed value looks the same as config: strict matching already required matching property-list types, but **Current** only showed the raw value.
> 
> When the stored type does not match the expected type, **Current** is now annotated like **`2 (real; expected integer)`** or **`15 (string; expected integer)`**. Same-type value mismatches keep the plain value display. **Compare/apply behavior is unchanged**—this is status output only.
> 
> Coverage adds unit tests for `display_difference` and a **Darwin-only E2E** that seeds mismatched types in an isolated preference domain, checks text/JSON status, read-only `--missing`, and that **apply** still corrects a string stored as an integer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 315f2910ececfd33ae1937f21ebb9f00881352d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preference status output now identifies both current and expected property-list types when a value has the wrong type.
  - Applying system defaults corrects compatible type mismatches while preserving values that should not be changed.
  - Read-only status checks preserve existing preference values and types without modifying them.
- **Tests**
  - Added macOS coverage for detecting, displaying, and applying preference type mismatches, including numeric and string values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->