### PR TITLE
fix(release): publish mise-agent-env before mise

### DIFF
--- a/xtasks/release-plz
+++ b/xtasks/release-plz
@@ -176,6 +176,9 @@ set_package_version() {
 
 	# Keep workspace path dependencies compatible before Cargo resolves the bump.
 	case "$crate_name" in
+	mise-agent-env)
+		set_path_dependency_version Cargo.toml mise-agent-env "$new_version"
+		;;
 	mise-cache-core)
 		set_path_dependency_version Cargo.toml mise-cache-core "$new_version"
 		;;
@@ -368,6 +371,10 @@ if [[ $cur_version != "$latest_version" ]]; then
 	INTERACTIVE_CONFIG_VERSION=""
 	MISE_SIGSTORE_VERSION=""
 	MISE_CACHE_CORE_VERSION=""
+	MISE_AGENT_ENV_VERSION=""
+
+	bump_and_publish_subcrate "mise-agent-env" "crates/mise-agent-env" "MISE_AGENT_ENV_VERSION"
+	cargo add -p mise "mise-agent-env@$MISE_AGENT_ENV_VERSION"
 
 	bump_and_publish_subcrate "mise-cache-core" "crates/mise-cache-core" "MISE_CACHE_CORE_VERSION"
 	cargo add -p mise "mise-cache-core@$MISE_CACHE_CORE_VERSION" --no-default-features


### PR DESCRIPTION
The 2026.9.6 release reached `cargo publish -p mise` before the new `mise-agent-env` path dependency existed on crates.io, causing packaging to fail with `no matching package named mise-agent-env found`.

This adds `mise-agent-env` to the independent subcrate release sequence. When it changes, release-plz now bumps and publishes it first, keeps the workspace path dependency version compatible during the bump, and rewrites mise to use the published version before publishing the main crate.

The initial `mise-agent-env` 0.1.0 package was bootstrapped on crates.io and configured for trusted publishing. The failed release-plz job was rerun successfully: https://github.com/jdx/mise/actions/runs/34720797533

Validation:
- `bash -n xtasks/release-plz`
- `shellcheck -x xtasks/release-plz`
- `shfmt -d -s xtasks/release-plz`
- `git diff --check origin/main...HEAD`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to the release script ordering and manifest rewriting; no runtime product behavior.
> 
> **Overview**
> Fixes release-plz so **`mise-agent-env`** is handled like other independently versioned workspace crates, preventing `cargo publish -p mise` from failing when crates.io does not yet have that dependency.
> 
> During version bumps, **`set_package_version`** now syncs the root **`Cargo.toml`** path dependency for **`mise-agent-env`**. In the publish path, the script **bumps/publishes `mise-agent-env` first**, then runs **`cargo add -p mise "mise-agent-env@$MISE_AGENT_ENV_VERSION"`** before the rest of the subcrate sequence and the main **`mise`** publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b51cf8975b0bd14f5909a265a9ab4f4633527d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to include the `mise-agent-env` component.
  * Improved version synchronization and dependency updates during releases, helping ensure compatible package versions are published together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->