### PR TITLE
fix(lockfile): allow packslip to replace legacy provenance

### DIFF
--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -37,7 +37,7 @@ use crate::file;
 use crate::github;
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
-use crate::lockfile::{PlatformInfo, ProvenanceType};
+use crate::lockfile::PlatformInfo;
 use crate::packslip_pins::{self, Observed};
 use crate::platform::Platform;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions};
@@ -149,42 +149,6 @@ fn bundle_name(project: &str) -> String {
         Some(sub) => format!("packslip.{}.sigstore.json", sub.replace('/', "-")),
         None => "packslip.sigstore.json".to_string(),
     }
-}
-
-/// The strongest provenance mechanism linked for an artifact. Packslip
-/// provenance links name SLSA statements; GitHub's attestation API is kept as
-/// its higher-priority lockfile variant so a backend migration does not look
-/// like a provenance downgrade on the next release.
-fn linked_provenance(artifact: &Artifact) -> Option<ProvenanceType> {
-    if artifact
-        .provenance
-        .iter()
-        .any(|url| is_github_attestation_url(url))
-    {
-        return Some(ProvenanceType::GithubAttestations);
-    }
-    artifact
-        .provenance
-        .first()
-        .cloned()
-        .map(|url| ProvenanceType::Slsa { url: Some(url) })
-}
-
-fn is_github_attestation_url(value: &str) -> bool {
-    let Ok(url) = reqwest::Url::parse(value) else {
-        return false;
-    };
-    let Some(mut path) = url.path_segments() else {
-        return false;
-    };
-    matches!(path.next(), Some("repos"))
-        && path.next().is_some()
-        && path.next().is_some()
-        && matches!(path.next(), Some("attestations"))
-        && path
-            .next()
-            .is_some_and(|digest| digest.starts_with("sha256:"))
-        && path.next().is_none()
 }
 
 /// The signed release list of a project on its own domain.
