### PR TITLE
perf(lockfile): skip generation for current warm installs

### DIFF
--- a/e2e/lockfile/test_lockfile_generate_current
+++ b/e2e/lockfile/test_lockfile_generate_current
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export MISE_LOCKFILE_MODE=generate
+
+cat >mise.toml <<'TOML'
+[settings]
+lockfile_platforms = ["linux-x64", "macos-arm64"]
+
+[tools."http:current-fixture"]
+version = "1.0.0"
+url = "https://mise.jdx.dev/test-fixtures/hello-world-1.0.0.tar.gz"
+checksum = "sha256:dbca4f08377d70dc0828f5822fc47ecec3895cd9a6dacbc54cc984d346a571af"
+bin_path = "hello-world-1.0.0/bin"
+TOML
+
+mise lock
+mise install
+
+# A marker makes unnecessary serialization observable: the regular writer
+# canonicalizes TOML and removes it. Warm installs should preserve the file.
+echo '# warm no-op marker' >>mise.lock
+cp mise.lock expected.lock
+mise install
+diff -u expected.lock mise.lock
+
+# Explicit lock commands and forced verification still use full generation.
+mise lock
+assert_not_contains "cat mise.lock" 'warm no-op marker'
+echo '# warm no-op marker' >>mise.lock
+MISE_LOCKED_VERIFY_PROVENANCE=1 mise install
+assert_not_contains "cat mise.lock" 'warm no-op marker'
+
+# Nothing needs installing, but a new target still needs lock metadata.
+python3 - <<'PY'
+from pathlib import Path
+p = Path("mise.toml")
+p.write_text(p.read_text().replace('"linux-x64", "macos-arm64"', '"linux-x64", "macos-arm64", "linux-arm64"'))
+PY
+mise install
+assert_contains "cat mise.lock" 'platforms.linux-arm64'
+
+# Stale entries must still be removed on a warm install.
+cat >>mise.lock <<'TOML'
+
+[[tools.obsolete]]
+version = "1.0.0"
+backend = "http:obsolete"
+TOML
+mise install
+assert_not_contains "cat mise.lock" 'tools.obsolete'

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -217,6 +217,20 @@ fn publication_lock_paths(
         .collect()
 }
 
