### PR TITLE
fix(upgrade): detect letter-suffixed version updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11445,11 +11445,11 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "versions"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f"
+checksum = "9f93c06c2578ebd229c6c936cfc5269e90855d63dd2eb567c50a153d14afde58"
 dependencies = [
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "nom 8.0.0",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,7 @@ url = "2"
 urlencoding = "2"
 uuid = { version = "1", features = ["v7"] }
 usage-lib = { version = "6.8", features = ["docs"] }
-versions = { version = "7", features = ["serde"] }
+versions = { version = "8", features = ["serde"] }
 vfox = { path = "crates/vfox", default-features = false }
 aqua-registry = { path = "crates/aqua-registry" }
 mise-interactive-config = { path = "crates/mise-interactive-config", version = "2026" }

--- a/crates/aqua-registry/Cargo.toml
+++ b/crates/aqua-registry/Cargo.toml
@@ -35,7 +35,7 @@ tempfile = "3"
 # Template parsing and evaluation
 expr-lang = "2"
 heck = "0.5"
-versions = { version = "7", features = ["serde"] }
+versions = { version = "8", features = ["serde"] }
 
 # Logging
 log = "0.4"

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -3894,13 +3894,11 @@ fn matching_request_bindings<'a>(
 /// Newest-first ordering for the lockfile entries that all satisfy one
 /// `latest` request.
 ///
-/// The version string is a tie-break, not decoration. `versions` compares an
-/// alphanumeric chunk by its leading digits and stops there, so `3.7b` and
-/// `3.7c` both reduce to `7` and come back `Equal` (fosskers/rs-versions#39).
-/// Entries are written in lexicographic order of the version string
-/// (`merge_tool_entries`) and `sort_by` is stable, so with nothing to break the
-/// tie that file order survives and the *older* entry always wins.
-/// `install_state` breaks the same tie the same way.
+/// The version string is a tie-break, not decoration. It guarantees a
+/// deterministic order when a parser considers distinct opaque versions
+/// equivalent. This originally worked around `versions` v7 treating `3.7b`
+/// and `3.7c` as equal (fosskers/rs-versions#39); `install_state` breaks ties
+/// the same way.
 ///
 /// Two identical strings still compare `Equal`, which leaves the stable sort to
 /// keep duplicate entries in the order they were read.

--- a/src/toolset/outdated_info.rs
+++ b/src/toolset/outdated_info.rs
@@ -486,6 +486,8 @@ mod tests {
 
     #[test]
     fn test_is_outdated_version() {
+        assert_eq!(is_outdated_version("3.7b", "3.7c"), true);
+        assert_eq!(is_outdated_version("3.7c", "3.7b"), false);
         assert_eq!(is_outdated_version("1.10.0", "1.12.0"), true);
         assert_eq!(is_outdated_version("1.12.0", "1.10.0"), false);
 

--- a/src/toolset/tool_request.rs
+++ b/src/toolset/tool_request.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use eyre::{Result, bail, eyre};
-use versions::{Chunk, Version};
 use xx::file;
 
 use crate::backend::platform_target::PlatformTarget;
@@ -866,37 +865,49 @@ pub(crate) fn version_sub(orig: &str, sub: &str) -> Result<String> {
     fn not_numeric(orig: &str, sub: &str) -> eyre::Report {
         eyre!("cannot subtract {sub} from {orig}: {orig} is not a numeric version")
     }
-    let mut version = Version::new(orig).ok_or_else(|| eyre!("invalid version: {orig}"))?;
-    let sub_version = Version::new(sub).ok_or_else(|| eyre!("invalid version: {sub}"))?;
-    while version.chunks.0.len() > sub_version.chunks.0.len() {
-        version.chunks.0.pop();
+    fn numeric_components(version: &str) -> Option<Vec<u32>> {
+        if version.is_empty() {
+            return None;
+        }
+        version
+            .split('.')
+            .map(str::parse)
+            .collect::<std::result::Result<_, _>>()
+            .ok()
     }
-    for i in 0..version.chunks.0.len() {
-        let m = sub_version
-            .nth(i)
-            .ok_or_else(|| eyre!("invalid version: {sub}"))?;
-        let orig_val = version.chunks.0[i]
-            .single_digit()
-            .ok_or_else(|| not_numeric(orig, sub))?;
+    fn format_components(version: &[u32]) -> String {
+        version
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(".")
+    }
+
+    let mut version = numeric_components(orig).ok_or_else(|| not_numeric(orig, sub))?;
+    let sub_version = numeric_components(sub).ok_or_else(|| eyre!("invalid version: {sub}"))?;
+    while version.len() > sub_version.len() {
+        version.pop();
+    }
+    for i in 0..version.len() {
+        let m = sub_version[i];
+        let orig_val = version[i];
 
         if orig_val < m {
             // Handle underflow with borrowing from higher digits
             for j in (0..i).rev() {
-                let prev_val = version.chunks.0[j]
-                    .single_digit()
-                    .ok_or_else(|| not_numeric(orig, sub))?;
+                let prev_val = version[j];
                 if prev_val > 0 {
-                    version.chunks.0[j] = Chunk::Numeric(prev_val - 1);
-                    version.chunks.0.truncate(j + 1);
-                    return Ok(version.to_string());
+                    version[j] = prev_val - 1;
+                    version.truncate(j + 1);
+                    return Ok(format_components(&version));
                 }
             }
             return Ok("0".to_string());
         }
 
-        version.chunks.0[i] = Chunk::Numeric(orig_val - m);
+        version[i] = orig_val - m;
     }
-    Ok(version.to_string())
+    Ok(format_components(&version))
 }
 
 impl Display for ToolRequest {
@@ -1275,6 +1286,7 @@ mod tests {
         assert!(err.contains("lts"), "unexpected error: {err}");
 
         assert!(version_sub("latest", "1").is_err());
+        assert!(version_sub("3.7b", "1").is_err());
         assert!(version_sub("1.2.3", "x").is_err());
         assert!(version_sub("", "1").is_err());
     }


### PR DESCRIPTION
Updates `versions` from v7 to v8 so `mise upgrade` correctly orders letter-suffixed releases such as tmux `3.7b` and `3.7c`.

Previously, `mise up tmux` could report that all tools were current with `3.7b` installed even when `3.7c` was available. The upgraded comparator now identifies `3.7b` as outdated while preserving the reverse-direction check, so both `mise up` and `mise up --bump` can proceed normally.

The dependency update changed the internal representation used by `sub-N` aliases. Numeric version subtraction now parses its documented dot-separated numeric components directly, preserving results such as `sub-1:2` resolving `2.1.0` to `1.1.0` while continuing to reject aliases and suffixed versions as arithmetic inputs.

Adds bidirectional regression coverage and updates the lockfile comparator explanation to describe the v7 workaround historically.

Discussion: https://github.com/jdx/mise/discussions/13116

Validation:
- `mise run lint-fix`
- `cargo test --locked --bin mise` (4,005 passed)
- `cargo test --locked -p aqua-registry`
- `mise run test:e2e e2e/plugins/test_version_range e2e/cli/test_ls_remote e2e/cli/test_latest`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved version comparisons, including correct ordering for opaque versions such as `3.7b` and `3.7c`.
  - Made lockfile version tie-breaking behavior deterministic.
  - Improved validation when subtracting version components and clarified errors for non-numeric versions.

- **Chores**
  - Updated version-handling support while preserving serialization compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->