### PR TITLE
fix(packslip): skip unsupported lockfile targets

### DIFF
--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -375,7 +375,7 @@ pub(crate) fn select_artifact<'a>(
 
 fn lock_artifact_error(err: eyre::Report, target: &PlatformTarget) -> eyre::Report {
     let context = format!("selecting the packslip artifact for {}", target.to_key());
-    if err.is::<NoHostArtifact>() {
+    if !target.is_current() && err.is::<NoHostArtifact>() {
         crate::errors::Error::UnsupportedTarget(format!("{context}: {err}")).into()
     } else {
         err.wrap_err(context)
@@ -2126,6 +2126,16 @@ list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packsl
             err.downcast_ref::<crate::errors::Error>(),
             Some(crate::errors::Error::UnsupportedTarget(message))
                 if message.contains("no artifact for windows/x86_64")
+        ));
+
+        let current = PlatformTarget::new(Platform::current());
+        let err = lock_artifact_error(
+            NoHostArtifact("no current artifact".into()).into(),
+            &current,
+        );
+        assert!(!matches!(
+            err.downcast_ref::<crate::errors::Error>(),
+            Some(crate::errors::Error::UnsupportedTarget(_))
         ));
 
         // Two artifacts that tie are refused, and a variant picks one.

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -2120,12 +2120,18 @@ list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packsl
             err.to_string().contains("no artifact for windows/x86_64"),
             "{err}"
         );
-        let target = PlatformTarget::new(Platform::parse("windows-x64").unwrap());
+        let target = PlatformTarget::new(if cfg!(windows) {
+            Platform::parse("macos-x64").unwrap()
+        } else {
+            Platform::parse("windows-x64").unwrap()
+        });
+        let host = HostPlatform::from_platform(&target.platform);
+        let err = select_artifact(&artifacts, &host, None).unwrap_err();
         let err = lock_artifact_error(err, &target);
         assert!(matches!(
             err.downcast_ref::<crate::errors::Error>(),
             Some(crate::errors::Error::UnsupportedTarget(message))
-                if message.contains("no artifact for windows/x86_64")
+                if message.contains("no artifact")
         ));
 
         let current = PlatformTarget::new(Platform::current());

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -373,6 +373,15 @@ pub(crate) fn select_artifact<'a>(
     .into())
 }
 
+fn lock_artifact_error(err: eyre::Report, target: &PlatformTarget) -> eyre::Report {
+    let context = format!("selecting the packslip artifact for {}", target.to_key());
+    if err.is::<NoHostArtifact>() {
+        crate::errors::Error::UnsupportedTarget(format!("{context}: {err}")).into()
+    } else {
+        err.wrap_err(context)
+    }
+}
+
 async fn select_compatible_artifact<'a>(
     artifacts: &'a [Artifact],
     host: &HostPlatform,
@@ -1692,7 +1701,7 @@ impl Backend for PackslipBackend {
                 opts.variant().as_deref(),
             )
         }
-        .wrap_err_with(|| format!("selecting the packslip artifact for {}", target.to_key()))?;
+        .map_err(|err| lock_artifact_error(err, target))?;
         let url = artifact
             .url
             .clone()
@@ -2111,6 +2120,13 @@ list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packsl
             err.to_string().contains("no artifact for windows/x86_64"),
             "{err}"
         );
+        let target = PlatformTarget::new(Platform::parse("windows-x64").unwrap());
+        let err = lock_artifact_error(err, &target);
+        assert!(matches!(
+            err.downcast_ref::<crate::errors::Error>(),
+            Some(crate::errors::Error::UnsupportedTarget(message))
+                if message.contains("no artifact for windows/x86_64")
+        ));
 
         // Two artifacts that tie are refused, and a variant picks one.
         let mut fips = artifact(
@@ -2150,6 +2166,12 @@ list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packsl
         ];
         let err = select_artifact(&tie, &linux(), None).unwrap_err();
         assert!(err.to_string().contains("will not guess"), "{err}");
+        let target = PlatformTarget::new(Platform::parse("linux-x64").unwrap());
+        let err = lock_artifact_error(err, &target);
+        assert!(!matches!(
+            err.downcast_ref::<crate::errors::Error>(),
+            Some(crate::errors::Error::UnsupportedTarget(_))
+        ));
 
         // A gnu host with no gnu build takes the static musl build; a
         // host that reports no libc takes only artifacts naming none.

--- a/src/lockfile/generate.rs
+++ b/src/lockfile/generate.rs
@@ -742,6 +742,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn supported_target_is_kept_when_another_target_is_unsupported() {
+        crate::backend::load_tools().await.unwrap();
+        let generated = generate(
+            &previous(),
+            &[tool()],
+            &[
+                Platform::parse("linux-x64").unwrap(),
+                Platform::parse("windows-arm64").unwrap(),
+            ],
+            false,
+            false,
+            2,
+            &[],
+        )
+        .await
+        .unwrap();
+        let platforms = &generated.tools["fixture"][0].platforms;
+        assert!(platforms.contains_key("linux-x64"));
+        assert!(!platforms.contains_key("windows-arm64"));
+    }
+
+    #[tokio::test]
     async fn unchanged_entries_reuse_metadata_without_network_and_are_stable() {
         crate::backend::load_tools().await.unwrap();
         let old = previous();


### PR DESCRIPTION
## Summary

- classify a missing Packslip artifact as an unsupported lockfile target
- let complete lockfile generation skip unsupported platforms while retaining supported entries
- keep ambiguous artifact selection and other Packslip failures fatal

## Validation

- `mise run test:unit -- packslip` (54 passed)
- `mise run format` (includes repository formatting and `cargo check --all-features`)
- reproduced Discussion #13099 with `pitchfork`: installation and generation succeed, supported targets are written, and Linux musl/macOS x64 are omitted

Fixes https://github.com/jdx/mise/discussions/13099

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error classification for packfile lock resolution; install and fatal packslip errors unchanged, with new tests covering the skip path.
> 
> **Overview**
> When resolving packslip lock entries for a **non-current** platform, a release with **no matching artifact** is now surfaced as `UnsupportedTarget` instead of a generic resolution failure. That lets lockfile generation **omit** that platform while still writing entries for supported targets (e.g. linux-x64 kept when windows-arm64 has no packslip build).
> 
> **Current-host** missing artifacts and non–`NoHostArtifact` failures (ambiguous ties, verification issues, etc.) still fail as before via wrapped errors, not `UnsupportedTarget`.
> 
> Unit tests cover `lock_artifact_error` mapping and multi-platform `generate` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73220c698ba13560041f8dc897f129f6a2cc30e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when a requested target does not have a compatible artifact.
  - Unsupported targets are reported with clearer, target-specific information.
  - Preserves supported target entries when another requested target is unavailable.
  - Retains additional context for artifact selection failures, making troubleshooting more accurate.
  - Correctly distinguishes failures on the current platform from unsupported cross-platform targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->