### PR TITLE
registry: fix editorconfig-checker 4.0.1

### DIFF
--- a/registry/editorconfig-checker.toml
+++ b/registry/editorconfig-checker.toml
@@ -1,7 +1,7 @@
 backends = [
-  "aqua:editorconfig-checker/editorconfig-checker",
+  "github:editorconfig-checker/editorconfig-checker",
   "asdf:gabitchov/asdf-editorconfig-checker",
 ]
 description = "A tool to verify that your files are in harmony with your .editorconfig"
-test = { cmd = "ec --help", expected = "editorconfig-checker [OPTIONS]" }
+test = { cmd = "editorconfig-checker --help", expected = "editorconfig-checker [OPTIONS]" }
 version_order = "semver"


### PR DESCRIPTION
editorconfig-checker 4.0.1 renamed its release assets and executable from ec to editorconfig-checker. The aqua registry metadata still targets the old names, so latest installs fail on macOS and the mise registry test fails on Linux after installation.

Use the GitHub backend, which lists and installs 4.0.1 across the current asset naming scheme, and update the smoke-test command to the new executable.

Validation: mise run lint-fix; mise ls-remote github:editorconfig-checker/editorconfig-checker; installed 4.0.1 and ran editorconfig-checker --help.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry metadata and smoke-test command only; no runtime application code changes.
> 
> **Overview**
> Fixes **editorconfig-checker** installs and registry smoke tests after **4.0.1** dropped the `ec` binary name and changed release layout.
> 
> The registry now prefers the **`github:`** backend instead of **`aqua:`** so mise can resolve current GitHub release assets, and the install test runs **`editorconfig-checker --help`** with the same expected help text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 755d18d04d92a56879d2b45a11d34fcaaccca3a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the EditorConfig Checker registry configuration to use the GitHub backend.
  * Updated the verification command to use the full `editorconfig-checker` executable name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->