### PR TITLE
fix(bootstrap): find ssh and tar on Windows for remote bootstrap

### DIFF
--- a/e2e-win/bootstrap_remote_tools.Tests.ps1
+++ b/e2e-win/bootstrap_remote_tools.Tests.ps1
@@ -1,0 +1,76 @@
+# `mise bootstrap remote` resolves the local `ssh` and `tar` with `file::which_spawnable`.
+# Plain `file::which` never finds `ssh.exe` on Windows, so this test crosses the process
+# boundary: both host tools are `.exe` fixtures on PATH that log how they were launched.
+Describe 'bootstrap remote host tools' {
+    BeforeAll {
+        $script:OriginalDir = Get-Location
+        Set-Location TestDrive:
+
+        $script:Saved = @{}
+        foreach ($name in 'MISE_TRUSTED_CONFIG_PATHS', 'PATH', 'MISE_E2E_TOOL_LOG_DIR', 'MISE_E2E_TOOL_SRC', 'MISE_E2E_TOOL_OUT') {
+            $script:Saved[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+        }
+
+        $script:Tools = Join-Path $TestDrive 'tools'
+        $script:Source = Join-Path $TestDrive 'source'
+        New-Item -ItemType Directory -Force $script:Tools, $script:Source | Out-Null
+        '[tools]' | Out-File -FilePath (Join-Path $script:Source 'mise.toml') -Encoding utf8NoBOM
+
+        # A tiny .NET Framework console program: append the argv to <tool>.log and answer
+        # with the staging path mise expects from its first ssh call. Built with Windows
+        # PowerShell because pwsh cannot emit console applications.
+        $program = @'
+using System;
+using System.IO;
+static class Tool {
+    static int Main(string[] args) {
+        string name = Path.GetFileNameWithoutExtension(Environment.GetCommandLineArgs()[0]);
+        string dir = Environment.GetEnvironmentVariable("MISE_E2E_TOOL_LOG_DIR");
+        File.AppendAllText(Path.Combine(dir, name + ".log"), string.Join(" ", args) + "\n");
+        Console.Out.Write("/tmp/mise-bootstrap.e2ewin\n");
+        return 0;
+    }
+}
+'@
+        $programFile = Join-Path $script:Tools 'tool.cs'
+        $program | Out-File -FilePath $programFile -Encoding utf8NoBOM
+        $ssh = Join-Path $script:Tools 'ssh.exe'
+        # Paths travel through the environment rather than the command string, so a
+        # TestDrive path containing a quote cannot break the inner command line.
+        $env:MISE_E2E_TOOL_SRC = $programFile
+        $env:MISE_E2E_TOOL_OUT = $ssh
+        powershell.exe -NoProfile -Command 'Add-Type -Path $env:MISE_E2E_TOOL_SRC -OutputAssembly $env:MISE_E2E_TOOL_OUT -OutputType ConsoleApplication'
+        $LASTEXITCODE | Should -Be 0
+        Copy-Item $ssh (Join-Path $script:Tools 'tar.exe')
+
+        $env:MISE_TRUSTED_CONFIG_PATHS = $TestDrive
+        $env:MISE_E2E_TOOL_LOG_DIR = $script:Tools
+        $env:PATH = "$script:Tools;$env:PATH"
+    }
+
+    AfterAll {
+        Set-Location $script:OriginalDir
+        foreach ($name in $script:Saved.Keys) {
+            if ($null -eq $script:Saved[$name]) {
+                Remove-Item "Env:\$name" -ErrorAction Ignore
+            } else {
+                [Environment]::SetEnvironmentVariable($name, $script:Saved[$name], 'Process')
+            }
+        }
+    }
+
+    It 'launches ssh.exe and tar.exe found on PATH' {
+        $out = mise bootstrap remote --host 'e2e@example.invalid' --source $script:Source --dry-run 2>&1 | Out-String
+
+        $out | Should -Not -BeLike "*required command 'ssh' not found*"
+        $out | Should -Not -BeLike "*required command 'tar' not found*"
+        $out | Should -BeLike "*$script:Tools\ssh.exe *"
+
+        $sshLog = Get-Content (Join-Path $script:Tools 'ssh.log') -Raw
+        $sshLog | Should -BeLike '*e2e@example.invalid*'
+        $sshLog | Should -BeLike '*mkdir -p /tmp/mise-bootstrap.e2ewin/project*'
+
+        $tarLog = Get-Content (Join-Path $script:Tools 'tar.log') -Raw
+        $tarLog | Should -BeLike '*-czf *source.tar.gz*'
+    }
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -1723,8 +1723,12 @@ pub(crate) fn which<P: AsRef<Path>>(name: P) -> Option<PathBuf> {
 /// Returns the first directly spawnable executable in PATH, expanding configured
 /// executable extensions on Windows when `name` has no extension.
 pub(crate) fn which_spawnable(name: &str) -> Option<PathBuf> {
+    _which_spawnable(name, &env::PATH)
+}
+
+fn _which_spawnable(name: &str, paths: &[PathBuf]) -> Option<PathBuf> {
     let names = executable_names(name);
-    env::PATH.iter().find_map(|dir| {
+    paths.iter().find_map(|dir| {
         names
             .iter()
             .map(|name| dir.join(name))
@@ -4887,6 +4891,22 @@ mod tests {
         for name in ["tool.ps1", "tool.PS1", "tool.vbs", "tool", r"C:\x\tool"] {
             assert!(!can_execute_directly(Path::new(name)), "{name}");
         }
+    }
+
+    /// `which` joins the bare name, so on Windows it never finds `ssh.exe`; host tools that
+    /// mise spawns by resolved path must go through `which_spawnable`.
+    #[cfg(windows)]
+    #[test]
+    fn which_spawnable_finds_the_exe_that_which_misses() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = [dir.path().to_path_buf()];
+        fs::write(dir.path().join("ssh.exe"), "").unwrap();
+
+        assert_eq!(_which("ssh", &paths), None);
+        assert_eq!(
+            _which_spawnable("ssh", &paths),
+            Some(dir.path().join("ssh.exe"))
+        );
     }
 
     fn io(raw: i32) -> std::io::Error {

--- a/src/system/remote.rs
+++ b/src/system/remote.rs
@@ -440,8 +440,10 @@ async fn run_inner(
     artifacts: &mut RemoteArtifactResolver,
     repository: Option<&super::remote_repository::Source>,
 ) -> Result<()> {
-    let ssh = crate::file::which("ssh").ok_or_else(|| eyre!("required command 'ssh' not found"))?;
-    let tar = crate::file::which("tar").ok_or_else(|| eyre!("required command 'tar' not found"))?;
+    let ssh = crate::file::which_spawnable("ssh")
+        .ok_or_else(|| eyre!("required command 'ssh' not found"))?;
+    let tar = crate::file::which_spawnable("tar")
+        .ok_or_else(|| eyre!("required command 'tar' not found"))?;
     let control_directory = if cfg!(unix) {
         Some(
             tempfile::Builder::new()
@@ -733,7 +735,7 @@ pub(crate) async fn ssh(
         .prefix("mise-ssh-")
         .tempdir_in("/tmp")?;
     let session = SshSession {
-        ssh: crate::file::which("ssh").ok_or_else(|| eyre!("ssh not found"))?,
+        ssh: crate::file::which_spawnable("ssh").ok_or_else(|| eyre!("ssh not found"))?,
         host,
         relay: true,
         connect_timeout: 10,


### PR DESCRIPTION
## Problem

On Windows, `mise bootstrap remote` refuses to run even though the OpenSSH client and `tar` are on PATH. The docs say a Windows machine may orchestrate remote runs (only Windows *targets* are unsupported), so this is a bug.

Measured on mise 2026.9.5 windows-x64, Windows 11, from PowerShell (same from cmd.exe; `MISE_VERBOSE=1` adds nothing):

```
> where.exe ssh tar
C:\Program Files\OpenSSH\ssh.exe
C:\Windows\System32\tar.exe

> mise bootstrap remote --host root@127.0.0.1 --port 2222 -i <key> --source <dir> --dry-run
mise ERROR remote bootstrap failed on root@127.0.0.1: required command 'ssh' not found
```

## Cause

`src/system/remote.rs` resolved the local host tools with `file::which`, which joins the bare name (`dir.join("ssh")`) and never tries executable extensions, so on Windows it only ever finds a file literally named `ssh`. `file::which_spawnable` already expands `windows_executable_extensions` and is what the other host-tool lookups (`git`, `winget`, `schtasks`, …) use.

## Fix

The three `ssh`/`tar` lookups in `src/system/remote.rs` now use `file::which_spawnable`. `which_spawnable` is split into a PATH-parameterised helper (mirroring `_which`) so a Windows unit test can cover the behaviour: a directory containing `ssh.exe` is found by `which_spawnable("ssh")` and not by `which("ssh")`.

The `/tmp` control directory in the relay `ssh` function is left alone: that function is `#[cfg(unix)]`, so it is not reachable on Windows, and `run_inner` already guards its control directory with `cfg!(unix)`.

## Verification

After the fix, the same command against a Debian (`debian:bookworm` + `openssh-server`) container from PowerShell on the same machine:

```
> .\target\debug\mise.exe bootstrap remote --host root@127.0.0.1 --port 2222 -i <key> --source <dir> --dry-run --remote-mise /usr/local/bin/mise
mise bootstrap remote root@127.0.0.1 (root@127.0.0.1)
mise $ C:\Program Files\OpenSSH\ssh.exe -o 'ConnectTimeout=10' -o 'BatchMode=yes' -p 2222 -i '<key>' root@127.0.0.1 'sh -c ...'
mise $ C:\Program Files\OpenSSH\ssh.exe ... root@127.0.0.1 'tar -xzf - -C /tmp/mise-bootstrap.EbiRVBsmzY/project'
2026.9.5 linux-x64 (2026-09-10)
mise bootstrap: tools
mise jq@1.7.1      ⇢ would install
mise remote bootstrap completed on 1 target(s)
```

`ssh.exe` is resolved, the source is archived with the Windows `tar.exe` and uploaded, and the dry run completes. (`--remote-mise` is only needed because a debug build cannot fetch the official Linux artifact.)

A new e2e-win test (`e2e-win/bootstrap_remote_tools.Tests.ps1`) crosses the process boundary: `ssh.exe` and `tar.exe` fixtures on PATH log how `mise bootstrap remote` launches them. It passes on the patched build and fails on the unfixed 2026.9.5 with `required command 'ssh' not found` (both runs measured locally). The Windows-only unit test in `src/file.rs` relies on the Windows CI job.

Not changed: `src/system/compose.rs` and `src/cli/oci/run.rs` also use `file::which("docker")`, but on this machine Docker Desktop ships an extensionless `docker` wrapper next to `docker.exe`, and `std::process::Command` appends `.exe` to an extensionless path, so `[bootstrap.compose]` was verified to work unchanged on Windows.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote connection setup by reliably locating the required SSH and archive tools on Windows.
  * Fixed executable discovery when command names require platform-specific extensions, including `.exe` files.
  * Remote bootstrapping now correctly detects Windows executable files, reducing false “tool not found” errors during setup.
  * Added coverage to verify that detected SSH and archive tools are launched with the expected commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->