### PR TITLE
registry: fix mc downloads from MinIO releases

### DIFF
--- a/registry/mc.toml
+++ b/registry/mc.toml
@@ -1,3 +1,12 @@
-backends = ["aqua:minio/mc", "asdf:mise-plugins/mise-mc"]
 description = "Unix like utilities for object store (minio)"
 version_order = "source"
+
+[[backends]]
+full = "github:minio/mc"
+
+[backends.options]
+bin = "mc"
+github_attestations = false
+
+[[backends]]
+full = "asdf:mise-plugins/mise-mc"

--- a/registry/mc.toml
+++ b/registry/mc.toml
@@ -5,8 +5,8 @@ version_order = "source"
 full = "github:minio/mc"
 
 [backends.options]
-bin = "mc"
 github_attestations = false
+rename_exe = "mc"
 
 [[backends]]
 full = "asdf:mise-plugins/mise-mc"


### PR DESCRIPTION
The `mc` shorthand now installs from MinIO’s GitHub releases instead of the retired Aqua download URL, which returns HTTP 410. The GitHub backend explicitly installs the raw asset as `mc`, skips unavailable GitHub attestations for this repository, and continues verifying MinIO’s published checksum.

Validation:
- `mise run build`
- `mise run lint-fix`
- `mise ls-remote mc`
- clean `mise exec mc@latest -- mc --version` installation (RELEASE.2025-08-13T08-35-41Z)

Follow-up:
- [ ] Switch `mc` back to `aqua:minio/mc` after [aquaproj/aqua-registry#60567](https://github.com/aquaproj/aqua-registry/pull/60567) is merged and available in an Aqua Registry release.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only change for one tool’s install sources; no runtime or auth logic affected.
> 
> **Overview**
> **Fixes broken `mc` installs** by replacing the retired Aqua source (HTTP 410) with **MinIO’s GitHub releases** as the primary backend.
> 
> The new `github:minio/mc` entry sets `github_attestations = false` and `rename_exe = "mc"` so the release asset installs as `mc` while checksum verification still applies. The **asdf** backend (`asdf:mise-plugins/mise-mc`) remains as an alternate install path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43cb92f0e57b69f3e014d1388fc3ebe0bd01fd8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated available installation sources for the `mc` command.
  * GitHub-based installation now uses the `mc` binary directly and does not require GitHub attestations.
  * Windows installations preserve the `.exe` file suffix.
  * GitHub and asdf installation sources are configured separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->