### PR TITLE
ci: increase vfox runner memory

### DIFF
--- a/.github/workflows/test-vfox-impl.yml
+++ b/.github/workflows/test-vfox-impl.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   "test-vfox":
-    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=cache' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64-large;overrides.cache-tag=cache' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only runner sizing change with no application or security impact.
> 
> **Overview**
> When `test-vfox` runs in **trusted** mode, it now uses the `namespace-profile-endev-linux-amd64-large` Namespace runner instead of `endev-linux-amd64`, matching other trusted workflows like `test-impl.yml`.
> 
> Untrusted runs still use `ubuntu-latest`; only the trusted runner profile changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6e3ee7e6c5dfbcaccc4ba8654494d0d2f61057b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the trusted workflow to use a larger build runner, improving capacity for eligible automated jobs.
  - Untrusted workflow runs continue using the standard hosted runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->