### PR TITLE
registry: prefer github backend for rumdl

### DIFF
--- a/registry/rumdl.toml
+++ b/registry/rumdl.toml
@@ -1,4 +1,4 @@
-backends = ["aqua:rvben/rumdl", "github:rvben/rumdl"]
+backends = ["github:rvben/rumdl", "aqua:rvben/rumdl"]
 description = "Markdown Linter and Formatter written in Rust"
 test = { cmd = "rumdl --version", expected = "rumdl {{version}}" }
 version_order = "semver"


### PR DESCRIPTION
rumdl 0.2.73 republished its release assets after the initial release. The replacement assets are valid GitHub-attested builds from tag v0.2.73 and commit 3ca6b92, but aqua's sidecar checksum path still resolves the original hash and makes mise registry tests fail.

Prefer the GitHub backend, which verifies the current release asset against GitHub's artifact attestation, while retaining aqua as the fallback.

Validation:
- `mise run lint-fix` passed
- `mise ls-remote github:rvben/rumdl` lists installable versions
- installed `github:rvben/rumdl@0.2.73`; `rumdl --version` reports 0.2.73
- `gh attestation verify` matched the replacement Linux x64 asset to the rumdl release workflow and tag commit

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line registry backend preference change with no runtime or security logic touched.
> 
> **Overview**
> **Reorders the `rumdl` mise registry entry** so **`github:rvben/rumdl` is tried before `aqua:rvben/rumdl`**, with aqua kept as fallback.
> 
> This fixes registry/install tests when aqua still checksums the original rumdl 0.2.73 assets after GitHub republished attested replacements; the GitHub backend resolves the current release artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b0578d50214e36e88777cdef335078007e2e8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reordered the listed backends so GitHub appears before Aqua.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->