### PR TITLE
docs: prevent landing tabs from shifting content

### DIFF
--- a/docs/.vitepress/theme/landing.css
+++ b/docs/.vitepress/theme/landing.css
@@ -999,7 +999,8 @@ a:hover > div + .card-link::after {
   color: var(--vp-c-success-1);
 }
 .workbench-terminal {
-  min-height: 170px;
+  /* Reserve four transcript lines so switching examples cannot resize the hero. */
+  min-height: 173px;
   padding: 16px 22px 20px;
   background: #251d26;
   color: #f3eaf0;


### PR DESCRIPTION
## Summary
- reserve enough height for the longest landing-page workbench transcript
- keep the hero and following content stationary when switching to the Tasks example

## Verification
- mise run docs:build
- mise x -- hk run check --safe docs/.vitepress/theme/landing.css --format json
- verified identical hero and downstream positions across all four tabs at desktop and 390px widths
- verified no horizontal overflow at 390px

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only CSS tweak to a fixed min-height; no runtime or security impact.
> 
> **Overview**
> Fixes **layout shift** on the docs home hero when users switch workbench example tabs (e.g. Tasks vs shorter transcripts).
> 
> The **`.workbench-terminal`** block’s **`min-height`** is bumped from **170px** to **173px**, with a comment that the space is reserved for **four transcript lines** so the tallest example doesn’t grow the hero and push content below.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36d728d5c4f483cb23a8ab5082b096b2fd34ef45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the workbench terminal layout to reserve space for four transcript lines, improving vertical spacing consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->