### PR TITLE
registry: restore aqua backend for mc

### DIFF
--- a/registry/mc.toml
+++ b/registry/mc.toml
@@ -1,12 +1,3 @@
+backends = ["aqua:minio/mc", "asdf:mise-plugins/mise-mc"]
 description = "Unix like utilities for object store (minio)"
 version_order = "source"
-
-[[backends]]
-full = "github:minio/mc"
-
-[backends.options]
-github_attestations = false
-rename_exe = "mc"
-
-[[backends]]
-full = "asdf:mise-plugins/mise-mc"


### PR DESCRIPTION
The `mc` shorthand uses `aqua:minio/mc` again now that aquaproj/aqua-registry#60567 is merged and published in aqua-registry v4.561.0. This removes the temporary direct `github:minio/mc` workaround while retaining `asdf:mise-plugins/mise-mc` as the fallback backend.

A clean install against the live Aqua registry downloaded MinIO's GitHub release asset and ran successfully:

```text
mc version RELEASE.2025-08-13T08-35-41Z (commit-id=7394ce0dd2a80935aded936b09fa12cbb3cb8096)
Runtime: go1.24.6 darwin/arm64
```

Validation:
- `mise run build`
- `mise run lint-fix`
- `mise ls-remote aqua:minio/mc`
- clean `mise exec mc@RELEASE.2025-08-13T08-35-41Z -- mc --version` with the live Aqua registry

Related: #13113

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry metadata only; no runtime or install logic changes beyond which backend resolves first.
> 
> **Overview**
> **Restores the standard `mc` registry entry** now that Aqua registry includes `minio/mc` again (v4.561.0+).
> 
> The temporary **`github:minio/mc`** backend block (with `github_attestations`, `rename_exe`, etc.) is removed. **`mc`** is configured like other tools via `backends = ["aqua:minio/mc", "asdf:mise-plugins/mise-mc"]`, keeping the ASDF plugin as fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cef84bea8245ca767b5a303cdeb23f49eab7e1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated backend configuration for improved consistency and maintainability.
  - Preserved support for the existing alternative backend.
  - No user-facing features or capabilities were added or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->