@@ -1438,8 +1402,6 @@ impl PackslipBackend {
             {
                 info.checksum = Some(format!("sha256:{sha256}"));
             }
-            info.provenance = linked_provenance(&artifact);
-            info.provenance_verified = None;
             info.signer = Some(signer);
             // Set for a repackager's document and cleared for the vendor's,
             // so the lockfile ratchets up the way the pin does.
@@ -1742,7 +1704,6 @@ impl Backend for PackslipBackend {
                 .map(|digest| format!("sha256:{digest}")),
             size: Some(artifact.size),
             url: Some(url),
-            provenance: linked_provenance(artifact),
             signer: Some(format!(
                 "{scheme}:{}",
                 packslip_pins::signer_of(&scheme, &verified.key_id)
@@ -1884,29 +1845,6 @@ list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packsl
                 .unwrap()
                 .to_string()
                 .contains("cannot be combined with pubkey")
-        );
-    }
-
-    #[test]
-    fn linked_artifact_provenance_is_recorded_by_mechanism() {
-        let mut artifact = artifact("tool.tar.gz", "linux", "x86_64", None, "tar.gz");
-        assert_eq!(linked_provenance(&artifact), None);
-
-        let slsa = "https://example.com/tool.intoto.jsonl";
-        artifact.provenance.push(slsa.into());
-        assert_eq!(
-            linked_provenance(&artifact),
-            Some(ProvenanceType::Slsa {
-                url: Some(slsa.into())
-            })
-        );
-
-        artifact
-            .provenance
-            .push("https://api.github.com/repos/o/r/attestations/sha256:deadbeef".into());
-        assert_eq!(
-            linked_provenance(&artifact),
-            Some(ProvenanceType::GithubAttestations)
         );
     }
 

--- a/src/backend/packslip.rs
+++ b/src/backend/packslip.rs
@@ -37,7 +37,7 @@ use crate::file;
 use crate::github;
 use crate::http::{HTTP, HTTP_FETCH};
 use crate::install_context::InstallContext;
-use crate::lockfile::PlatformInfo;
+use crate::lockfile::{PlatformInfo, ProvenanceType};
 use crate::packslip_pins::{self, Observed};
 use crate::platform::Platform;
 use crate::toolset::{ToolRequest, ToolVersion, ToolVersionOptions};
@@ -149,6 +149,42 @@ fn bundle_name(project: &str) -> String {
         Some(sub) => format!("packslip.{}.sigstore.json", sub.replace('/', "-")),
         None => "packslip.sigstore.json".to_string(),
     }
+}
+
+/// The strongest provenance mechanism linked for an artifact. Packslip
+/// provenance links name SLSA statements; GitHub's attestation API is kept as
+/// its higher-priority lockfile variant so a backend migration does not look
+/// like a provenance downgrade on the next release.
+fn linked_provenance(artifact: &Artifact) -> Option<ProvenanceType> {
+    if artifact
+        .provenance
+        .iter()
+        .any(|url| is_github_attestation_url(url))
+    {
+        return Some(ProvenanceType::GithubAttestations);
+    }
+    artifact
+        .provenance
+        .first()
+        .cloned()
+        .map(|url| ProvenanceType::Slsa { url: Some(url) })
+}
+
+fn is_github_attestation_url(value: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(value) else {
+        return false;
+    };
+    let Some(mut path) = url.path_segments() else {
+        return false;
+    };
+    matches!(path.next(), Some("repos"))
+        && path.next().is_some()
+        && path.next().is_some()
+        && matches!(path.next(), Some("attestations"))
+        && path
+            .next()
+            .is_some_and(|digest| digest.starts_with("sha256:"))
+        && path.next().is_none()
 }
 
 /// The signed release list of a project on its own domain.
@@ -1402,6 +1438,8 @@ impl PackslipBackend {
             {
                 info.checksum = Some(format!("sha256:{sha256}"));
             }
+            info.provenance = linked_provenance(&artifact);
+            info.provenance_verified = None;
             info.signer = Some(signer);
             // Set for a repackager's document and cleared for the vendor's,
             // so the lockfile ratchets up the way the pin does.
@@ -1704,6 +1742,7 @@ impl Backend for PackslipBackend {
                 .map(|digest| format!("sha256:{digest}")),
             size: Some(artifact.size),
             url: Some(url),
+            provenance: linked_provenance(artifact),
             signer: Some(format!(
                 "{scheme}:{}",
                 packslip_pins::signer_of(&scheme, &verified.key_id)
@@ -1845,6 +1884,29 @@ list_identity_prefix = "https://github.com/jdx/packslip/.github/workflows/packsl
                 .unwrap()
                 .to_string()
                 .contains("cannot be combined with pubkey")
+        );
+    }
+
+    #[test]
+    fn linked_artifact_provenance_is_recorded_by_mechanism() {
+        let mut artifact = artifact("tool.tar.gz", "linux", "x86_64", None, "tar.gz");
+        assert_eq!(linked_provenance(&artifact), None);
+
+        let slsa = "https://example.com/tool.intoto.jsonl";
+        artifact.provenance.push(slsa.into());
+        assert_eq!(
+            linked_provenance(&artifact),
+            Some(ProvenanceType::Slsa {
+                url: Some(slsa.into())
+            })
+        );
+
+        artifact
+            .provenance
+            .push("https://api.github.com/repos/o/r/attestations/sha256:deadbeef".into());
+        assert_eq!(
+            linked_provenance(&artifact),
+            Some(ProvenanceType::GithubAttestations)
         );
     }
 

--- a/src/lockfile/generate.rs
+++ b/src/lockfile/generate.rs
@@ -565,11 +565,14 @@ pub(crate) async fn generate(
 }
 
 fn ensure_no_downgrade(old: &PlatformInfo, new: &PlatformInfo, backend: &str) -> Result<()> {
-    // Packslip authenticates artifacts through its signed release manifest and
-    // signer chain. Older incremental lock updates could carry detected GitHub
-    // provenance into a Packslip entry, but complete generation intentionally
-    // does not persist that unverified link for a replacement artifact.
-    let compare_provenance = !backend.starts_with("packslip:");
+    // A verified Packslip signer is the replacement trust baseline for an
+    // artifact authenticated by its signed release manifest. Older incremental
+    // lock updates could carry detected GitHub provenance into a Packslip entry,
+    // but complete generation intentionally does not persist that unverified
+    // link. Without a signer, retain the ordinary provenance ratchet.
+    let packslip_signer_replaces_provenance =
+        backend.starts_with("packslip:") && new.signer.is_some();
+    let compare_provenance = !packslip_signer_replaces_provenance;
     if compare_provenance && new.provenance < old.provenance {
         bail!(
             "lockfile generation would downgrade recorded provenance; previous files were preserved"
@@ -1201,6 +1204,9 @@ mod tests {
 
         assert!(ensure_no_downgrade(&old, &new, "packslip:github.com/o/r").is_ok());
         assert!(ensure_no_downgrade(&old, &new, "github:o/r").is_err());
+
+        new.signer = None;
+        assert!(ensure_no_downgrade(&old, &new, "packslip:github.com/o/r").is_err());
 
         new.signer =
             Some("sigstore-oidc:https://github.com/o/r/.github/workflows/other.yml".into());

--- a/src/lockfile/generate.rs
+++ b/src/lockfile/generate.rs
@@ -527,7 +527,7 @@ pub(crate) async fn generate(
                 })
                 .filter_map(|old| old.platforms.get(&platform.to_key()))
             {
-                ensure_no_downgrade(old, &info)?;
+                ensure_no_downgrade(old, &info, &backend)?;
             }
         }
         if let Some(error) = check_single_tool_provenance(
@@ -564,8 +564,13 @@ pub(crate) async fn generate(
     Ok(candidate)
 }
 
-fn ensure_no_downgrade(old: &PlatformInfo, new: &PlatformInfo) -> Result<()> {
-    if new.provenance < old.provenance {
+fn ensure_no_downgrade(old: &PlatformInfo, new: &PlatformInfo, backend: &str) -> Result<()> {
+    // Packslip authenticates artifacts through its signed release manifest and
+    // signer chain. Older incremental lock updates could carry detected GitHub
+    // provenance into a Packslip entry, but complete generation intentionally
+    // does not persist that unverified link for a replacement artifact.
+    let compare_provenance = !backend.starts_with("packslip:");
+    if compare_provenance && new.provenance < old.provenance {
         bail!(
             "lockfile generation would downgrade recorded provenance; previous files were preserved"
         );
@@ -579,21 +584,23 @@ fn ensure_no_downgrade(old: &PlatformInfo, new: &PlatformInfo) -> Result<()> {
     }
     // Preserve identities across reordering, then pair replaced URLs in their
     // configured order so version upgrades retain the previous trust baseline.
-    let mut replacements = new.additional_artifacts.iter().filter(|artifact| {
-        !old.additional_artifacts
-            .iter()
-            .any(|old| old.url == artifact.url)
-    });
-    for artifact in &old.additional_artifacts {
-        let replacement = new
-            .additional_artifacts
-            .iter()
-            .find(|new| new.url == artifact.url)
-            .or_else(|| replacements.next());
-        if replacement.and_then(|a| a.provenance.as_ref()) < artifact.provenance.as_ref() {
-            bail!(
-                "lockfile generation would downgrade additional artifact provenance; previous files were preserved"
-            );
+    if compare_provenance {
+        let mut replacements = new.additional_artifacts.iter().filter(|artifact| {
+            !old.additional_artifacts
+                .iter()
+                .any(|old| old.url == artifact.url)
+        });
+        for artifact in &old.additional_artifacts {
+            let replacement = new
+                .additional_artifacts
+                .iter()
+                .find(|new| new.url == artifact.url)
+                .or_else(|| replacements.next());
+            if replacement.and_then(|a| a.provenance.as_ref()) < artifact.provenance.as_ref() {
+                bail!(
+                    "lockfile generation would downgrade additional artifact provenance; previous files were preserved"
+                );
+            }
         }
     }
     Ok(())
@@ -1174,10 +1181,30 @@ mod tests {
             provenance_verified: Some(false),
             ..Default::default()
         };
-        assert!(ensure_no_downgrade(&old, &PlatformInfo::default()).is_err());
+        assert!(ensure_no_downgrade(&old, &PlatformInfo::default(), "github:o/r").is_err());
         let mut new = old.clone();
         new.provenance_verified = None;
-        assert!(ensure_no_downgrade(&old, &new).is_ok());
+        assert!(ensure_no_downgrade(&old, &new, "github:o/r").is_ok());
+    }
+
+    #[test]
+    fn packslip_replaces_legacy_provenance_with_its_signer_chain() {
+        let old = PlatformInfo {
+            provenance: Some(ProvenanceType::GithubAttestations),
+            signer: Some(
+                "sigstore-oidc:https://github.com/o/r/.github/workflows/release.yml".into(),
+            ),
+            ..Default::default()
+        };
+        let mut new = old.clone();
+        new.provenance = None;
+
+        assert!(ensure_no_downgrade(&old, &new, "packslip:github.com/o/r").is_ok());
+        assert!(ensure_no_downgrade(&old, &new, "github:o/r").is_err());
+
+        new.signer =
+            Some("sigstore-oidc:https://github.com/o/r/.github/workflows/other.yml".into());
+        assert!(ensure_no_downgrade(&old, &new, "packslip:github.com/o/r").is_err());
     }
 
     #[test]
@@ -1189,7 +1216,7 @@ mod tests {
             }],
             ..Default::default()
         };
-        assert!(ensure_no_downgrade(&old, &PlatformInfo::default()).is_err());
+        assert!(ensure_no_downgrade(&old, &PlatformInfo::default(), "github:o/r").is_err());
     }
 
     #[test]
@@ -1210,12 +1237,12 @@ mod tests {
         };
         let mut new = old.clone();
         new.additional_artifacts.reverse();
-        assert!(ensure_no_downgrade(&old, &new).is_ok());
+        assert!(ensure_no_downgrade(&old, &new, "github:o/r").is_ok());
         new.additional_artifacts[1].url = "https://example.com/verified-v2".into();
-        assert!(ensure_no_downgrade(&old, &new).is_ok());
+        assert!(ensure_no_downgrade(&old, &new, "github:o/r").is_ok());
         new.additional_artifacts[1].provenance = None;
-        assert!(ensure_no_downgrade(&old, &new).is_err());
+        assert!(ensure_no_downgrade(&old, &new, "github:o/r").is_err());
         new.additional_artifacts.pop();
-        assert!(ensure_no_downgrade(&old, &new).is_err());
+        assert!(ensure_no_downgrade(&old, &new, "github:o/r").is_err());
     }
 }

--- a/src/lockfile/generate.rs
+++ b/src/lockfile/generate.rs
@@ -572,8 +572,11 @@ fn ensure_no_downgrade(old: &PlatformInfo, new: &PlatformInfo, backend: &str) ->
     // link. Without a signer, retain the ordinary provenance ratchet.
     let packslip_signer_replaces_provenance =
         backend.starts_with("packslip:") && new.signer.is_some();
-    let compare_provenance = !packslip_signer_replaces_provenance;
-    if compare_provenance && new.provenance < old.provenance {
+    if provenance_is_downgrade(
+        old.provenance.as_ref(),
+        new.provenance.as_ref(),
+        packslip_signer_replaces_provenance,
+    ) {
         bail!(
             "lockfile generation would downgrade recorded provenance; previous files were preserved"
         );
@@ -587,26 +590,41 @@ fn ensure_no_downgrade(old: &PlatformInfo, new: &PlatformInfo, backend: &str) ->
     }
     // Preserve identities across reordering, then pair replaced URLs in their
     // configured order so version upgrades retain the previous trust baseline.
-    if compare_provenance {
-        let mut replacements = new.additional_artifacts.iter().filter(|artifact| {
-            !old.additional_artifacts
-                .iter()
-                .any(|old| old.url == artifact.url)
-        });
-        for artifact in &old.additional_artifacts {
-            let replacement = new
-                .additional_artifacts
-                .iter()
-                .find(|new| new.url == artifact.url)
-                .or_else(|| replacements.next());
-            if replacement.and_then(|a| a.provenance.as_ref()) < artifact.provenance.as_ref() {
-                bail!(
-                    "lockfile generation would downgrade additional artifact provenance; previous files were preserved"
-                );
-            }
+    let mut replacements = new.additional_artifacts.iter().filter(|artifact| {
+        !old.additional_artifacts
+            .iter()
+            .any(|old| old.url == artifact.url)
+    });
+    for artifact in &old.additional_artifacts {
+        let replacement = new
+            .additional_artifacts
+            .iter()
+            .find(|new| new.url == artifact.url)
+            .or_else(|| replacements.next());
+        if provenance_is_downgrade(
+            artifact.provenance.as_ref(),
+            replacement.and_then(|a| a.provenance.as_ref()),
+            packslip_signer_replaces_provenance,
+        ) {
+            bail!(
+                "lockfile generation would downgrade additional artifact provenance; previous files were preserved"
+            );
         }
     }
     Ok(())
+}
+
+fn provenance_is_downgrade(
+    old: Option<&ProvenanceType>,
+    new: Option<&ProvenanceType>,
+    packslip_signer_replaces_provenance: bool,
+) -> bool {
+    if packslip_signer_replaces_provenance
+        && old.is_some_and(ProvenanceType::is_github_attestations)
+    {
+        return false;
+    }
+    new < old
 }
 
 fn validate_provenance_settings(
@@ -1211,6 +1229,13 @@ mod tests {
         new.signer =
             Some("sigstore-oidc:https://github.com/o/r/.github/workflows/other.yml".into());
         assert!(ensure_no_downgrade(&old, &new, "packslip:github.com/o/r").is_err());
+
+        new.signer = old.signer.clone();
+        let old = PlatformInfo {
+            provenance: Some(ProvenanceType::Slsa { url: None }),
+            ..old
+        };
+        assert!(ensure_no_downgrade(&old, &new, "packslip:github.com/o/r").is_err());
     }
 
     #[test]
@@ -1223,6 +1248,26 @@ mod tests {
             ..Default::default()
         };
         assert!(ensure_no_downgrade(&old, &PlatformInfo::default(), "github:o/r").is_err());
+
+        let mut new = PlatformInfo {
+            signer: Some(
+                "sigstore-oidc:https://github.com/o/r/.github/workflows/release.yml".into(),
+            ),
+            ..Default::default()
+        };
+        assert!(ensure_no_downgrade(&old, &new, "packslip:github.com/o/r").is_ok());
+
+        let old = PlatformInfo {
+            additional_artifacts: vec![ArtifactInfo {
+                provenance: Some(ProvenanceType::Slsa { url: None }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(ensure_no_downgrade(&old, &new, "packslip:github.com/o/r").is_err());
+
+        new.signer = None;
+        assert!(ensure_no_downgrade(&old, &new, "packslip:github.com/o/r").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- allow a verified Packslip signer to replace legacy GitHub-attestation metadata
- continue enforcing Packslip's verified signer identity across upgrades
- retain SLSA provenance downgrade checks for Packslip and all provenance checks for other backends

## Why

Older incremental lock updates could carry detected GitHub provenance into a Packslip entry. Complete generation intentionally records only provenance that it cryptographically verifies, while Packslip authenticates artifacts through its signed release manifest and signer chain. On an upgrade, the generic provenance ratchet therefore mistook the removal of that legacy field for a security downgrade.

Packslip generation now permits only legacy `github-attestations` metadata to be replaced by a newly verified signer. It still rejects a missing or changed signer, a changed attestation identity, and any downgrade from SLSA provenance. Other backends retain the full existing provenance ratchet.

This addresses https://github.com/aubepkg/aube/discussions/1528 and follows the trust model established in #13031.

This is related to but independent of #13102, which handles unsupported cross-platform artifacts.

## Validation

- `mise run test:unit -- lockfile::generate`
- `mise run lint-fix`
- reproduced an aube 2.2.12 to 2.2.13 `mise lock --bump` across `macos-arm64` and `linux-x64`; generated Packslip entries contain checksums and the verified signer, without synthesizing provenance metadata

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Packslip provenance replacements now correctly allow updates from GitHub attestations when the replacement artifact is signed.
  - SLSA provenance protections remain enforced for primary and additional artifacts, preventing unsupported downgrades to no provenance.
  - Additional artifacts now receive consistent provenance validation during replacement checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->