+fn distinct_lockfile_targets(mut targets: impl ExactSizeIterator<Item = impl AsRef<Path>>) -> bool {
+    if targets.len() < 2 {
+        return true;
+    }
+    let mut canonical = BTreeSet::new();
+    targets.all(|path| match fs::canonicalize(path) {
+        Ok(path) => canonical.insert(path),
+        // Missing files cannot take the fast path, so only existing targets
+        // need to be distinct before one of them can be skipped.
+        Err(error) if error.kind() == ErrorKind::NotFound => true,
+        Err(_) => false,
+    })
+}
+
 fn verify_generation_snapshots<'a>(
     snapshots: impl Iterator<Item = (&'a PathBuf, &'a Option<Vec<u8>>)>,
 ) -> Result<()> {
@@ -384,6 +398,14 @@ impl Lock {
         let lockfile_targets =
             self.get_lockfile_targets(&config, effective_config_files, &scoped_config_paths);
         let migration_inputs = lockfile::monorepo_lockfile_migration_paths(&config);
+        let can_skip_generation = generate
+            && installed.is_some_and(|versions| versions.is_empty())
+            && !self.upgrade
+            && !self.bump
+            && self.tool.is_empty()
+            && self.platform.is_empty()
+            && migration_inputs.is_empty()
+            && distinct_lockfile_targets(lockfile_targets.keys());
         let initial_lockfiles = lockfile_targets
             .keys()
             .chain(
@@ -645,6 +667,20 @@ impl Lock {
             // Compute stale versions BEFORE process_tools so provenance checks can
             // compare against old version entries. Actual pruning happens after.
             let stale_versions = self.stale_versions_if_pruned(&lockfile, &tools);
+
+            // No new installation result can override the cached artifacts here.
+            // Keep unchanged files out of the mutation/rollback set, but leave them
+            // in initial_lockfiles so publication still checks concurrent edits.
+            if can_skip_generation
+                && original_content.is_some()
+                && lockfile::generate::is_current(&lockfile, &tools, &target_platforms)?
+            {
+                debug!(
+                    "lockfile {} is already current",
+                    display_path(&lockfile_path)
+                );
+                continue;
+            }
 
             let (results, resolution_errors) = if generate {
                 lockfile = lockfile::generate::generate(
@@ -1970,7 +2006,8 @@ impl Lock {
 mod tests {
     use super::{
         Lock, LockTaskResult, LockTaskStatus, LockfileSnapshot, classify_lock_result,
-        prepare_lockfile_rollback, push_unique_lock_tool, restore_lockfile_snapshots,
+        distinct_lockfile_targets, prepare_lockfile_rollback, push_unique_lock_tool,
+        restore_lockfile_snapshots,
     };
     use crate::cli::args::{BackendArg, ToolArg};
     use crate::lockfile::{Lockfile, PlatformInfo, apply_lock_result};
@@ -1980,6 +2017,20 @@ mod tests {
     use std::fs;
     use std::str::FromStr;
     use std::sync::Arc;
+
+    #[test]
+    fn aliased_lockfile_targets_cannot_be_skipped_independently() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join("mise.lock");
+        fs::write(&lock, "[tools]\n").unwrap();
+        fs::create_dir(dir.path().join("sub")).unwrap();
+        let alias = dir.path().join("sub/../mise.lock");
+        assert!(!distinct_lockfile_targets([&lock, &alias].into_iter()));
+        let other = dir.path().join("mise.dev.lock");
+        assert!(distinct_lockfile_targets([&lock, &other].into_iter()));
+        fs::write(&other, "[tools]\n").unwrap();
+        assert!(distinct_lockfile_targets([&lock, &other].into_iter()));
+    }
 
     #[test]
     fn publication_locks_read_only_inputs_without_adding_rollback_targets() {

--- a/src/lockfile/generate.rs
+++ b/src/lockfile/generate.rs
@@ -239,6 +239,102 @@ async fn resolve(
 
 pub(crate) type Tool = (crate::cli::args::BackendArg, ToolVersion);
 
+/// A conservative check for a complete, unfiltered warm install. Compare the
+/// resolved inputs, not file timestamps: environment-dependent options and
+/// verification settings can change without editing mise.toml.
+///
+/// Multiple requests for one short and shared dependency tables use the normal
+/// generator, which owns binding conflicts and dependency-table cleanup.
+pub(crate) fn is_current(
+    previous: &Lockfile,
+    tools: &[Tool],
+    platforms: &[Platform],
+) -> Result<bool> {
+    if tools.is_empty()
+        || platforms.is_empty()
+        || previous.tools.len() != tools.len()
+        || !previous.conda_packages.is_empty()
+        || !previous.pkgx_packages.is_empty()
+        || Settings::get().force_provenance_verify()
+    {
+        return Ok(false);
+    }
+    let mut shorts = BTreeSet::new();
+    for (ba, tv) in tools {
+        if !shorts.insert(&ba.short) {
+            return Ok(false);
+        }
+        let Some(entries) = previous.tools.get(&ba.short) else {
+            return Ok(false);
+        };
+        let backend = tv.backend()?;
+        let stored_backend = ba.stored_full();
+        let specifier = tv.request.version();
+        let mut covered: BTreeMap<usize, BTreeSet<String>> = BTreeMap::new();
+        for platform in platforms {
+            for platform in backend.platform_variants(platform) {
+                let options = backend.resolve_lockfile_options(
+                    &tv.request,
+                    &PlatformTarget::new(platform.clone()),
+                )?;
+                let Some((index, entry)) = entries.iter().enumerate().find(|(_, entry)| {
+                    entry.version == tv.version
+                        && entry.backend.as_deref() == Some(stored_backend.as_str())
+                        && entry.options == options
+                }) else {
+                    return Ok(false);
+                };
+                let bindings_current = if previous.uses_request_bindings() {
+                    entry.specifiers.len() == 1 && entry.specifiers.contains(&specifier)
+                } else {
+                    entry.specifiers.is_empty()
+                };
+                let key = platform.to_key();
+                let Some(info) = entry.platforms.get(&key) else {
+                    return Ok(false);
+                };
+                if !bindings_current || !can_reuse(info) {
+                    return Ok(false);
+                }
+                validate_provenance_settings(ba, tv, &key, info)?;
+                if let Some(error) = check_single_tool_provenance(
+                    Some(entries),
+                    &ba.short,
+                    &tv.version,
+                    &stored_backend,
+                    &key,
+                    info.provenance.as_ref(),
+                ) {
+                    bail!("{error}");
+                }
+                covered.entry(index).or_default().insert(key);
+            }
+        }
+        // Extra versions, option variants, or platforms must still be pruned.
+        // Counting distinct entries also rejects duplicate version/option rows.
+        if covered.is_empty()
+            || covered.len() != entries.len()
+            || covered
+                .iter()
+                .any(|(index, keys)| keys.len() != entries[*index].platforms.len())
+        {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn can_reuse(info: &PlatformInfo) -> bool {
+    info.checksum.is_some()
+        && info.url.is_some()
+        && info.signer.is_none()
+        && info
+            .additional_artifacts
+            .iter()
+            .all(|artifact| artifact.checksum.is_some())
+        && !Settings::get().force_provenance_verify()
+}
+
 pub(crate) async fn generate(
     previous: &Lockfile,
     tools: &[Tool],
@@ -343,16 +439,7 @@ pub(crate) async fn generate(
         }
         // Complete cached artifacts need neither I/O nor a spawned task. Keep them
         // in the same ordered result stream so all downgrade checks still run.
-        let reusable = previous_info.as_ref().filter(|info| {
-            info.checksum.is_some()
-                && info.url.is_some()
-                && info.signer.is_none()
-                && info
-                    .additional_artifacts
-                    .iter()
-                    .all(|artifact| artifact.checksum.is_some())
-                && !Settings::get().force_provenance_verify()
-        });
+        let reusable = previous_info.as_ref().filter(|info| can_reuse(info));
         if actual.is_none()
             && let Some(info) = reusable
         {
@@ -843,6 +930,148 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn current_lockfile_matches_full_generation_in_both_formats() {
+        crate::backend::load_tools().await.unwrap();
+        let tools = vec![tool()];
+        let platforms = vec![
+            Platform::parse("linux-x64").unwrap(),
+            Platform::parse("macos-arm64").unwrap(),
+        ];
+        for version in [0, 1] {
+            let mut old = previous();
+            old.lockfile_version = version;
+            if version == 0 {
+                old.tools.get_mut("fixture").unwrap()[0].specifiers.clear();
+            }
+            assert!(is_current(&old, &tools, &platforms).unwrap());
+            let generated = generate(&old, &tools, &platforms, false, false, 2, &[])
+                .await
+                .unwrap();
+            assert_eq!(old.tools, generated.tools);
+        }
+    }
+
+    #[tokio::test]
+    async fn current_check_requires_exact_scope_and_bindings() {
+        crate::backend::load_tools().await.unwrap();
+        let platforms = vec![
+            Platform::parse("linux-x64").unwrap(),
+            Platform::parse("macos-arm64").unwrap(),
+        ];
+        let tools = vec![tool()];
+        let old = previous();
+        assert!(!is_current(&old, &tools, &platforms[..1]).unwrap());
+        let mut extra_platform = platforms.clone();
+        extra_platform.push(Platform::parse("linux-arm64").unwrap());
+        assert!(!is_current(&old, &tools, &extra_platform).unwrap());
+        assert!(!is_current(&old, &[], &platforms).unwrap());
+        assert!(!is_current(&old, &tools, &[]).unwrap());
+        assert!(!is_current(&old, &[tool(), tool()], &platforms).unwrap());
+
+        let mut changed = old.clone();
+        changed
+            .tools
+            .insert("obsolete".into(), old.tools["fixture"].clone());
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+        let mut changed = old.clone();
+        changed
+            .tools
+            .get_mut("fixture")
+            .unwrap()
+            .push(old.tools["fixture"][0].clone());
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+        let mut changed = old.clone();
+        changed.tools.get_mut("fixture").unwrap()[0].version = "other-tag".into();
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+        let mut changed = old.clone();
+        changed.tools.get_mut("fixture").unwrap()[0].backend = Some("http:other".into());
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+        let mut changed = old.clone();
+        changed.tools.get_mut("fixture").unwrap()[0]
+            .options
+            .insert("format".into(), "tar.gz".into());
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+        let mut changed = old.clone();
+        changed.tools.get_mut("fixture").unwrap()[0]
+            .specifiers
+            .clear();
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+        let mut changed = old.clone();
+        changed.tools.get_mut("fixture").unwrap()[0]
+            .specifiers
+            .insert("obsolete".into());
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+        let mut changed = old.clone();
+        changed
+            .conda_packages
+            .insert("linux-x64".into(), BTreeMap::new());
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+        let mut changed = old.clone();
+        changed
+            .pkgx_packages
+            .insert("linux-x64".into(), BTreeMap::new());
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+    }
+
+    #[tokio::test]
+    async fn current_check_requires_complete_artifacts_and_valid_provenance() {
+        crate::backend::load_tools().await.unwrap();
+        let platforms = vec![
+            Platform::parse("linux-x64").unwrap(),
+            Platform::parse("macos-arm64").unwrap(),
+        ];
+        let tools = vec![tool()];
+        let old = previous();
+        let mut changed = old.clone();
+        changed.tools.get_mut("fixture").unwrap()[0]
+            .platforms
+            .get_mut("linux-x64")
+            .unwrap()
+            .checksum = None;
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+        let mut changed = old.clone();
+        changed.tools.get_mut("fixture").unwrap()[0]
+            .platforms
+            .get_mut("linux-x64")
+            .unwrap()
+            .url = None;
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+        let mut changed = old.clone();
+        changed.tools.get_mut("fixture").unwrap()[0]
+            .platforms
+            .get_mut("linux-x64")
+            .unwrap()
+            .signer = Some("signer".into());
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+        let mut changed = old.clone();
+        changed.tools.get_mut("fixture").unwrap()[0]
+            .platforms
+            .get_mut("linux-x64")
+            .unwrap()
+            .additional_artifacts
+            .push(ArtifactInfo {
+                url: "https://example.invalid/extra".into(),
+                ..Default::default()
+            });
+        assert!(!is_current(&changed, &tools, &platforms).unwrap());
+
+        let ba = BackendArg::new("fixture".into(), Some("github:example/fixture".into()));
+        let request = ToolRequest::new(Arc::new(ba.clone()), "1", ToolSource::Argument).unwrap();
+        let tv = ToolVersion::new(request, "1.0".into());
+        let entry = &mut changed.tools.get_mut("fixture").unwrap()[0];
+        entry.backend = Some(ba.stored_full());
+        let artifact = &mut entry
+            .platforms
+            .get_mut("linux-x64")
+            .unwrap()
+            .additional_artifacts[0];
+        artifact.checksum = Some("sha256:unchanged".into());
+        artifact.provenance = Some(ProvenanceType::Minisign);
+        let error = is_current(&changed, &[(ba, tv)], &platforms).unwrap_err();
+        assert!(error.to_string().contains("unexpected provenance type"));
+    }
+
+    #[tokio::test]
     async fn filtered_platform_carries_other_platform_forward() {
         crate::backend::load_tools().await.unwrap();
         let old = previous();
@@ -931,6 +1160,7 @@ mod tests {
             );
             old.bind_request("erlang", "28", "28.0", &options);
         }
+        assert!(is_current(&old, &[(ba.clone(), tv.clone())], &platforms).unwrap());
         let generated = generate(&old, &[(ba, tv)], &platforms, false, false, 2, &[])
             .await
             .unwrap();


### PR DESCRIPTION
A fully warm install in `lockfile_mode = "generate"` still reconstructs and rebinds the lockfile, serializes it, and prepares a synced rollback replacement before discovering that its contents are unchanged. Skip that work when the already-resolved requests match a complete current lockfile.

This follows #13101 and uses the same artifact-reuse eligibility. The check compares tool/backend/version identity, platform-specific options, exact request bindings, and platform coverage, then validates recorded provenance. Unchanged targets stay in the transaction's input snapshots and locks, but are omitted from its mutation and rollback sets.

The shortcut is limited to installs with no newly installed tools. Explicit `mise lock`, forced verification, upgrades, migrations, aliased target paths, multiple requests for a short, shared dependency tables, and incomplete/non-reusable metadata continue through the existing path. No persisted cache or lockfile-format change is introduced.

Follow-up to https://github.com/jdx/mise/discussions/13018#discussioncomment-18406024.

## Performance

Full warm `mise install`, macOS arm64 debug builds, 30 installed HTTP tools and three target platforms. Baseline is `22b8eb592`, including #13101. Thirty measured runs per mode, interleaved after five warmups per mode; lockfile bytes were checked after every run.

| Mode | Median |
| --- | ---: |
| Baseline generate | 83.9 ms |
| This PR, generate | 74.2 ms |
| Merge | 65.7 ms |

About 12% faster overall, removing roughly half of generation's extra warm-run cost in this fixture. Configuration resolution and input validation still run. These synthetic project/debug-build timings do not predict the original reporter's end-to-end improvement.

## Validation

- 17 generation tests passed, covering both lockfile formats, stale scope/bindings/options, missing metadata, provenance, and Erlang platform variants.
- 27 lock-command tests passed, including transaction input protection and the new aliased-target regression.
- End-to-end warm no-op, forced verification, added-platform, stale-entry, concurrent-edit, and platform-option tests passed. The no-op test preserves a TOML comment that full serialization would remove.
- Scoped safe hk fix (format, shell checks, all-features Cargo check) and `cargo clippy --workspace --all-features --all-targets -- -D warnings` passed.

Validation used the repository's documented `MBX_DISABLE=1` fallback.

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when lockfiles are rewritten during install; incorrect skipping could leave stale metadata, but guards and tests target bindings, provenance, aliased paths, and pruning.
> 
> **Overview**
> Warm **`mise install`** runs in **`lockfile_mode = generate`** can now **skip** full lockfile rebuild, serialization, and rollback staging when nothing was installed and the on-disk lock already matches the resolved toolset.
> 
> The fast path is gated by **`can_skip_generation`** in the lock CLI (no bump/upgrade/tool/platform filters, no migrations, distinct canonical lockfile targets) and **`lockfile::generate::is_current`**, which compares tools, backends, versions, platform options, request bindings, full platform coverage, and reusable artifact metadata—including provenance checks aligned with **`can_reuse`**. Unchanged lockfiles stay in transaction snapshots but are omitted from mutations.
> 
> **Explicit `mise lock`**, **`MISE_LOCKED_VERIFY_PROVENANCE`**, new platforms, and stale lock entries still go through full generation or pruning. An e2e script asserts warm installs preserve a TOML comment marker that canonical rewrite would strip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb78b35c00c60818d90580a74ed32b2f6180088b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Lockfile generation is faster when the existing lockfile is already up to date.
  - Unchanged lockfiles are preserved during warm installs, reducing unnecessary file updates.
  - Lockfile metadata now reflects newly added platform targets even when no tools require installation.
  - Stale tool entries are removed during warm installs.
  - Explicit lockfile regeneration and provenance verification continue to refresh lockfiles when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->